### PR TITLE
PT-586 | Improve how seats left is presented

### DIFF
--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -210,13 +210,13 @@ test('renders form and user can fill it and submit', async () => {
 
   expect(
     screen.queryByRole('row', {
-      name: '25.09.2020 12:30 – 12:30 Kirjasto 0 / 30',
+      name: '25.09.2020 12:30 – 12:30 Kirjasto 30 / 30',
     })
   ).toBeInTheDocument();
 
   expect(
     screen.queryByRole('row', {
-      name: '26.09.2020 13:20 – 12:30 Kirjasto 0 / 30',
+      name: '26.09.2020 13:20 – 12:30 Kirjasto 30 / 30',
     })
   ).toBeInTheDocument();
 

--- a/src/domain/enrolment/occurrenceTable/OccurrenceTable.tsx
+++ b/src/domain/enrolment/occurrenceTable/OccurrenceTable.tsx
@@ -42,7 +42,7 @@ const OccurrenceTable: React.FC<Props> = ({ eventLocationId, occurrences }) => {
     {
       Header: t('enrolment:occurrenceTable.columnSeatsInfo'),
       accessor: (row: OccurrenceFieldsFragment) =>
-        `${row.seatsTaken} / ${row.amountOfSeats}`,
+        `${row.amountOfSeats - row.seatsTaken} / ${row.amountOfSeats}`,
       id: 'seatsInfo',
     },
   ];

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -170,7 +170,7 @@ const apolloMocks = [
 const eventData = eventResult.data.event;
 const originalUseRouter = Router.useRouter;
 
-const rowText = `27.07.2020 12:00 – 12:30 ${data.placeName} 0 / 30 Ilmoittaudu`;
+const rowText = `27.07.2020 12:00 – 12:30 ${data.placeName} 30 / 30 Ilmoittaudu`;
 
 advanceTo(new Date(2020, 6, 14));
 

--- a/src/domain/event/occurrences/Occurrences.tsx
+++ b/src/domain/event/occurrences/Occurrences.tsx
@@ -184,7 +184,7 @@ const Occurrences: React.FC<Props> = ({
     {
       Header: t('enrolment:occurrenceTable.columnSeatsInfo'),
       accessor: (row: OccurrenceFieldsFragment) =>
-        `${row.seatsTaken} / ${row.amountOfSeats}`,
+        `${row.amountOfSeats - row.seatsTaken} / ${row.amountOfSeats}`,
       id: 'seatsInfo',
     },
     {


### PR DESCRIPTION
## Description

- Present seats left so that it is more understandable. Instead of showing 0/100 seats left (which meant 100 places left) show 100/100 seats left

## Issues
### Closes
**[PT-586](https://helsinkisolutionoffice.atlassian.net/browse/PT-586):** 

### Related

## Testin
### Automated tests

### Manual testing

## Screenshots

<img width="328" alt="Screenshot 2021-01-23 at 14 40 01" src="https://user-images.githubusercontent.com/15219142/105578437-e858c800-5d88-11eb-85a9-95f05a85564e.png">


## Additional notes