### PR TITLE
PT-411 | Add url slashes to event url if protocol missing

### DIFF
--- a/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
+++ b/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
@@ -5,6 +5,7 @@ import { EventFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import { useTranslation } from '../../../i18n';
 import IconTicket from '../../../icons/IconTicket';
+import addUrlSlashes from '../../../utils/addUrlSlashes';
 import EventKeywords from '../eventKeywords/EventKeywords';
 import { getEventFields } from '../utils';
 import styles from './eventBasicInfo.module.scss';
@@ -48,7 +49,7 @@ const EventBasicInfo: React.FC<EventBasicInfoProps> = ({ event }) => {
         {infoUrl && (
           <div>
             <IconInfoCircle />
-            <a href={infoUrl} target="_blank" rel="noreferrer">
+            <a href={addUrlSlashes(infoUrl)} target="_blank" rel="noreferrer">
               {infoUrl}
             </a>
           </div>

--- a/src/utils/__tests__/addUrlSlashes.test.ts
+++ b/src/utils/__tests__/addUrlSlashes.test.ts
@@ -1,0 +1,9 @@
+import addUrlSlashes from '../addUrlSlashes';
+
+test('works correctly on url with or without protocol', () => {
+  expect(addUrlSlashes('http://test.test')).toBe('http://test.test');
+  expect(addUrlSlashes('https://test.test')).toBe('https://test.test');
+  expect(addUrlSlashes('htp://test.test')).toBe('//htp://test.test');
+  expect(addUrlSlashes('test.test')).toBe('//test.test');
+  expect(addUrlSlashes('//test.test')).toBe('//test.test');
+});

--- a/src/utils/addUrlSlashes.ts
+++ b/src/utils/addUrlSlashes.ts
@@ -2,11 +2,7 @@
 const addUrlSlashes = (url: string): string => {
   const protocolRegex = /^((https?:\/\/)|(\/\/))/i;
   const urlIsMissingProtocol = !protocolRegex.test(url);
-
-  if (urlIsMissingProtocol) {
-    return `//${url}`;
-  }
-  return url;
+  return urlIsMissingProtocol ? `//${url}` : url;
 };
 
 export default addUrlSlashes;

--- a/src/utils/addUrlSlashes.ts
+++ b/src/utils/addUrlSlashes.ts
@@ -1,0 +1,12 @@
+// add "//" to the beginning of the url if protocol is missing.
+const addUrlSlashes = (url: string): string => {
+  const protocolRegex = /^((https?:\/\/)|(\/\/))/i;
+  const urlIsMissingProtocol = !protocolRegex.test(url);
+
+  if (urlIsMissingProtocol) {
+    return `//${url}`;
+  }
+  return url;
+};
+
+export default addUrlSlashes;


### PR DESCRIPTION
## Description

- Add //-prefix to url if protocol is missing from it (so that browser knows it is an external url)

## Issues
### Closes
**[PT-411](https://helsinkisolutionoffice.atlassian.net/browse/PT-411):** 