### PR TITLE
Don't allow sms notifications if no phone number is given

### DIFF
--- a/public/static/locales/en/enrolment.json
+++ b/public/static/locales/en/enrolment.json
@@ -6,6 +6,8 @@
     "infoText2": "We will send you a separate confirmation message once the organizer has processed and confirmed your registration.",
     "labelHasEmailNotification": "By e-mail",
     "labelHasSmsNotification": "By SMS",
+    "titleTextHasEmailNotification": "Email notifications are mandatory",
+    "titleTextHasSmsNotification": "SMS notifications are available when a phone number is entered",
     "labelIsSameResponsiblePerson": "Same as notifier",
     "labelIsSharingDataAccepted": "I agree to share my information with the event organizer",
     "labelLanguage": "Language",

--- a/public/static/locales/fi/enrolment.json
+++ b/public/static/locales/fi/enrolment.json
@@ -6,6 +6,8 @@
     "infoText2": "Lähetämme sinulle erillisen vahvistusviestin, kun järjestäjä on käsitellyt ja vahvistanut ilmoittautumisesi.",
     "labelHasEmailNotification": "Sähköpostilla",
     "labelHasSmsNotification": "Tekstiviestillä",
+    "titleTextHasEmailNotification": "Sähköposti-ilmoitukset ovat pakollisia",
+    "titleTextHasSmsNotification": "Tekstiviesti-ilmoitukset valittavissa kun puhelinnumero on annettu",
     "labelIsSameResponsiblePerson": "Sama kuin ilmoittaja",
     "labelIsSharingDataAccepted": "Hyväksyn tietojeni jakamisen tapahtuman järjestäjän kanssa",
     "labelLanguage": "Kieli",

--- a/public/static/locales/sv/enrolment.json
+++ b/public/static/locales/sv/enrolment.json
@@ -6,6 +6,8 @@
     "infoText2": "Vi skickar ett separat bekräftelsemeddelande när organisatören har behandlat och bekräftat din registrering.",
     "labelHasEmailNotification": "Via e-post",
     "labelHasSmsNotification": "Via SMS",
+    "titleTextHasEmailNotification": "E-postaviseringar krävs",
+    "titleTextHasSmsNotification": "SMS-aviseringar är tillgängliga när ett telefonnummer anges",
     "labelIsSameResponsiblePerson": "Samma som anmälare",
     "labelIsSharingDataAccepted": "Jag accepterar att dela min information med arrangören",
     "labelLanguage": "Språk",

--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -557,9 +557,21 @@ test('Do not allow sms notifications if no phone number is given', async () => {
   await waitFor(() => {
     expect(screen.getByLabelText(/Puhelinnumero/i)).toBeInTheDocument();
   });
-  expect(screen.getByLabelText(/Puhelinnumero/i)).not.toHaveValue();
-  expect(screen.getByLabelText(/Tekstiviestillä/i)).toBeDisabled();
-  userEvent.type(screen.getByLabelText(/Puhelinnumero/i), '123');
+  const phoneField = screen.getByLabelText(/Puhelinnumero/i);
+  const smsField = screen.getByLabelText(/Tekstiviestillä/i);
+  expect(phoneField).not.toHaveValue();
+  expect(smsField).toBeDisabled();
+  userEvent.type(phoneField, '123');
   userEvent.tab();
-  expect(screen.getByLabelText(/Tekstiviestillä/i)).not.toBeDisabled();
+  await waitFor(() => {
+    expect(screen.getByLabelText(/Tekstiviestillä/i)).not.toBeDisabled();
+  });
+  userEvent.click(smsField);
+  expect(smsField).toBeChecked();
+  userEvent.clear(phoneField);
+  userEvent.tab();
+  await waitFor(() => {
+    expect(screen.getByLabelText(/Tekstiviestillä/i)).toBeDisabled();
+  });
+  expect(smsField).not.toBeChecked();
 });

--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -575,3 +575,33 @@ test('Do not allow sms notifications if no phone number is given', async () => {
   });
   expect(smsField).not.toBeChecked();
 });
+
+test('Allow sms notifications if any of the phone numbers are given', async () => {
+  render(<CreateEnrolmentPage />, {
+    mocks: mock4,
+    query: { eventId: eventId, occurrences: occurrenceIds },
+  });
+  await waitFor(() => {
+    expect(screen.getByLabelText(/Sama kuin ilmoittaja/i)).toBeInTheDocument();
+  });
+  const isResponsiblePersonField = screen.getByLabelText(
+    /Sama kuin ilmoittaja/i
+  );
+
+  userEvent.click(isResponsiblePersonField);
+
+  const phoneFields = screen.queryAllByLabelText(/Puhelinnumero/i);
+
+  phoneFields.forEach((f) => userEvent.type(f, '123'));
+  await waitFor(() => {
+    expect(screen.getByLabelText(/Tekstiviestillä/i)).not.toBeDisabled();
+  });
+  userEvent.clear(phoneFields[0]);
+  await waitFor(() => {
+    expect(screen.getByLabelText(/Tekstiviestillä/i)).not.toBeDisabled();
+  });
+  phoneFields.forEach((f) => userEvent.clear(f));
+  await waitFor(() => {
+    expect(screen.getByLabelText(/Tekstiviestillä/i)).toBeDisabled();
+  });
+});

--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -548,3 +548,18 @@ test('mandatory additional information forces extraNeeds field to be required', 
     expect(screen.getByText(/Tämä kenttä on pakollinen/i)).toBeInTheDocument();
   });
 });
+
+test('Do not allow sms notifications if no phone number is given', async () => {
+  render(<CreateEnrolmentPage />, {
+    mocks: mock4,
+    query: { eventId: eventId, occurrences: occurrenceIds },
+  });
+  await waitFor(() => {
+    expect(screen.getByLabelText(/Puhelinnumero/i)).toBeInTheDocument();
+  });
+  expect(screen.getByLabelText(/Puhelinnumero/i)).not.toHaveValue();
+  expect(screen.getByLabelText(/Tekstiviestillä/i)).toBeDisabled();
+  userEvent.type(screen.getByLabelText(/Puhelinnumero/i), '123');
+  userEvent.tab();
+  expect(screen.getByLabelText(/Tekstiviestillä/i)).not.toBeDisabled();
+});

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -52,20 +52,21 @@ const EnrolmentForm: React.FC<Props> = ({
       onSubmit={onSubmit}
       validationSchema={ValidationSchema}
     >
-      {({
-        errors,
-        handleSubmit,
-        touched,
-        submitCount,
-        values: {
+      {({ errors, handleSubmit, touched, submitCount, values }) => {
+        const {
           isSameResponsiblePerson,
           isMandatoryAdditionalInformationRequired,
-        },
-      }) => {
+          studyGroup: {
+            person: { phoneNumber: studyGroupPhoneNumber },
+          },
+        } = values;
         const showErrorNotification = !isEmpty(errors) && !!submitCount;
         const errorLabelKeys = keyify(errors)
           .map((path) => nameToLabelPath[path])
           .filter((i) => i);
+        const hasPhoneNumber = () => {
+          return !!studyGroupPhoneNumber;
+        };
         return (
           <form
             className={styles.enrolmentForm}
@@ -239,6 +240,9 @@ const EnrolmentForm: React.FC<Props> = ({
                   <div className={styles.checkboxWrapper}>
                     <Field
                       disabled
+                      title={t(
+                        'enrolment:enrolmentForm.titleTextHasEmailNotification'
+                      )}
                       label={t(nameToLabelPath['hasEmailNotification'])}
                       component={CheckboxField}
                       name="hasEmailNotification"
@@ -248,6 +252,10 @@ const EnrolmentForm: React.FC<Props> = ({
                 <FormGroup>
                   <div className={styles.checkboxWrapper}>
                     <Field
+                      disabled={!hasPhoneNumber()}
+                      title={t(
+                        'enrolment:enrolmentForm.titleTextHasSmsNotification'
+                      )}
                       label={t(nameToLabelPath['hasSmsNotification'])}
                       component={CheckboxField}
                       name="hasSmsNotification"

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -64,6 +64,7 @@ const EnrolmentForm: React.FC<Props> = ({
         const {
           isSameResponsiblePerson,
           isMandatoryAdditionalInformationRequired,
+          person: { phoneNumber },
           studyGroup: {
             person: { phoneNumber: studyGroupPhoneNumber },
           },
@@ -73,16 +74,26 @@ const EnrolmentForm: React.FC<Props> = ({
           .map((path) => nameToLabelPath[path])
           .filter((i) => i);
         const hasPhoneNumber = () => {
-          return !!studyGroupPhoneNumber;
+          return !!phoneNumber || !!studyGroupPhoneNumber;
         };
-        const handlePhonNumberChange = (
+        const handlePersonPhoneNumberChange = (
           e: React.ChangeEvent<HTMLInputElement>
         ) => {
           handleChange(e);
-          if (!e.target.value) {
+          if (!e.target.value && !studyGroupPhoneNumber) {
             setFieldValue('hasSmsNotification', false);
           }
         };
+
+        const handleStudyGroupPhoneNumberChange = (
+          e: React.ChangeEvent<HTMLInputElement>
+        ) => {
+          handleChange(e);
+          if (!e.target.value && !phoneNumber) {
+            setFieldValue('hasSmsNotification', false);
+          }
+        };
+
         return (
           <form
             className={styles.enrolmentForm}
@@ -129,7 +140,7 @@ const EnrolmentForm: React.FC<Props> = ({
                     nameToLabelPath['studyGroup.person.phoneNumber']
                   )}
                   component={TextInputField}
-                  onChange={handlePhonNumberChange}
+                  onChange={handleStudyGroupPhoneNumberChange}
                   name="studyGroup.person.phoneNumber"
                 />
               </FormGroup>
@@ -244,6 +255,7 @@ const EnrolmentForm: React.FC<Props> = ({
                       labelText={t(nameToLabelPath['person.phoneNumber'])}
                       component={TextInputField}
                       name="person.phoneNumber"
+                      onChange={handlePersonPhoneNumberChange}
                     />
                   </FormGroup>
                 </>

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -52,7 +52,15 @@ const EnrolmentForm: React.FC<Props> = ({
       onSubmit={onSubmit}
       validationSchema={ValidationSchema}
     >
-      {({ errors, handleSubmit, touched, submitCount, values }) => {
+      {({
+        errors,
+        handleSubmit,
+        touched,
+        submitCount,
+        values,
+        setFieldValue,
+        handleChange,
+      }) => {
         const {
           isSameResponsiblePerson,
           isMandatoryAdditionalInformationRequired,
@@ -66,6 +74,14 @@ const EnrolmentForm: React.FC<Props> = ({
           .filter((i) => i);
         const hasPhoneNumber = () => {
           return !!studyGroupPhoneNumber;
+        };
+        const handlePhonNumberChange = (
+          e: React.ChangeEvent<HTMLInputElement>
+        ) => {
+          handleChange(e);
+          if (!e.target.value) {
+            setFieldValue('hasSmsNotification', false);
+          }
         };
         return (
           <form
@@ -113,6 +129,7 @@ const EnrolmentForm: React.FC<Props> = ({
                     nameToLabelPath['studyGroup.person.phoneNumber']
                   )}
                   component={TextInputField}
+                  onChange={handlePhonNumberChange}
                   name="studyGroup.person.phoneNumber"
                 />
               </FormGroup>

--- a/src/domain/enrolment/utils.ts
+++ b/src/domain/enrolment/utils.ts
@@ -6,7 +6,9 @@ import {
 import { EnrolmentFormFields } from './enrolmentForm/constants';
 
 const getNotificationType = (values: EnrolmentFormFields): NotificationType => {
-  return values.hasEmailNotification && values.hasSmsNotification
+  return values.hasEmailNotification &&
+    values.studyGroup.person.phoneNumber &&
+    values.hasSmsNotification
     ? NotificationType.EmailSms
     : NotificationType.Email;
 };


### PR DESCRIPTION
PT-880. If no phone number field is filled, sms-notifications checkbox should be disabled and unchecked. If any of the phone number fields is filled, it should be enabled and free to use.

![image](https://user-images.githubusercontent.com/389204/114013400-29348900-9870-11eb-8ca3-200295f05d0b.png)


![image](https://user-images.githubusercontent.com/389204/114013375-220d7b00-9870-11eb-8269-2df6d70f4ef8.png)
