### PR TITLE
Rendered event languages on event page

### DIFF
--- a/public/static/locales/en/event.json
+++ b/public/static/locales/en/event.json
@@ -47,7 +47,8 @@
     "labelCategories": "Categories",
     "labelAudience": "Target groups",
     "labelActivities": "Activities",
-    "labelKeywords": "Keywords"
+    "labelKeywords": "Keywords",
+    "labelLanguages": "Event languages"
   },
   "shareLinks": {
     "title": "Jaa tapahtuma"

--- a/public/static/locales/en/occurrence.json
+++ b/public/static/locales/en/occurrence.json
@@ -4,10 +4,12 @@
   "textAmountOfSeats": "{{count}} seat",
   "textAmountOfSeats_plural": "{{count}} seats",
   "textGroupInfo": "group size {{minGroupSize}}–{{maxGroupSize}}",
+  "labelGroupInfo": "Seats",
+  "labelLanguages": "Language",
   "languages": {
-    "en": "in English",
-    "fi": "in Finnish",
-    "sv": "in Swedish"
+    "en": "English",
+    "fi": "Finnish",
+    "sv": "Swedish"
   },
   "showOccurrenceDetails": "Show occurrence details",
   "occurrenceSelection": {

--- a/public/static/locales/fi/event.json
+++ b/public/static/locales/fi/event.json
@@ -47,7 +47,8 @@
     "labelCategories": "Kategoriat",
     "labelAudience": "Kohderyhmät",
     "labelActivities": "Aktiviteetit",
-    "labelKeywords": "Avainsanat"
+    "labelKeywords": "Avainsanat",
+    "labelLanguages": "Tapahtuman kielet"
   },
   "shareLinks": {
     "title": "Share Event"

--- a/public/static/locales/fi/occurrence.json
+++ b/public/static/locales/fi/occurrence.json
@@ -4,10 +4,12 @@
   "textAmountOfSeats": "{{count}} paikka",
   "textAmountOfSeats_plural": "{{count}} paikkaa",
   "textGroupInfo": "ryhmän koko {{minGroupSize}}–{{maxGroupSize}}",
+  "labelGroupInfo": "Paikkoja",
+  "labelLanguages": "Kieli",
   "languages": {
-    "en": "englanninkielinen",
-    "fi": "suomenkielinen",
-    "sv": "ruotsinkielinen"
+    "en": "englanti",
+    "fi": "suomi",
+    "sv": "ruotsi"
   },
   "showOccurrenceDetails": "Näytä tapahtuma-ajan lisätiedot",
   "occurrenceSelection": {

--- a/public/static/locales/sv/event.json
+++ b/public/static/locales/sv/event.json
@@ -47,7 +47,8 @@
     "labelAudience": "Målgrupper",
     "labelKeywords": "Evenemangs nyckelord",
     "labelCategories": "Kategorier",
-    "labelActivities": "Aktiviteter"
+    "labelActivities": "Aktiviteter",
+    "labelLanguages": "Evenemangspråk"
   },
   "shareLinks": {
     "title": "Dela händelsen"

--- a/public/static/locales/sv/occurrence.json
+++ b/public/static/locales/sv/occurrence.json
@@ -4,8 +4,10 @@
   "textAmountOfSeats": "{{count}} plats",
   "textAmountOfSeats_plural": "{{count}} platser",
   "textGroupInfo": "gruppstorlek {{minGroupSize}}–{{maxGroupSize}}",
+  "labelGroupInfo": "Platser",
+  "labelLanguages": "Språk",
   "languages": {
-    "en": "engelsk",
+    "en": "engelska",
     "fi": "finska",
     "sv": "svenska"
   },

--- a/src/domain/event/EventPage.tsx
+++ b/src/domain/event/EventPage.tsx
@@ -41,7 +41,7 @@ const EventPage = (): ReactElement => {
   const { data: eventData, loading, refetch: refetchEvent } = useEventQuery({
     variables: {
       id: eventId as string,
-      include: ['keywords', 'location', 'audience'],
+      include: ['keywords', 'location', 'audience', 'in_language'],
       upcomingOccurrencesOnly: true,
     },
   });

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -17,6 +17,7 @@ import { Router as i18nRouter } from '../../../i18n';
 import {
   fakeEvent,
   fakeImage,
+  fakeInLanguage,
   fakeKeyword,
   fakeLocalizedObject,
   fakeOccurrences,
@@ -61,6 +62,7 @@ const data = {
   categories: ['Musiikki', 'Teatteri'],
   audience: ['1.–2. luokat', '3.–6. luokat', 'Valmistava opetus'],
   additionalCriteria: ['Luento', 'Työpaja', 'perheet'],
+  languages: ['suomi', 'englanti'],
 };
 
 const createFakeKeyword = (k: string) =>
@@ -149,6 +151,19 @@ const eventData = {
       audience: data.audience.map(createFakeKeyword),
       // activities
       additionalCriteria: data.additionalCriteria.map(createFakeKeyword),
+      inLanguage: [
+        fakeInLanguage(),
+        fakeInLanguage({
+          id: 'en',
+          internalId: 'https://api.hel.fi/linkedevents-test/v1/language/en/',
+          name: {
+            en: 'English',
+            fi: 'englanti',
+            sv: 'Engelska',
+            __typename: 'LocalisedObject',
+          },
+        }),
+      ],
     }),
   },
 };
@@ -188,7 +203,7 @@ const apolloMocks = [
       query: EventDocument,
       variables: {
         id: data.id,
-        include: ['keywords', 'location', 'audience'],
+        include: ['keywords', 'location', 'audience', 'in_language'],
         upcomingOccurrencesOnly: true,
       },
     },
@@ -329,6 +344,7 @@ it('renders categorisation section with all categories and keywords', async () =
     ...data.audience,
     ...data.keywords,
     ...data.additionalCriteria,
+    ...data.languages,
   ].forEach((k) => {
     expect(
       categorisationContainer.getByText(new RegExp(k, 'i'))

--- a/src/domain/event/eventBasicInfo/EventCategorisation.tsx
+++ b/src/domain/event/eventBasicInfo/EventCategorisation.tsx
@@ -19,7 +19,10 @@ const EventCategorisation: React.FC<{
   const locale = useLocale();
   const realKeywords = getRealKeywords({ event });
   const { t } = useTranslation();
-  const { categories, activities, audience } = getEventFields(event, locale);
+  const { categories, activities, audience, languages } = getEventFields(
+    event,
+    locale
+  );
 
   return (
     <div
@@ -44,6 +47,12 @@ const EventCategorisation: React.FC<{
         <CategorySection
           title={t('event:categorisation.labelKeywords')}
           text={keywordArrayToText(realKeywords, locale)}
+        />
+      </div>
+      <div className={styles.categorisationRow}>
+        <CategorySection
+          title={t('event:categorisation.labelLanguages')}
+          text={keywordArrayToText(languages, locale)}
         />
       </div>
     </div>

--- a/src/domain/event/occurrences/Occurrences.tsx
+++ b/src/domain/event/occurrences/Occurrences.tsx
@@ -23,6 +23,7 @@ import formatTimeRange from '../../../utils/formatTimeRange';
 import { translateValue } from '../../../utils/translateUtils';
 import { ENROLMENT_ERRORS } from '../../enrolment/constants';
 import OccurrenceGroupInfo from '../../occurrence/occurrenceGroupInfo/OccurrenceGroupInfo';
+import OccurrenceGroupLanguageInfo from '../../occurrence/occurrenceGroupInfo/OccurrenceGroupLanguageInfo';
 import {
   getAmountOfSeatsLeft,
   hasOccurrenceSpace,
@@ -327,6 +328,7 @@ const OccurrenceInfo: React.FC<OccurrenceInfoProps> = ({
         </div>
         <div>{t('occurrence:textDateAndTime', { date, time })}</div>
         <OccurrenceGroupInfo occurrence={occurrence} />
+        <OccurrenceGroupLanguageInfo occurrence={occurrence} />
       </div>
     </>
   );

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -84,6 +84,7 @@ export const getEventFields = (
         categories: event.categories,
         activities: event.additionalCriteria,
         audience: event.audience,
+        languages: event.inLanguage,
         isMandatoryAdditionalInformationRequired: !!event.pEvent
           ?.mandatoryAdditionalInformation,
         occurrences:

--- a/src/domain/occurrence/occurrenceGroupInfo/OccurrenceGroupInfo.tsx
+++ b/src/domain/occurrence/occurrenceGroupInfo/OccurrenceGroupInfo.tsx
@@ -24,14 +24,15 @@ const OccurrenceGroupInfo: React.FC<Props> = ({ occurrence }) => {
       maxGroupSize,
       minGroupSize,
     }),
-    languages
-      ?.map((language) => t(`occurrence:languages.${language}`))
-      .join(', '),
   ]
     .filter((e) => e)
     .join(', ');
 
-  return <p>{groupInfo}</p>;
+  return (
+    <p>
+      {t('occurrence:labelGroupInfo')}: {groupInfo}
+    </p>
+  );
 };
 
 export default OccurrenceGroupInfo;

--- a/src/domain/occurrence/occurrenceGroupInfo/OccurrenceGroupLanguageInfo.tsx
+++ b/src/domain/occurrence/occurrenceGroupInfo/OccurrenceGroupLanguageInfo.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { OccurrenceFieldsFragment } from '../../../generated/graphql';
+import { useTranslation } from '../../../i18n';
+
+interface Props {
+  occurrence: OccurrenceFieldsFragment;
+}
+
+const OccurrenceGroupLanguageInfo: React.FC<Props> = ({ occurrence }) => {
+  const { t } = useTranslation();
+
+  const languages =
+    occurrence.languages.edges.map((edge) => edge?.node?.id ?? '') ?? [];
+
+  return (
+    <p>
+      {t('occurrence:labelLanguages')}:{' '}
+      {languages
+        ?.map((language) => t(`occurrence:languages.${language}`))
+        .join(', ')}
+    </p>
+  );
+};
+
+export default OccurrenceGroupLanguageInfo;


### PR DESCRIPTION
PT-830. In language field is now included in event query and the languages are listed in category section because it was designed there and the field works exactly the same as keywords. Changes to how the group info with language is shown on occurrence. Added labels for seats taken and language. Some changes to translations.

![image](https://user-images.githubusercontent.com/389204/111633246-f6155180-87fd-11eb-9bd7-646b425cdc60.png)

![image](https://user-images.githubusercontent.com/389204/111633337-11805c80-87fe-11eb-96da-3e8b516e512c.png)

