### PR TITLE
Critical fix to create enrolment page's event query.

### DIFF
--- a/src/domain/enrolment/CreateEnrolmentPage.tsx
+++ b/src/domain/enrolment/CreateEnrolmentPage.tsx
@@ -44,7 +44,7 @@ const CreateEnrolmentPage: React.FC = () => {
   } = useRouter();
 
   const { data: eventData, loading } = useEventQuery({
-    variables: { id: eventId as string, include: ['location'] },
+    variables: { id: eventId as string, include: ['location', 'keywords'] },
   });
 
   const [enrolOccurrence] = useEnrolOccurrenceMutation();

--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -46,7 +46,7 @@ configure({ defaultHidden: true });
 const mockBase = (event: Event): MockedResponse => ({
   request: {
     query: EventDocument,
-    variables: { id: eventId, include: ['location'] },
+    variables: { id: eventId, include: ['location', 'keywords'] },
   },
   result: {
     data: {


### PR DESCRIPTION
PT-842 Fixed enrolment creation page. Keywords must be included in events query like they are in event page.