### PR TITLE
refactor(events-list): New sorters and filters for events.

### DIFF
--- a/public/locales/en/events.json
+++ b/public/locales/en/events.json
@@ -11,7 +11,7 @@
   },
   "sortOptions": {
     "lastModifiedTimeDesc": "Last modified",
-    "occurrenceStartTimeDesc": "Occurrence date"
+    "startTime": "Topical"
   },
   "search": {
     "buttonClear": "Clear search criteria",

--- a/public/locales/en/events.json
+++ b/public/locales/en/events.json
@@ -10,14 +10,8 @@
     "title": "Events"
   },
   "sortOptions": {
-    "duration": "Duration, ascending",
-    "durationDesc": "Duration, descending",
-    "endTime": "End time, ascending",
-    "endTimeDesc": "End time, descending",
-    "lastModifiedTime": "Last modified, ascending",
-    "lastModifiedTimeDesc": "Last modified, descending",
-    "startTime": "Start time, ascending",
-    "startTimeDesc": "Start time, descending"
+    "lastModifiedTimeDesc": "Last modified",
+    "occurrenceStartTimeDesc": "Occurrence date"
   },
   "search": {
     "buttonClear": "Clear search criteria",

--- a/public/locales/fi/events.json
+++ b/public/locales/fi/events.json
@@ -11,7 +11,7 @@
   },
   "sortOptions": {
     "lastModifiedTimeDesc": "Viimeksi muokattu",
-    "occurrenceStartTimeDesc": "Ajankohta"
+    "startTime": "Ajankohtaista"
   },
   "search": {
     "buttonClear": "Tyhjennä hakuehdot",

--- a/public/locales/fi/events.json
+++ b/public/locales/fi/events.json
@@ -10,14 +10,8 @@
     "title": "Tapahtumat"
   },
   "sortOptions": {
-    "duration": "Kesto, nouseva",
-    "durationDesc": "Kesto, laskeva",
-    "endTime": "Loppuaika, nouseva",
-    "endTimeDesc": "Loppuaika, laskeva",
-    "lastModifiedTime": "Viimeki muokattu, nouseva",
-    "lastModifiedTimeDesc": "Viimeksi muokattu, laskeva",
-    "startTime": "Aika, nouseva",
-    "startTimeDesc": "Aika, laskeva"
+    "lastModifiedTimeDesc": "Viimeksi muokattu",
+    "occurrenceStartTimeDesc": "Ajankohta"
   },
   "search": {
     "buttonClear": "Tyhjennä hakuehdot",

--- a/public/locales/sv/events.json
+++ b/public/locales/sv/events.json
@@ -10,14 +10,8 @@
     "title": "Evenemang"
   },
   "sortOptions": {
-    "duration": "Varaktighet, stigande",
-    "durationDesc": "Varaktighet, fallande",
-    "endTime": "Sluttid, stigande",
-    "endTimeDesc": "Sluttid, fallande",
-    "lastModifiedTime": "Senast modifierad, stigande",
     "lastModifiedTimeDesc": "Senast modifierad, fallande",
-    "startTime": "Starttid, stigande",
-    "startTimeDesc": "Starttid, fallande"
+    "occurrenceStartTimeDesc": "Förekomstdatum"
   },
   "search": {
     "buttonClear": "Rensa sökkriterier",

--- a/public/locales/sv/events.json
+++ b/public/locales/sv/events.json
@@ -11,7 +11,7 @@
   },
   "sortOptions": {
     "lastModifiedTimeDesc": "Senast modifierad, fallande",
-    "occurrenceStartTimeDesc": "Förekomstdatum"
+    "startTime": "Aktuell"
   },
   "search": {
     "buttonClear": "Rensa sökkriterier",

--- a/src/domain/app/header/__tests__/Header.test.tsx
+++ b/src/domain/app/header/__tests__/Header.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 
+import { render, screen } from '../../../../utils/testUtils';
 import { store } from '../../store';
 import Header from '../Header';
 

--- a/src/domain/app/layout/__tests__/PageLayout.test.tsx
+++ b/src/domain/app/layout/__tests__/PageLayout.test.tsx
@@ -1,7 +1,7 @@
-import { render } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 
+import { render } from '../../../../utils/testUtils';
 import { store } from '../../store';
 import PageLayout from '../PageLayout';
 

--- a/src/domain/events/EventsPage.tsx
+++ b/src/domain/events/EventsPage.tsx
@@ -34,7 +34,7 @@ const EventsPage = (): ReactElement => {
   );
   const [sort, setSort] = React.useState<EVENT_SORT_OPTIONS>(
     (getTextFromDict(router.query, 'sort') ||
-      EVENT_SORT_OPTIONS.START_TIME) as EVENT_SORT_OPTIONS
+      EVENT_SORT_OPTIONS.OCCURRENCE_START_TIME_DESC) as EVENT_SORT_OPTIONS
   );
 
   const {

--- a/src/domain/events/EventsPage.tsx
+++ b/src/domain/events/EventsPage.tsx
@@ -34,7 +34,7 @@ const EventsPage = (): ReactElement => {
   );
   const [sort, setSort] = React.useState<EVENT_SORT_OPTIONS>(
     (getTextFromDict(router.query, 'sort') ||
-      EVENT_SORT_OPTIONS.OCCURRENCE_START_TIME_DESC) as EVENT_SORT_OPTIONS
+      EVENT_SORT_OPTIONS.START_TIME) as EVENT_SORT_OPTIONS
   );
 
   const {

--- a/src/domain/events/__tests__/EventsPage.test.tsx
+++ b/src/domain/events/__tests__/EventsPage.test.tsx
@@ -106,9 +106,9 @@ test('renders search form and events list with correct information', async () =>
     screen.queryByRole('button', { name: 'Tyhjennä hakuehdot' })
   ).toBeInTheDocument();
 
-  expect(
-    screen.getByText(/Järjestys/i, { selector: 'button' })
-  ).toHaveTextContent('Ajankohta');
+  expect(screen.getByRole('button', { name: /järjestys/i })).toHaveTextContent(
+    'Ajankohtaista'
+  );
 
   expect(
     screen.queryByRole('heading', { name: 'Tapahtumat 3 kpl' })

--- a/src/domain/events/__tests__/EventsPage.test.tsx
+++ b/src/domain/events/__tests__/EventsPage.test.tsx
@@ -107,8 +107,8 @@ test('renders search form and events list with correct information', async () =>
   ).toBeInTheDocument();
 
   expect(
-    screen.getByLabelText(/Järjestys/i, { selector: 'button' })
-  ).toHaveTextContent('Aika, nouseva');
+    screen.getByText(/Järjestys/i, { selector: 'button' })
+  ).toHaveTextContent('Ajankohta');
 
   expect(
     screen.queryByRole('heading', { name: 'Tapahtumat 3 kpl' })

--- a/src/domain/events/constants.ts
+++ b/src/domain/events/constants.ts
@@ -1,12 +1,8 @@
 export const EVENT_LIST_PAGE_SIZE = 10;
 
 export enum EVENT_SORT_OPTIONS {
-  END_TIME = 'end_time',
-  END_TIME_DESC = '-end_time',
-  LAST_MODIFIED_TIME = 'last_modified_time',
   LAST_MODIFIED_TIME_DESC = '-last_modified_time',
-  START_TIME = 'start_time',
-  START_TIME_DESC = '-start_time',
+  OCCURRENCE_START_TIME_DESC = '-occurrence_start_time',
 }
 
 export const EVENT_TOP_CATEGORIES = ['yso:p26626'];

--- a/src/domain/events/constants.ts
+++ b/src/domain/events/constants.ts
@@ -1,8 +1,8 @@
 export const EVENT_LIST_PAGE_SIZE = 10;
 
 export enum EVENT_SORT_OPTIONS {
+  START_TIME = 'start_time',
   LAST_MODIFIED_TIME_DESC = '-last_modified_time',
-  OCCURRENCE_START_TIME_DESC = '-occurrence_start_time',
 }
 
 export const EVENT_TOP_CATEGORIES = ['yso:p26626'];


### PR DESCRIPTION
Started using only 2 different events filters and sorters. Both are descending by start times, but another uses events from LinkedEvents and another uses occurrences from API.

PT-1150 PT-1154.