### PR TITLE
fix: dont show upcoming occurrences in event card when there is none

### DIFF
--- a/public/locales/en/event.json
+++ b/public/locales/en/event.json
@@ -11,6 +11,7 @@
   "eventCard": {
     "ariaLabelOpenEvent": "Go to event: {{eventName}}",
     "free": "Free",
+    "noUpcomingOccurrences": "No upcoming occurrences",
     "startTime": {
       "other": "{{date}} at {{time}}",
       "today": "Today at {{time}}",

--- a/public/locales/fi/event.json
+++ b/public/locales/fi/event.json
@@ -11,6 +11,7 @@
   "eventCard": {
     "ariaLabelOpenEvent": "Siirry tapahtumaan: {{eventName}}",
     "free": "Maksuton",
+    "noUpcomingOccurrences": "Ei tulevia tapahtuma-aikoja",
     "startTime": {
       "other": "{{date}} klo {{time}}",
       "today": "Tänään klo {{time}}",

--- a/public/locales/sv/event.json
+++ b/public/locales/sv/event.json
@@ -11,6 +11,7 @@
   "eventCard": {
     "ariaLabelOpenEvent": "Gå till evenemang: {{eventName}}",
     "free": "Fri",
+    "noUpcomingOccurrences": "Inga kommande händelser",
     "startTime": {
       "other": "{{date}} kl {{time}}",
       "today": "Idag kl {{time}}",

--- a/src/__tests__/cms-page/[...slug].test.tsx
+++ b/src/__tests__/cms-page/[...slug].test.tsx
@@ -1,6 +1,6 @@
 import { TextEncoder, TextDecoder } from 'util';
 
-import { screen, fireEvent } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { getPage } from 'next-page-tester';
 
 import {

--- a/src/domain/event/eventCard/EventCard.tsx
+++ b/src/domain/event/eventCard/EventCard.tsx
@@ -95,7 +95,8 @@ const EventTime: React.FC<{
   const nextOccurrenceTime = event.pEvent.nextOccurrenceDatetime;
   const lastOccurrenceTime =
     event.pEvent.lastOccurrenceDatetime ?? nextOccurrenceTime;
-  const hasMultipleOccurrences = nextOccurrenceTime !== lastOccurrenceTime;
+  const hasMultipleFutureOccurrences =
+    nextOccurrenceTime && nextOccurrenceTime !== lastOccurrenceTime;
 
   const { data: occurrencesData, loading: loadingOccurrencesData } =
     useOccurrencesQuery({
@@ -128,7 +129,7 @@ const EventTime: React.FC<{
         <OccurrenceTime time={time} />
         {showOccurrences && occurrenceTimes}
       </ul>
-      {hasMultipleOccurrences && (
+      {hasMultipleFutureOccurrences && (
         <Button
           variant="secondary"
           className={styles.multipleOccurrenceButton}

--- a/src/domain/event/eventCard/EventCard.tsx
+++ b/src/domain/event/eventCard/EventCard.tsx
@@ -114,7 +114,7 @@ const EventTime: React.FC<{
         </li>
       ))
     : occurrencesData?.occurrences?.edges
-        ?.slice(1) // First one is alraedy rendered
+        ?.slice(1) // First one is already rendered
         .map((edge) => (
           <OccurrenceTime
             key={`occurrence-${edge?.node?.id}`}
@@ -148,13 +148,12 @@ const OccurrenceTime: React.FC<{
 }> = ({ time }) => {
   const { t } = useTranslation();
   const locale = useLocale();
-  if (!time) {
-    return null;
-  }
   return (
     <li className={styles.textWithIcon}>
       <IconClock />
-      {getEventStartTimeStr(time, locale, t)}
+      {time
+        ? getEventStartTimeStr(time, locale, t)
+        : t('event:eventCard.noUpcomingOccurrences')}
     </li>
   );
 };

--- a/src/domain/events/EventsPage.tsx
+++ b/src/domain/events/EventsPage.tsx
@@ -19,7 +19,6 @@ import {
   getEventFilterVariables,
   getInitialValues,
   getTextFromDict,
-  // getEventsThatHaveUpcomingOccurrence,
   getSearchQueryObject,
 } from './utils';
 
@@ -60,7 +59,6 @@ const EventsPage = (): ReactElement => {
   }, [router.query, organisationName]);
 
   const eventsWithUpcomingOccurrences = eventsData?.events?.data;
-  // getEventsThatHaveUpcomingOccurrence(eventsData);
 
   const search = (values: EventSearchFormValues) => {
     values = { ...values, organisation: values.organisationId };

--- a/src/domain/events/EventsPage.tsx
+++ b/src/domain/events/EventsPage.tsx
@@ -19,7 +19,7 @@ import {
   getEventFilterVariables,
   getInitialValues,
   getTextFromDict,
-  getEventsThatHaveUpcomingOccurrence,
+  // getEventsThatHaveUpcomingOccurrence,
   getSearchQueryObject,
 } from './utils';
 
@@ -59,8 +59,8 @@ const EventsPage = (): ReactElement => {
     };
   }, [router.query, organisationName]);
 
-  const eventsWithUpcomingOccurrences =
-    getEventsThatHaveUpcomingOccurrence(eventsData);
+  const eventsWithUpcomingOccurrences = eventsData?.events?.data;
+  // getEventsThatHaveUpcomingOccurrence(eventsData);
 
   const search = (values: EventSearchFormValues) => {
     values = { ...values, organisation: values.organisationId };

--- a/src/domain/events/__tests__/EventsPage.test.tsx
+++ b/src/domain/events/__tests__/EventsPage.test.tsx
@@ -9,6 +9,7 @@ import {
   fakePEvent,
   fakeLocalizedObject,
   fakeKeyword,
+  fakeOccurrences,
 } from '../../../utils/mockDataUtils';
 import { render, screen, act, configure } from '../../../utils/testUtils';
 import EventsPage from '../EventsPage';
@@ -52,6 +53,16 @@ const eventMocks: Partial<Event>[] = [
     }),
     keywords: fakeKeywords,
   },
+  {
+    name: fakeLocalizedObject('Testitapahtuma 4'),
+    shortDescription: fakeLocalizedObject('Tapahtuman lyhytkuvaus 4'),
+    pEvent: fakePEvent({
+      nextOccurrenceDatetime: null,
+      lastOccurrenceDatetime: null,
+      occurrences: fakeOccurrences(0),
+    }),
+    keywords: fakeKeywords,
+  },
 ];
 
 const mocks: MockedResponse[] = [
@@ -74,7 +85,7 @@ const mocks: MockedResponse[] = [
     },
     result: {
       data: {
-        events: fakeEvents(3, eventMocks),
+        events: fakeEvents(4, eventMocks),
       },
     },
   },
@@ -113,8 +124,11 @@ test('renders search form and events list with correct information', async () =>
   );
 
   expect(
-    screen.queryByRole('heading', { name: 'Tapahtumat 3 kpl' })
+    screen.queryByRole('heading', { name: 'Tapahtumat 4 kpl' })
   ).toBeInTheDocument();
+
+  // one event has no upcoming occurrences
+  expect(screen.queryByText('Ei tulevia tapahtuma-aikoja')).toBeInTheDocument();
 
   eventMocks.forEach((event) => {
     if (!event?.name?.fi) {
@@ -131,6 +145,6 @@ test('renders search form and events list with correct information', async () =>
     if (!keyword?.name?.fi) {
       throw new Error('keyword name is missing');
     }
-    expect(screen.getAllByText(keyword.name.fi)).toHaveLength(3);
+    expect(screen.getAllByText(keyword.name.fi)).toHaveLength(4);
   });
 });

--- a/src/domain/neighborhood/divisionSelector/__tests__/DivisionSelector.test.tsx
+++ b/src/domain/neighborhood/divisionSelector/__tests__/DivisionSelector.test.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { NeighborhoodListDocument } from '../../../../generated/graphql';
 import { fakeNeighborhoods } from '../../../../utils/mockDataUtils';
 import {
-  act,
   render,
   screen,
   userEvent,

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -251,7 +251,7 @@ export const fakeImage = (overrides?: Partial<Image>): Image => ({
 export const fakePEvent = (
   overrides?: Partial<PalvelutarjotinEventNode>
 ): PalvelutarjotinEventNode => ({
-  id: 'UGFsdmVsdXRhcmpvdGluRXZlbnROb2RlOjcw',
+  id: faker.datatype.uuid(),
   contactPerson: fakePerson(),
   contactEmail: 'test@email.com',
   contactPhoneNumber: '1233211234',


### PR DESCRIPTION
## Description :sparkles:

- Dont show upcoming occurrences in event card when there is none
- Show "No upcoming occurrences" text when event has no more upcoming occurrences

## Issues :bug:

### Closes :no_good_woman:

**[PT-1208](https://helsinkisolutionoffice.atlassian.net/browse/PT-1208):**
**[PT-1164](https://helsinkisolutionoffice.atlassian.net/browse/PT-1164):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
