### PR TITLE
PT-1224 | Add notice about unreliable mail traffic

### DIFF
--- a/public/locales/en/event.json
+++ b/public/locales/en/event.json
@@ -1,8 +1,8 @@
 {
   "enrolmentConfirmation": {
     "sentBy": {
-      "email": "We will send you a confirmation email.",
-      "emailSms": "We will send you a confirmation email and text message.",
+      "email": "We will send you a confirmation email. Please also check your junk mail folder for messages. Please note that the sites are still in development. If you do not receive any registration mail at all, please contact the event organizer.",
+      "emailSms": "We will send you a confirmation email and text message. Please also check your junk mail folder for messages. Please note that the sites are still in development. If you do not receive any registration mail at all, please contact the event organizer.",
       "sms": "We will send you a confirmation via SMS."
     },
     "title": "Registration sent",

--- a/public/locales/fi/event.json
+++ b/public/locales/fi/event.json
@@ -1,8 +1,8 @@
 {
   "enrolmentConfirmation": {
     "sentBy": {
-      "email": "Lähetämme sinulle vahvistuksen sähköpostitse.",
-      "emailSms": "Lähetämme sinulle vahvistuksen sähköpostitse ja tekstiviestillä.",
+      "email": "Lähetämme sinulle vahvistuksen sähköpostitse. HUOM! Palvelu on vielä kehitysvaiheessa ja viestiliikenteessä on havaittu ongelmia. Tarkistathan viestit myös roskapostilaatikostasi. Mikäli et saa ollenkaan ilmoittautumiseen liittyvää postia, ole yhteydessä tapahtuman järjestäjään.",
+      "emailSms": "Lähetämme sinulle vahvistuksen sähköpostitse ja tekstiviestillä. HUOM! Palvelu on vielä kehitysvaiheessa ja viestiliikenteessä on havaittu ongelmia. Tarkistathan viestit myös roskapostilaatikostasi. Mikäli et saa ollenkaan ilmoittautumiseen liittyvää postia, ole yhteydessä tapahtuman järjestäjään.",
       "sms": "Lähetämme sinulle vahvistuksen tekstiviestillä."
     },
     "title": "Ilmoittautuminen lähetetty",

--- a/public/locales/sv/event.json
+++ b/public/locales/sv/event.json
@@ -1,8 +1,8 @@
 {
   "enrolmentConfirmation": {
     "sentBy": {
-      "email": "Vi skickar ett bekräftelsemeddelande.",
-      "emailSms": "Vi skickar ett bekräftelsemail och textmeddelande.",
+      "email": "Vi skickar ett bekräftelsemeddelande. Obs! Tjänsten är fortfarande under utveckling och vi har noterat störningar i kommunikationen. Vänligen kontrollera även din skräppost. Om du inte får svar på din bokning, vänligen kontakta programarrangören.",
+      "emailSms": "Vi skickar ett bekräftelsemail och textmeddelande. Obs! Tjänsten är fortfarande under utveckling och vi har noterat störningar i kommunikationen. Vänligen kontrollera även din skräppost. Om du inte får svar på din bokning, vänligen kontakta programarrangören.",
       "sms": "Vi skickar en bekräftelse via SMS."
     },
     "title": "Registrering skickad",

--- a/src/domain/event/EventPage.tsx
+++ b/src/domain/event/EventPage.tsx
@@ -113,6 +113,7 @@ const EventPage = (): ReactElement => {
                   }`
                 )}
                 type={autoAcceptance ? 'success' : 'alert'}
+                className={styles.eventPageNotification}
               >
                 {notificationType &&
                   translateValue(

--- a/src/domain/event/eventPage.module.scss
+++ b/src/domain/event/eventPage.module.scss
@@ -6,6 +6,10 @@
   --enrol-button-width: 250px;
 }
 
+.eventPageNotification {
+  margin: var(--spacing-layout-s) 0;
+}
+
 .sharePart {
   display: grid;
   grid-template-columns: 1fr auto;


### PR DESCRIPTION
## Waiting for translations

## Description :sparkles:

- Extends existing translations so that they contain information about unreliable mail traffic
- Adds margin to the notification

## Issues :bug:

### Closes :no_good_woman:

**[PT-1224](https://helsinkisolutionoffice.atlassian.net/browse/PT-1224):**

### Related :handshake:

[PT-1216](https://helsinkisolutionoffice.atlassian.net/browse/PT-1216)

## Screenshots :camera_flash:

<img width="1679" alt="Screenshot 2021-10-18 at 11 34 31" src="https://user-images.githubusercontent.com/9090689/137696812-89c0f525-4c16-4ba4-94f5-11f0c847e18a.png">
