### PR TITLE
Added a validation against minimum  group size validation.

### DIFF
--- a/public/static/locales/en/form.json
+++ b/public/static/locales/en/form.json
@@ -26,8 +26,9 @@
       "max": "This time must be before {{max}}"
     },
     "studygroup": {
-      "adultmaxwithchildren": "Maximun value is {{max}} with current amount of children",
-      "childrenmaxwithadults": "Maximun value is {{max}} with current amount of adults",
+      "childrenandadultmin": "The total number of children and adults must be at least {{min}}",
+      "adultmaxwithchildren": "Maximum value is {{max}} with current amount of children",
+      "childrenmaxwithadults": "Maximum value is {{max}} with current amount of adults",
       "childrenandadultmax": "The total number of children and adults must not exceed {{max}}"
     }
   },

--- a/public/static/locales/fi/form.json
+++ b/public/static/locales/fi/form.json
@@ -26,6 +26,7 @@
       "max": "Arvon tulee olla enintään {{max}}"
     },
     "studygroup": {
+      "childrenandadultmin": "Lasten ja aikuisten yhteislukumäärän tulee olla vähintään {{min}}",
       "adultmaxwithchildren": "Arvon tulee olla enintään {{max}} yhdessä lasten lukumäärän kanssa",
       "childrenmaxwithadults": "Arvon tulee olla enintään {{max}} yhdessä aikuisten lukumäärän kanssa",
       "childrenandadultmax": "Lasten ja aikuisten yhteislukumäärän tulee olla enintään {{max}}"

--- a/public/static/locales/sv/form.json
+++ b/public/static/locales/sv/form.json
@@ -26,6 +26,7 @@
       "max": "Den här tiden måste vara innan {{max}}"
     },
     "studygroup": {
+      "childrenandadultmin": "Det totala antalet barn och vuxna måste vara minst {{min}}",
       "adultmaxwithchildren": "Maxvärdet är {{max}} med nuvarande antal barn",
       "childrenmaxwithadults": "Maxvärdet är {{max}} med nuvarande antal vuxen",
       "childrenandadultmax": "Det totala antalet barn och vuxna får inte överstiga {{max}}"

--- a/src/domain/app/forms/constants.ts
+++ b/src/domain/app/forms/constants.ts
@@ -16,6 +16,7 @@ export enum VALIDATION_MESSAGE_KEYS {
   TIME_MIN = 'form:validation.time.min',
   TIME_MAX = 'form:validation.time.min',
   TIME_REQUIRED = 'form:validation.time.required',
+  STUDYGROUP_MIN_CHILDREN_WITH_ADULTS = 'form:validation.studygroup.childrenandadultmin',
   STUDYGROUP_MAX_WITH_CHILDREN = 'form:validation.studygroup.adultmaxwithchildren',
   STUDYGROUP_MAX_WITH_ADULTS = 'form:validation.studygroup.childrenmaxwithadults',
   STUDYGROUP_MAX_CHILDREN_WITH_ADULTS = 'form:validation.studygroup.childrenandadultmax',

--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -443,6 +443,38 @@ describe('max group size validation of the Children and Adults -fields', () => {
     });
   });
 
+  test('both of the fields are less than the min group size, but the total is valid', async () => {
+    await createEnrolmentForm('8', '9');
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          /Lasten ja aikuisten yhteislukumäärän tulee olla enintään 20/i
+        )
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(
+        /Lasten ja aikuisten yhteislukumäärän tulee olla vähintään 10/i
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  test('one of the fields are less than the min group size, but the total is valid', async () => {
+    await createEnrolmentForm('7', '11');
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          /Lasten ja aikuisten yhteislukumäärän tulee olla enintään 20/i
+        )
+      ).not.toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(
+        /Lasten ja aikuisten yhteislukumäärän tulee olla vähintään 10/i
+      )
+    ).not.toBeInTheDocument();
+  });
+
   test('one field is greater than the max group size and another one is (still) empty', async () => {
     await createEnrolmentForm('21', '');
     await waitFor(() => {
@@ -453,6 +485,17 @@ describe('max group size validation of the Children and Adults -fields', () => {
       ).toBeInTheDocument();
     });
     expect(screen.getByText(/Tämä kenttä on pakollinen/i)).toBeInTheDocument();
+  });
+
+  test('the total count is less than minimum', async () => {
+    await createEnrolmentForm('1', '2');
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(
+          /Lasten ja aikuisten yhteislukumäärän tulee olla vähintään 10/i
+        )
+      ).toHaveLength(2);
+    });
   });
 
   test('both the fields are valid as a single, but the total is greater than the maximum group size', async () => {


### PR DESCRIPTION
PT-798 Added the missing validation against minimum  group size validation. If the total count in under minimum required, same validation message will appear under both the study group count fields.

Issue: https://helsinkisolutionoffice.atlassian.net/browse/PT-798

Other validation cases here (in a linked task): https://helsinkisolutionoffice.atlassian.net/browse/PT-772?focusedCommentId=19250