### PR TITLE
Show zero instead of a negative amount as space left in a study group.

### DIFF
--- a/src/domain/occurrence/utils.ts
+++ b/src/domain/occurrence/utils.ts
@@ -23,7 +23,13 @@ export const hasOccurrenceSpace = (
 
 export const getAmountOfSeatsLeft = (
   occurrence: OccurrenceFieldsFragment
-): number => occurrence.amountOfSeats - (occurrence.seatsTaken || 0);
+): number => {
+  const amountOfSeatsLeft =
+    occurrence.amountOfSeats - (occurrence.seatsTaken || 0);
+
+  // Don't return negative space left, but a 0 instead
+  return Math.max(0, amountOfSeatsLeft);
+};
 
 export const isEnrolmentStarted = (
   event?: EventFieldsFragment | null


### PR DESCRIPTION
PT-807 Earlier versions of app filled the event with children only. Now when the adults are added to total seats taken calculation, some negative numbers started to appear. This fix returns 0 instead of negative space left.

Before:
![image](https://user-images.githubusercontent.com/389204/109124179-4d6e5780-7753-11eb-9ffa-20978c2d072b.png)
