### PR TITLE
Showing weekday on occurrence table titles.

### DIFF
--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -262,13 +262,13 @@ test('renders form and user can fill it and submit', async () => {
 
   expect(
     screen.queryByRole('row', {
-      name: '25.09.2020 12:30 – 12:30 Kirjasto 30 / 30',
+      name: '25.09.2020 pe 12:30 – 12:30 Kirjasto 30 / 30',
     })
   ).toBeInTheDocument();
 
   expect(
     screen.queryByRole('row', {
-      name: '26.09.2020 13:20 – 12:30 Kirjasto 30 / 30',
+      name: '26.09.2020 la 13:20 – 12:30 Kirjasto 30 / 30',
     })
   ).toBeInTheDocument();
 

--- a/src/domain/enrolment/occurrenceTable/OccurrenceTable.tsx
+++ b/src/domain/enrolment/occurrenceTable/OccurrenceTable.tsx
@@ -22,7 +22,7 @@ const OccurrenceTable: React.FC<Props> = ({ eventLocationId, occurrences }) => {
     {
       Header: t('enrolment:occurrenceTable.columnDate'),
       accessor: (row: OccurrenceFieldsFragment) =>
-        formatDate(new Date(row.startTime)),
+        formatDate(new Date(row.startTime), 'dd.MM.yyyy eeeeee', locale),
       id: 'date',
     },
     {

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -230,7 +230,7 @@ const apolloMocks = [
   },
 ];
 
-const rowText = `27.07.2020 12:00 – 12:30 ${data.placeName} 30 / 30 Ilmoittaudu`;
+const rowText = `27.07.2020 ma 12:00 – 12:30 ${data.placeName} 30 / 30 Ilmoittaudu`;
 
 advanceTo(new Date(2020, 6, 14));
 
@@ -265,9 +265,9 @@ it('shows full events correctly in occurrences list', async () => {
   await waitForRequestsToComplete();
 
   const fullOccurrenceRowText1 =
-    '23.07.2020 12:00 – 12:30 Soukan kirjasto 0 / 1 Tapahtuma on täynnä';
+    '23.07.2020 to 12:00 – 12:30 Soukan kirjasto 0 / 1 Tapahtuma on täynnä';
   const fullOccurrenceRowText2 =
-    '29.07.2020 12:00 – 12:30 Soukan kirjasto 0 / 30 Tapahtuma on täynnä';
+    '29.07.2020 ke 12:00 – 12:30 Soukan kirjasto 0 / 30 Tapahtuma on täynnä';
 
   expect(
     screen.queryByRole('row', {

--- a/src/domain/event/occurrences/Occurrences.tsx
+++ b/src/domain/event/occurrences/Occurrences.tsx
@@ -167,7 +167,7 @@ const Occurrences: React.FC<Props> = ({
     {
       Header: t('enrolment:occurrenceTable.columnDate'),
       accessor: (row: OccurrenceFieldsFragment) =>
-        formatDate(new Date(row.startTime)),
+        formatDate(new Date(row.startTime), 'dd.MM.yyyy eeeeee', locale),
       id: 'date',
     },
     {


### PR DESCRIPTION
PT-790. Weekday shown in title table row in format "dd.MM.yyyy eeeeee", e.g "24.03.2021 We".