### PR TITLE
Fixed too long urls on event details page.

### DIFF
--- a/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
+++ b/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
@@ -57,7 +57,12 @@ const EventBasicInfo: React.FC<EventBasicInfoProps> = ({ event }) => {
         {infoUrl && (
           <div>
             <IconInfoCircle />
-            <a href={addUrlSlashes(infoUrl)} target="_blank" rel="noreferrer">
+            <a
+              className={styles.infoLink}
+              href={addUrlSlashes(infoUrl)}
+              target="_blank"
+              rel="noreferrer"
+            >
               {infoUrl}
             </a>
           </div>

--- a/src/domain/event/eventBasicInfo/eventBasicInfo.module.scss
+++ b/src/domain/event/eventBasicInfo/eventBasicInfo.module.scss
@@ -84,4 +84,9 @@
     font-weight: 700;
     margin-bottom: var(--spacing-3-xs);
   }
+
+  .infoLink {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }


### PR DESCRIPTION
PT-1109.

Too long url is now ellipsed and hidden.
![image](https://user-images.githubusercontent.com/389204/125932480-5df546c4-a11e-49c4-ac19-34a2eae65556.png)
