### PR TITLE
Splitted Occurrences component to multiple new private components.

### DIFF
--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -598,4 +598,42 @@ describe('refetch of event works correctly', () => {
 
     expect(refetchMock).not.toHaveBeenCalled();
   });
+
+  it('informs when there are no occurrences in future', async () => {
+    render(<EventPage />, {
+      mocks: [
+        {
+          request: {
+            query: EventDocument,
+            variables: {
+              id: data.id,
+              include: ['keywords', 'location', 'audience', 'in_language'],
+              upcomingOccurrencesOnly: true,
+            },
+          },
+          result: {
+            ...eventData,
+            data: {
+              ...eventData.data,
+              event: {
+                ...eventData.data.event,
+                pEvent: {
+                  ...eventData.data.event.pEvent,
+                  occurrences: fakeOccurrences(0),
+                },
+              },
+            },
+          },
+        },
+      ],
+      query: { eventId: eventData.data.event.id },
+      path: `/fi${ROUTES.EVENT_DETAILS.replace(':id', data.id)}`,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Tapahtumalla ei ole tapahtuma-aikoja')
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -99,6 +99,12 @@ export const getEventSomeImageUrl = (event: EventFieldsFragment): string => {
   return image ? image.url : EVENT_SOME_IMAGE;
 };
 
+/* NOTE: occurrences could be an empty list, 
+and then we would get index out of bound error. 
+However, TypeScript makes it hard or impossible 
+at the moment to return undefined from here, 
+because callers are waiting for a Date 
+and hooks don't allow early returns */
 export const getFirstOrLastDateOfOccurrences = (
   occurrences: OccurrenceFieldsFragment[],
   option: 'first' | 'last'


### PR DESCRIPTION
PT-911 Occurrences component was a massive function that had issues with hooks. Because React hooks doesn't allow early returns, a bug in occurrences rendering could not be resolved without a great refactoring.

Screenshots of the wanted result and the error log in issue: https://helsinkisolutionoffice.atlassian.net/browse/PT-911

![image](https://user-images.githubusercontent.com/389204/112458176-32e4c980-8d65-11eb-981c-0133b8877f6d.png)
