### PR TITLE
Improved events query.

### DIFF
--- a/src/domain/event/eventCard/EventCard.tsx
+++ b/src/domain/event/eventCard/EventCard.tsx
@@ -2,7 +2,7 @@
 import { IconLocation } from 'hds-react';
 import React from 'react';
 
-import { EventFieldsFragment } from '../../../generated/graphql';
+import { EventsFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import { useTranslation, Link } from '../../../i18n';
 import IconClock from '../../../icons/IconClock';
@@ -13,7 +13,7 @@ import { getEventPlaceholderImage, getEventStartTimeStr } from '../utils';
 import styles from './eventCard.module.scss';
 
 interface Props {
-  event: EventFieldsFragment;
+  event: EventsFieldsFragment;
   link: string;
 }
 

--- a/src/domain/event/eventKeywords/EventKeywords.tsx
+++ b/src/domain/event/eventKeywords/EventKeywords.tsx
@@ -1,6 +1,9 @@
 import React, { ReactElement } from 'react';
 
-import { EventFieldsFragment } from '../../../generated/graphql';
+import {
+  EventFieldsFragment,
+  EventsFieldsFragment,
+} from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import { useTranslation } from '../../../i18n';
 import getLocalisedString from '../../../utils/getLocalisedString';
@@ -8,7 +11,7 @@ import { isEventFree } from '../utils';
 import styles from './eventKeywords.module.scss';
 
 interface Props {
-  event: EventFieldsFragment;
+  event: EventFieldsFragment | EventsFieldsFragment;
 }
 
 const EventKeywords = ({ event }: Props): ReactElement => {

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -6,6 +6,7 @@ import { TFunction } from 'next-i18next';
 
 import {
   EventFieldsFragment,
+  EventsFieldsFragment,
   OccurrenceFieldsFragment,
 } from '../../generated/graphql';
 import { Language } from '../../types';
@@ -25,7 +26,7 @@ export const getEventPlaceholderImage = (id: string): string => {
 };
 
 export const getEventStartTimeStr = (
-  event: EventFieldsFragment,
+  event: EventFieldsFragment | EventsFieldsFragment,
   locale: Language,
   t: TFunction
 ): string | null => {
@@ -52,8 +53,9 @@ export const getEventStartTimeStr = (
   });
 };
 
-export const isEventFree = (event: EventFieldsFragment): boolean =>
-  Boolean(event.offers.find((item) => item.isFree)?.isFree);
+export const isEventFree = (
+  event: EventFieldsFragment | EventsFieldsFragment
+): boolean => Boolean(event.offers.find((item) => item.isFree)?.isFree);
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const getEventFields = (

--- a/src/domain/events/eventList/EventList.tsx
+++ b/src/domain/events/eventList/EventList.tsx
@@ -2,7 +2,7 @@ import { Button, Dropdown, IconArrowDown } from 'hds-react';
 import React, { ReactElement } from 'react';
 
 import LoadingSpinner from '../../../common/components/loadingSpinner/LoadingSpinner';
-import { EventFieldsFragment } from '../../../generated/graphql';
+import { EventsFieldsFragment } from '../../../generated/graphql';
 import { useTranslation } from '../../../i18n';
 import { translateValue } from '../../../utils/translateUtils';
 import { ROUTES } from '../../app/routes/constants';
@@ -11,7 +11,7 @@ import { EVENT_SORT_OPTIONS } from '../constants';
 import styles from './eventList.module.scss';
 
 interface Props {
-  events: EventFieldsFragment[];
+  events: EventsFieldsFragment[];
   fetchMore: () => void;
   isLoading: boolean;
   shouldShowLoadMore: boolean;

--- a/src/domain/events/query.ts
+++ b/src/domain/events/query.ts
@@ -7,6 +7,50 @@ export const QUERY_EVENTS = gql`
     previous
   }
 
+  fragment eventsFields on Event {
+    id
+    internalId
+    name {
+      ...localisedFields
+    }
+    shortDescription {
+      ...localisedFields
+    }
+    description {
+      ...localisedFields
+    }
+    images {
+      ...imageFields
+    }
+    infoUrl {
+      ...localisedFields
+    }
+    offers {
+      ...offerFields
+    }
+    pEvent {
+      id
+      nextOccurrenceDatetime
+    }
+    inLanguage {
+      id
+      internalId
+      name {
+        ...localisedFields
+      }
+    }
+    audience {
+      ...keywordFields
+    }
+    keywords {
+      ...keywordFields
+    }
+    location {
+      ...placeFields
+    }
+    startTime
+  }
+
   query Events(
     $division: [String]
     $end: String
@@ -51,7 +95,7 @@ export const QUERY_EVENTS = gql`
         ...metaFields
       }
       data {
-        ...eventFields
+        ...eventsFields
       }
     }
   }

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -3,7 +3,7 @@ import isValidDate from 'date-fns/isValid';
 import { EVENT_LANGUAGES } from '../../constants';
 import {
   EventsQueryVariables,
-  EventFieldsFragment,
+  EventsFieldsFragment,
   EventsQuery,
 } from '../../generated/graphql';
 import { queryParameterToArray } from '../../utils/queryParameterToArray';
@@ -99,6 +99,6 @@ export const getInitialDate = (date?: string | string[]): Date | null => {
 
 export const getEventsThatHaveUpcomingOccurrence = (
   eventData?: EventsQuery
-): EventFieldsFragment[] | undefined => {
+): EventsFieldsFragment[] | undefined => {
   return eventData?.events?.data.filter((e) => e.pEvent.nextOccurrenceDatetime);
 };

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -722,6 +722,8 @@ export type Event = {
   categories: Array<Keyword>;
   /** Only use this field in single event query for best performance. This field only work if `keywords` is included in the query argument */
   additionalCriteria: Array<Keyword>;
+  /** Only use this field in single event query for best performance. This field only work if `keywords` is included in the query argument */
+  activities: Array<Keyword>;
 };
 
 export type Place = {
@@ -949,6 +951,7 @@ export type KeywordSet = {
 export enum KeywordSetType {
   Category = 'CATEGORY',
   AdditionalCriteria = 'ADDITIONAL_CRITERIA',
+  Activities = 'ACTIVITIES',
   TargetGroup = 'TARGET_GROUP',
 }
 
@@ -1850,6 +1853,36 @@ export type MetaFieldsFragment = { __typename?: 'Meta' } & Pick<
   'count' | 'next' | 'previous'
 >;
 
+export type EventsFieldsFragment = { __typename?: 'Event' } & Pick<
+  Event,
+  'id' | 'internalId' | 'startTime'
+> & {
+    name: { __typename?: 'LocalisedObject' } & LocalisedFieldsFragment;
+    shortDescription: {
+      __typename?: 'LocalisedObject';
+    } & LocalisedFieldsFragment;
+    description: { __typename?: 'LocalisedObject' } & LocalisedFieldsFragment;
+    images: Array<{ __typename?: 'Image' } & ImageFieldsFragment>;
+    infoUrl?: Maybe<
+      { __typename?: 'LocalisedObject' } & LocalisedFieldsFragment
+    >;
+    offers: Array<{ __typename?: 'Offer' } & OfferFieldsFragment>;
+    pEvent: { __typename?: 'PalvelutarjotinEventNode' } & Pick<
+      PalvelutarjotinEventNode,
+      'id' | 'nextOccurrenceDatetime'
+    >;
+    inLanguage: Array<
+      { __typename?: 'InLanguage' } & Pick<InLanguage, 'id' | 'internalId'> & {
+          name?: Maybe<
+            { __typename?: 'LocalisedObject' } & LocalisedFieldsFragment
+          >;
+        }
+    >;
+    audience: Array<{ __typename?: 'Keyword' } & KeywordFieldsFragment>;
+    keywords: Array<{ __typename?: 'Keyword' } & KeywordFieldsFragment>;
+    location: { __typename?: 'Place' } & PlaceFieldsFragment;
+  };
+
 export type EventsQueryVariables = Exact<{
   division?: Maybe<Array<Maybe<Scalars['String']>>>;
   end?: Maybe<Scalars['String']>;
@@ -1875,7 +1908,7 @@ export type EventsQuery = { __typename?: 'Query' } & {
   events?: Maybe<
     { __typename?: 'EventListResponse' } & {
       meta: { __typename?: 'Meta' } & MetaFieldsFragment;
-      data: Array<{ __typename?: 'Event' } & EventFieldsFragment>;
+      data: Array<{ __typename?: 'Event' } & EventsFieldsFragment>;
     }
   >;
 };
@@ -2378,6 +2411,56 @@ export const MetaFieldsFragmentDoc = gql`
     previous
   }
 `;
+export const EventsFieldsFragmentDoc = gql`
+  fragment eventsFields on Event {
+    id
+    internalId
+    name {
+      ...localisedFields
+    }
+    shortDescription {
+      ...localisedFields
+    }
+    description {
+      ...localisedFields
+    }
+    images {
+      ...imageFields
+    }
+    infoUrl {
+      ...localisedFields
+    }
+    offers {
+      ...offerFields
+    }
+    pEvent {
+      id
+      nextOccurrenceDatetime
+    }
+    inLanguage {
+      id
+      internalId
+      name {
+        ...localisedFields
+      }
+    }
+    audience {
+      ...keywordFields
+    }
+    keywords {
+      ...keywordFields
+    }
+    location {
+      ...placeFields
+    }
+    startTime
+  }
+  ${LocalisedFieldsFragmentDoc}
+  ${ImageFieldsFragmentDoc}
+  ${OfferFieldsFragmentDoc}
+  ${KeywordFieldsFragmentDoc}
+  ${PlaceFieldsFragmentDoc}
+`;
 export const EnrolOccurrenceDocument = gql`
   mutation EnrolOccurrence($input: EnrolOccurrenceMutationInput!) {
     enrolOccurrence(input: $input) {
@@ -2588,12 +2671,12 @@ export const EventsDocument = gql`
         ...metaFields
       }
       data {
-        ...eventFields
+        ...eventsFields
       }
     }
   }
   ${MetaFieldsFragmentDoc}
-  ${EventFieldsFragmentDoc}
+  ${EventsFieldsFragmentDoc}
 `;
 export type EventsProps<TChildProps = {}, TDataName extends string = 'data'> = {
   [key in TDataName]: ApolloReactHoc.DataValue<

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -108,6 +108,7 @@ export const fakeEvent = (overrides?: Partial<Event>): Event => {
     endTime: '2020-07-13T05:51:05.761000Z',
     additionalCriteria: [],
     categories: [],
+    activities: [],
     __typename: 'Event',
     ...overrides,
   };


### PR DESCRIPTION
PT-797 Removed pEvent and venue fields (but left an id and nextOccurrenceDatetime) to much improve the events query. Single event query is unchanged.

API changes done in https://github.com/City-of-Helsinki/palvelutarjotin/pull/129.