### PR TITLE
Show all events from provider link added to event basic information.

### DIFF
--- a/public/static/locales/en/event.json
+++ b/public/static/locales/en/event.json
@@ -16,6 +16,9 @@
       "tomorrow": "Tomorrow at {{time}}"
     }
   },
+  "organization": {
+    "showAllOrganizationEvents": "Show all events of this provider"
+  },
   "occurrenceList": {
     "loadMoreOccurrences": "Show more occurrences",
     "enrolOccurrenceButton": "Enrol",

--- a/public/static/locales/fi/event.json
+++ b/public/static/locales/fi/event.json
@@ -16,6 +16,9 @@
       "tomorrow": "Huomenna klo {{time}}"
     }
   },
+  "organization": {
+    "showAllOrganizationEvents": "Näytä järjestäjän tapahtumat"
+  },
   "occurrenceList": {
     "loadMoreOccurrences": "Näytä lisää aikoja",
     "enrolOccurrenceButton": "Ilmoittaudu",

--- a/public/static/locales/sv/event.json
+++ b/public/static/locales/sv/event.json
@@ -16,6 +16,9 @@
       "tomorrow": "Imorgon kl {{time}}"
     }
   },
+  "organization": {
+    "showAllOrganizationEvents": "Visa arrangörshändelser"
+  },
   "occurrenceList": {
     "loadMoreOccurrences": "Visa fler händelser",
     "enrolOccurrenceButton": "Skriva in",

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -636,4 +636,56 @@ describe('refetch of event works correctly', () => {
       ).toBeInTheDocument();
     });
   });
+
+  it('renders a link which leads to all events of the organisation', async () => {
+    renderComponent();
+    await waitForRequestsToComplete();
+    expect(
+      screen.queryByText('Näytä järjestäjän tapahtumat')
+    ).toBeInTheDocument();
+  });
+
+  it('does not render organisation section when organisation is not given', async () => {
+    const eventWithoutOrganisation = {
+      ...eventData,
+      data: {
+        ...eventData.data,
+        event: {
+          ...eventData.data.event,
+          pEvent: {
+            ...eventData.data.event.pEvent,
+            organisation: {
+              ...eventData.data.event.pEvent.organisation,
+              name: '',
+            },
+          },
+        },
+      },
+    };
+    const mocks = apolloMocks.map((m, index) => {
+      const mock = { ...m };
+      if (index === 0) {
+        mock.result = eventWithoutOrganisation as any;
+      }
+      return mock;
+    });
+
+    render(<EventPage />, {
+      mocks: mocks,
+      query: { eventId: eventData.data.event.id },
+      path: `/fi${ROUTES.EVENT_DETAILS.replace(':id', data.id)}`,
+    });
+    await waitForRequestsToComplete();
+    expect(
+      screen.queryByText('Näytä järjestäjän tapahtumat')
+    ).not.toBeInTheDocument();
+
+    [
+      data.contactPersonName,
+      data.contactPersonEmail,
+      data.contactPersonPhoneNumber,
+    ].forEach((text) =>
+      expect(screen.queryByText(text)).not.toBeInTheDocument()
+    );
+  });
 });

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -640,9 +640,12 @@ describe('refetch of event works correctly', () => {
   it('renders a link which leads to all events of the organisation', async () => {
     renderComponent();
     await waitForRequestsToComplete();
-    expect(
-      screen.queryByText('Näytä järjestäjän tapahtumat')
-    ).toBeInTheDocument();
+    await screen.findByRole('link', { name: /näytä järjestäjän tapahtumat/i });
+    [
+      data.contactPersonName,
+      data.contactPersonEmail,
+      data.contactPersonPhoneNumber,
+    ].forEach((text) => expect(screen.queryByText(text)).toBeInTheDocument());
   });
 
   it('does not render organisation section when organisation is not given', async () => {
@@ -677,7 +680,7 @@ describe('refetch of event works correctly', () => {
     });
     await waitForRequestsToComplete();
     expect(
-      screen.queryByText('Näytä järjestäjän tapahtumat')
+      screen.queryByRole('link', { name: /näytä järjestäjän tapahtumat/i })
     ).not.toBeInTheDocument();
 
     [

--- a/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
+++ b/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { EventFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
-import { useTranslation } from '../../../i18n';
+import { Link, useTranslation } from '../../../i18n';
 import IconTicket from '../../../icons/IconTicket';
 import addUrlSlashes from '../../../utils/addUrlSlashes';
 import EventKeywords from '../eventKeywords/EventKeywords';
@@ -25,6 +25,7 @@ const EventBasicInfo: React.FC<EventBasicInfoProps> = ({ event }) => {
     shortDescription,
     isEventFree,
     organization,
+    organizationId,
     contactEmail,
     contactPerson,
     contactPhoneNumber,
@@ -58,20 +59,53 @@ const EventBasicInfo: React.FC<EventBasicInfoProps> = ({ event }) => {
         )}
         <div>
           <IconFaceSmile />
-          <div>
-            <p className={styles.organization}>{organization}</p>
-            {contactPerson && (
-              <div className={styles.contactInfo}>
-                <p>{t('event:contactPerson')}</p>
-                <p>{contactPerson}</p>
-                {contactEmail && <p>{contactEmail}</p>}
-                {contactPhoneNumber && <p>{contactPhoneNumber}</p>}
-              </div>
-            )}
-          </div>
+          {organization && organizationId && (
+            <OrganizationInfo
+              organization={organization}
+              organizationId={organizationId}
+              contactEmail={contactEmail}
+              contactPerson={contactPerson}
+              contactPhoneNumber={contactPhoneNumber}
+            />
+          )}
         </div>
       </div>
     </section>
+  );
+};
+
+const OrganizationInfo: React.FC<{
+  organizationId: string;
+  organization: string;
+  contactEmail: string | undefined;
+  contactPerson: string | undefined;
+  contactPhoneNumber: string | undefined;
+}> = ({
+  organization,
+  organizationId,
+  contactEmail,
+  contactPerson,
+  contactPhoneNumber,
+}) => {
+  const { t } = useTranslation();
+  const organizationSearchUrl = `/?organization=${organizationId}`;
+  return (
+    <div>
+      <p className={styles.organization}>{organization}</p>
+      <p className={styles.organizationLink}>
+        <Link href={organizationSearchUrl} passHref>
+          {t('event:organization.showAllOrganizationEvents')}
+        </Link>
+      </p>
+      {contactPerson && (
+        <div className={styles.contactInfo}>
+          <p>{t('event:contactPerson')}</p>
+          <p>{contactPerson}</p>
+          {contactEmail && <p>{contactEmail}</p>}
+          {contactPhoneNumber && <p>{contactPhoneNumber}</p>}
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
+++ b/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
@@ -57,9 +57,9 @@ const EventBasicInfo: React.FC<EventBasicInfoProps> = ({ event }) => {
             </a>
           </div>
         )}
-        <div>
-          <IconFaceSmile />
-          {organization && organizationId && (
+        {organization && organizationId && (
+          <div>
+            <IconFaceSmile />
             <OrganizationInfo
               organization={organization}
               organizationId={organizationId}
@@ -67,8 +67,8 @@ const EventBasicInfo: React.FC<EventBasicInfoProps> = ({ event }) => {
               contactPerson={contactPerson}
               contactPhoneNumber={contactPhoneNumber}
             />
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </section>
   );
@@ -77,9 +77,9 @@ const EventBasicInfo: React.FC<EventBasicInfoProps> = ({ event }) => {
 const OrganizationInfo: React.FC<{
   organizationId: string;
   organization: string;
-  contactEmail: string | undefined;
-  contactPerson: string | undefined;
-  contactPhoneNumber: string | undefined;
+  contactEmail?: string;
+  contactPerson?: string;
+  contactPhoneNumber?: string;
 }> = ({
   organization,
   organizationId,

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -77,6 +77,7 @@ export const getEventFields = (
         locationId: event.location?.id,
         photographerName: event.images?.[0]?.photographerName,
         organization: event.pEvent?.organisation?.name,
+        organizationId: event.pEvent?.organisation?.id,
         contactPhoneNumber: event.pEvent?.contactPhoneNumber,
         contactEmail: event.pEvent?.contactEmail,
         contactPerson: event.pEvent?.contactPerson?.name,

--- a/src/domain/events/__tests__/EventsPage.test.tsx
+++ b/src/domain/events/__tests__/EventsPage.test.tsx
@@ -68,6 +68,7 @@ const mocks: MockedResponse[] = [
         pageSize: 10,
         sort: 'start_time',
         end: null,
+        organisationId: '',
       },
     },
     result: {

--- a/src/domain/events/query.ts
+++ b/src/domain/events/query.ts
@@ -70,6 +70,7 @@ export const QUERY_EVENTS = gql`
     $superEventType: [String]
     $text: String
     $translation: String
+    $organisationId: String
   ) {
     events(
       division: $division
@@ -90,6 +91,7 @@ export const QUERY_EVENTS = gql`
       superEventType: $superEventType
       text: $text
       translation: $translation
+      organisationId: $organisationId
     ) {
       meta {
         ...metaFields

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -46,6 +46,7 @@ export const getEventFilterVariables = (
   start: getDateString(query.date) || 'now',
   end: getDateString(query.endDate),
   location: getTextFromDict(query, 'places', undefined),
+  organisationId: getTextFromDict(query, 'organization', undefined),
   ...options,
 });
 

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -1945,6 +1945,7 @@ export type EventsQueryVariables = Exact<{
   superEventType?: Maybe<Array<Maybe<Scalars['String']>>>;
   text?: Maybe<Scalars['String']>;
   translation?: Maybe<Scalars['String']>;
+  organisationId?: Maybe<Scalars['String']>;
 }>;
 
 export type EventsQuery = { __typename?: 'Query' } & {
@@ -2730,6 +2731,7 @@ export const EventsDocument = gql`
     $superEventType: [String]
     $text: String
     $translation: String
+    $organisationId: String
   ) {
     events(
       division: $division
@@ -2750,6 +2752,7 @@ export const EventsDocument = gql`
       superEventType: $superEventType
       text: $text
       translation: $translation
+      organisationId: $organisationId
     ) {
       meta {
         ...metaFields
@@ -2822,6 +2825,7 @@ export function withEvents<
  *      superEventType: // value for 'superEventType'
  *      text: // value for 'text'
  *      translation: // value for 'translation'
+ *      organisationId: // value for 'organisationId'
  *   },
  * });
  */


### PR DESCRIPTION
PT-298 Events can be searched with organisationId. Added organisationId in events query arguments.

Show all events from provider link added to event basic information. Refactored organization information to a new OrganizationInfo -component. Added there a router link that would open a search page with organization parameter. Search by organization is still missing.

The query can now be made with organization -parameter, which should be an organizationId. E.g http://localhost:3000/fi?organization=T3JnYW5pc2F0aW9uTm9kZToy

![image](https://user-images.githubusercontent.com/389204/114171186-9ada0900-993c-11eb-91e0-bae6158a4068.png)
