### PR TITLE
Email is mandatory but phone number is optional in the enrolment form

### DIFF
--- a/public/static/locales/en/enrolment.json
+++ b/public/static/locales/en/enrolment.json
@@ -38,7 +38,8 @@
     "titleNotifications": "Event notifications",
     "titleResponsiblePerson": "An adult in charge of the group during the event",
     "validation": {
-      "isSharingDataAccepted": "Sharing information with the event organizer must be accepted"
+      "isSharingDataAccepted": "Sharing information with the event organizer must be accepted",
+      "hasEmailNotification": "Email notifications are mandatory"
     }
   },
   "errors": {

--- a/public/static/locales/fi/enrolment.json
+++ b/public/static/locales/fi/enrolment.json
@@ -38,7 +38,8 @@
     "titleNotifications": "Tapahtumaa koskevat ilmoitukset",
     "titleResponsiblePerson": "Tapahtuman aikana ryhmästä vastuussa oleva aikuinen",
     "validation": {
-      "isSharingDataAccepted": "Tietojen jakaminen tapahtuman järjestäjän kanssa tulee olla hyväksytty"
+      "isSharingDataAccepted": "Tietojen jakaminen tapahtuman järjestäjän kanssa tulee olla hyväksytty",
+      "hasEmailNotification": "Sähköposti-ilmoitukset ovat pakollisia"
     }
   },
   "errors": {

--- a/public/static/locales/sv/enrolment.json
+++ b/public/static/locales/sv/enrolment.json
@@ -38,7 +38,8 @@
     "titleNotifications": "Meddelanden om händelse",
     "titleResponsiblePerson": "An adult in charge of the group during the event",
     "validation": {
-      "isSharingDataAccepted": "Dela information med arrangören måste godkännas"
+      "isSharingDataAccepted": "Dela information med arrangören måste godkännas",
+      "hasEmailNotification": "E-postaviseringar krävs"
     }
   },
   "errors": {

--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -399,7 +399,6 @@ test('render and focuses error notification correctly', async () => {
   const requiredFieldLabels = [
     'Hyväksyn tietojeni jakamisen tapahtuman järjestäjän kanssa',
     'Nimi',
-    'Puhelinnumero',
     'Sähköpostiosoite',
     'Päiväkoti / koulu / oppilaitos',
     'Ryhmä',

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -108,8 +108,6 @@ const EnrolmentForm: React.FC<Props> = ({
               </FormGroup>
               <FormGroup>
                 <Field
-                  required
-                  aria-required
                   labelText={t(
                     nameToLabelPath['studyGroup.person.phoneNumber']
                   )}
@@ -207,6 +205,8 @@ const EnrolmentForm: React.FC<Props> = ({
                 <>
                   <FormGroup>
                     <Field
+                      required
+                      aria-required
                       labelText={t(nameToLabelPath['person.name'])}
                       component={TextInputField}
                       name="person.name"
@@ -214,6 +214,8 @@ const EnrolmentForm: React.FC<Props> = ({
                   </FormGroup>
                   <FormGroup>
                     <Field
+                      required
+                      aria-required
                       labelText={t(nameToLabelPath['person.emailAddress'])}
                       component={TextInputField}
                       name="person.emailAddress"

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -238,6 +238,7 @@ const EnrolmentForm: React.FC<Props> = ({
                 <FormGroup>
                   <div className={styles.checkboxWrapper}>
                     <Field
+                      disabled
                       label={t(nameToLabelPath['hasEmailNotification'])}
                       component={CheckboxField}
                       name="hasEmailNotification"

--- a/src/domain/enrolment/enrolmentForm/ValidationSchema.tsx
+++ b/src/domain/enrolment/enrolmentForm/ValidationSchema.tsx
@@ -3,6 +3,10 @@ import * as Yup from 'yup';
 import { VALIDATION_MESSAGE_KEYS } from '../../app/forms/constants';
 
 export default Yup.object().shape({
+  hasEmailNotification: Yup.bool().oneOf(
+    [true],
+    'enrolment:enrolmentForm.validation.hasEmailNotification'
+  ),
   isSharingDataAccepted: Yup.bool().oneOf(
     [true],
     'enrolment:enrolmentForm.validation.isSharingDataAccepted'

--- a/src/domain/enrolment/enrolmentForm/ValidationSchema.tsx
+++ b/src/domain/enrolment/enrolmentForm/ValidationSchema.tsx
@@ -17,9 +17,6 @@ export default Yup.object().shape({
             name: Yup.string().required(
               VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
             ),
-            phoneNumber: Yup.string().required(
-              VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
-            ),
             emailAddress: Yup.string()
               .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
               .email(VALIDATION_MESSAGE_KEYS.EMAIL),
@@ -85,9 +82,6 @@ export default Yup.object().shape({
         {
           person: Yup.object().shape({
             name: Yup.string().required(
-              VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
-            ),
-            phoneNumber: Yup.string().required(
               VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
             ),
             emailAddress: Yup.string()

--- a/src/domain/enrolment/enrolmentForm/constants.ts
+++ b/src/domain/enrolment/enrolmentForm/constants.ts
@@ -28,7 +28,7 @@ export type EnrolmentFormFields = {
 };
 
 export const defaultInitialValues: EnrolmentFormFields = {
-  hasEmailNotification: false,
+  hasEmailNotification: true,
   hasSmsNotification: false,
   isSameResponsiblePerson: true,
   isSharingDataAccepted: false,

--- a/src/domain/enrolment/utils.ts
+++ b/src/domain/enrolment/utils.ts
@@ -5,15 +5,10 @@ import {
 } from '../../generated/graphql';
 import { EnrolmentFormFields } from './enrolmentForm/constants';
 
-const getNotificationType = (
-  values: EnrolmentFormFields
-): NotificationType | undefined => {
-  if (values.hasEmailNotification && values.hasSmsNotification)
-    return NotificationType.EmailSms;
-  else if (values.hasEmailNotification) return NotificationType.Email;
-  else if (values.hasSmsNotification) return NotificationType.Sms;
-
-  return undefined;
+const getNotificationType = (values: EnrolmentFormFields): NotificationType => {
+  return values.hasEmailNotification && values.hasSmsNotification
+    ? NotificationType.EmailSms
+    : NotificationType.Email;
 };
 
 export const getEnrolmentPayload = ({


### PR DESCRIPTION
PT-891. Enrolments does not require a phone number anymore.

Added missing required-attributes to emails and names. Removed required-attributes and validations from phone fields. 

Enrolment's email notifications are now mandatory. The checkbox is auto selected and disabled in UI, so it appears as checked but passive. GraphQL mutation does not allow sms only notifications anymore. It should be noted that API still allows them!