### PR TITLE
PT-1252 | Initialize enrolment form from local storage if possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "jest": "^27.0.5",
     "jest-axe": "^5.0.1",
     "jest-date-mock": "^1.0.8",
+    "jest-localstorage-mock": "^2.4.18",
     "lint-staged": "^11.0.0",
     "msw": "^0.35.0",
     "next-page-tester": "^0.28.0",

--- a/public/locales/en/enrolment.json
+++ b/public/locales/en/enrolment.json
@@ -1,6 +1,7 @@
 {
   "buttonBack": "Back",
   "enrolmentForm": {
+    "buttonResetForm": "Reset form",
     "buttonSubmit": "Submit registration",
     "buttonSubmitEnquiry": "Submit Enquiry",
     "infoText1": "We do not use the information you provide for marketing purposes.",

--- a/public/locales/fi/enrolment.json
+++ b/public/locales/fi/enrolment.json
@@ -1,6 +1,7 @@
 {
   "buttonBack": "Takaisin",
   "enrolmentForm": {
+    "buttonResetForm": "Tyhjennä lomake",
     "buttonSubmit": "Lähetä ilmoittautuminen",
     "buttonSubmitEnquiry": "Lähetä varaustiedustelu",
     "infoText1": "Emme käytä antamiasi tietoja markkinointiin.",

--- a/public/locales/sv/enrolment.json
+++ b/public/locales/sv/enrolment.json
@@ -1,7 +1,7 @@
 {
   "buttonBack": "Tillbaka",
   "enrolmentForm": {
-    "buttonResetForm": "SV: Tyhjennä lomake",
+    "buttonResetForm": "Töm formuläret",
     "buttonSubmit": "Skicka in registrering",
     "buttonSubmitEnquiry": "Skicka anmälan",
     "infoText1": "Vi använder inte de uppgifter som du uppgett för marknadsföring.",

--- a/public/locales/sv/enrolment.json
+++ b/public/locales/sv/enrolment.json
@@ -1,6 +1,7 @@
 {
   "buttonBack": "Tillbaka",
   "enrolmentForm": {
+    "buttonResetForm": "SV: Tyhjennä lomake",
     "buttonSubmit": "Skicka in registrering",
     "buttonSubmitEnquiry": "Skicka anmälan",
     "infoText1": "Vi använder inte de uppgifter som du uppgett för marknadsföring.",

--- a/src/common/components/formikPersist/FormikPersist.tsx
+++ b/src/common/components/formikPersist/FormikPersist.tsx
@@ -1,10 +1,22 @@
 import { FormikProps, useFormikContext } from 'formik';
-import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 import * as React from 'react';
 
 import useIsMounted from '../../../hooks/useIsMounted';
 import keyify from '../../../utils/keyify';
+
+// lodash/debounce was problematic in tests so we use our own simple implementation
+const debounce = (cb: (...params: any[]) => void, wait: number) => {
+  let timeout: any;
+  return function executedFunction(...args: unknown[]) {
+    const later = () => {
+      timeout = null;
+      cb(...args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+};
 
 export interface PersistProps {
   name: string;

--- a/src/common/components/formikPersist/FormikPersist.tsx
+++ b/src/common/components/formikPersist/FormikPersist.tsx
@@ -1,0 +1,90 @@
+import { FormikProps, useFormikContext } from 'formik';
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
+import * as React from 'react';
+
+import useIsMounted from '../../../hooks/useIsMounted';
+import keyify from '../../../utils/keyify';
+
+export interface PersistProps {
+  name: string;
+  debounceTime?: number;
+  isSessionStorage?: boolean;
+  initialValues: Record<string, unknown>;
+}
+
+const FormikPersist = ({
+  debounceTime = 300,
+  isSessionStorage = false,
+  name,
+  initialValues,
+}: PersistProps): null => {
+  const isMounted = useIsMounted();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const formik = useFormikContext<any>();
+
+  const debouncedSaveForm = React.useMemo(
+    () =>
+      debounce((data: FormikProps<Record<string, unknown>>) => {
+        /* istanbul ignore next */
+        if (!isMounted.current) return;
+
+        if (isSessionStorage) {
+          window.sessionStorage.setItem(name, JSON.stringify(data));
+        } else {
+          window.localStorage.setItem(name, JSON.stringify(data));
+        }
+      }, debounceTime),
+    [debounceTime, isMounted, isSessionStorage, name]
+  );
+
+  const saveForm = React.useCallback(
+    (data: FormikProps<Record<string, unknown>>) => {
+      debouncedSaveForm(data);
+    },
+    [debouncedSaveForm]
+  );
+
+  React.useEffect(() => {
+    saveForm(formik);
+  }, [formik, saveForm]);
+
+  React.useEffect(() => {
+    let timeout: any;
+
+    const storedFormikState = isSessionStorage
+      ? window.sessionStorage.getItem(name)
+      : window.localStorage.getItem(name);
+
+    const storedFormikStateObject =
+      storedFormikState && JSON.parse(storedFormikState);
+
+    if (
+      storedFormikStateObject &&
+      objectStructureMatches(initialValues, storedFormikStateObject.values)
+    ) {
+      formik.setFormikState(JSON.parse(storedFormikState));
+
+      // Validate form after setting state
+      timeout = setTimeout(() => {
+        formik.validateForm();
+      });
+    }
+    return () => clearTimeout(timeout);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return null;
+};
+
+const objectStructureMatches = (
+  a: Record<string, any>,
+  b: Record<string, any>
+): boolean => {
+  const arrayA = keyify(a);
+  const arrayB = keyify(b);
+
+  return isEqual(arrayA.sort(), arrayB.sort());
+};
+
+export default FormikPersist;

--- a/src/common/components/formikPersist/__tests__/FormikPersist.test.tsx
+++ b/src/common/components/formikPersist/__tests__/FormikPersist.test.tsx
@@ -1,0 +1,125 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable max-len */
+import { act, render, waitFor } from '@testing-library/react';
+import { Formik, FormikProps } from 'formik';
+import * as React from 'react';
+
+import Persist from '../FormikPersist';
+
+beforeEach(() => {
+  // values stored in tests will also be available in other tests unless you run
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+const formName = 'form-name';
+
+const defaultState = {
+  values: { name: 'Name from local storage' },
+  errors: {},
+  touched: {},
+  isSubmitting: false,
+  isValidating: false,
+  submitCount: 0,
+  initialValues: { name: 'Test name' },
+  initialErrors: {},
+  initialTouched: {},
+  isValid: true,
+  dirty: true,
+  validateOnBlur: true,
+  validateOnChange: true,
+  validateOnMount: false,
+};
+
+test('attempts to rehydrate on mount', async () => {
+  let injected: FormikProps<{ name: string }>;
+
+  (localStorage.getItem as jest.Mock).mockReturnValueOnce(
+    JSON.stringify({
+      ...defaultState,
+      values: { name: 'Name from local storage' },
+    })
+  );
+
+  render(
+    <Formik initialValues={{ name: 'Test name' }} onSubmit={jest.fn()}>
+      {(props: FormikProps<{ name: string }>) => {
+        injected = props;
+
+        return (
+          <div>
+            <Persist
+              name={formName}
+              debounceTime={0}
+              initialValues={{ name: '' }}
+            />
+          </div>
+        );
+      }}
+    </Formik>
+  );
+
+  expect(localStorage.getItem).toHaveBeenCalled();
+
+  expect(injected!.values.name).toEqual('Name from local storage');
+
+  act(() => {
+    injected.setValues({ name: 'changed value' });
+  });
+
+  expect(injected!.values.name).toEqual('changed value');
+
+  await waitFor(() => {
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      formName,
+      JSON.stringify({ ...defaultState, values: { name: 'changed value' } })
+    );
+  });
+});
+
+test('attempts to rehydrate on mount if session storage is true on props', async () => {
+  let injected: FormikProps<{ name: string }>;
+
+  (sessionStorage.getItem as jest.Mock).mockReturnValueOnce(
+    JSON.stringify({
+      ...defaultState,
+      values: { name: 'Name from session storage' },
+    })
+  );
+
+  render(
+    <Formik initialValues={{ name: 'Test name' }} onSubmit={jest.fn()}>
+      {(props: FormikProps<{ name: string }>) => {
+        injected = props;
+
+        return (
+          <div>
+            <Persist
+              name={formName}
+              debounceTime={0}
+              isSessionStorage={true}
+              initialValues={{ name: 'Name from local storage' }}
+            />
+          </div>
+        );
+      }}
+    </Formik>
+  );
+
+  expect(sessionStorage.getItem).toHaveBeenCalled();
+
+  expect(injected!.values.name).toEqual('Name from session storage');
+
+  act(() => {
+    injected.setValues({ name: 'changed value' });
+  });
+
+  expect(injected!.values.name).toEqual('changed value');
+
+  await waitFor(() => {
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      formName,
+      JSON.stringify({ ...defaultState, values: { name: 'changed value' } })
+    );
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,9 @@
 export const IS_CLIENT = typeof window !== 'undefined';
 
+export enum FORM_NAMES {
+  ENROLMENT_FORM = 'enrolment-form',
+}
+
 export enum SUPPORTED_LANGUAGES {
   FI = 'fi',
   SV = 'sv',

--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -33,7 +33,8 @@ import CreateEnrolmentPage from '../CreateEnrolmentPage';
 import { defaultInitialValues } from '../enrolmentForm/constants';
 import * as utils from '../utils';
 
-// couldn't get FormikPersist lodash debounce function work without this.
+// couldn't get FormikPersist lodash debounce to work in tests
+// it was never being caled no matter how long you waited.
 jest.mock('lodash/debounce', () =>
   jest.fn((func, wait) => {
     let timeout: any;

--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -33,22 +33,6 @@ import CreateEnrolmentPage from '../CreateEnrolmentPage';
 import { defaultInitialValues } from '../enrolmentForm/constants';
 import * as utils from '../utils';
 
-// couldn't get FormikPersist lodash debounce to work in tests
-// it was never being caled no matter how long you waited.
-jest.mock('lodash/debounce', () =>
-  jest.fn((func, wait) => {
-    let timeout: any;
-    return function executedFunction(...args: any) {
-      const later = () => {
-        timeout = null;
-        func(...args);
-      };
-      clearTimeout(timeout);
-      timeout = setTimeout(later, wait);
-    };
-  })
-);
-
 const eventId = '123321';
 const occurrenceId1 = '123321';
 const occurrenceId2 = '321123';

--- a/src/domain/enrolment/__tests__/__snapshots__/CreateEnrolmentPage.test.tsx.snap
+++ b/src/domain/enrolment/__tests__/__snapshots__/CreateEnrolmentPage.test.tsx.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders form and user can fill it and submit and form is saved to local storage 1`] = `
+Object {
+  "dirty": true,
+  "errors": Object {},
+  "initialErrors": Object {},
+  "initialTouched": Object {},
+  "initialValues": Object {
+    "hasEmailNotification": true,
+    "hasSmsNotification": false,
+    "isMandatoryAdditionalInformationRequired": false,
+    "isSameResponsiblePerson": true,
+    "isSharingDataAccepted": false,
+    "language": "FI",
+    "maxGroupSize": 20,
+    "minGroupSize": 10,
+    "person": Object {
+      "emailAddress": "",
+      "name": "",
+      "phoneNumber": "",
+    },
+    "studyGroup": Object {
+      "amountOfAdult": "",
+      "extraNeeds": "",
+      "groupName": "",
+      "groupSize": "",
+      "name": "",
+      "person": Object {
+        "emailAddress": "",
+        "name": "",
+        "phoneNumber": "",
+      },
+      "studyLevels": Array [],
+    },
+  },
+  "isSubmitting": false,
+  "isValid": true,
+  "isValidating": false,
+  "submitCount": 2,
+  "touched": Object {
+    "hasEmailNotification": true,
+    "hasSmsNotification": true,
+    "isMandatoryAdditionalInformationRequired": true,
+    "isSameResponsiblePerson": true,
+    "isSharingDataAccepted": true,
+    "language": true,
+    "maxGroupSize": true,
+    "minGroupSize": true,
+    "person": Object {
+      "emailAddress": true,
+      "name": true,
+      "phoneNumber": true,
+    },
+    "studyGroup": Object {
+      "amountOfAdult": true,
+      "extraNeeds": true,
+      "groupName": true,
+      "groupSize": true,
+      "name": true,
+      "person": Object {
+        "emailAddress": true,
+        "name": true,
+        "phoneNumber": true,
+      },
+      "studyLevels": Array [
+        true,
+        true,
+      ],
+    },
+  },
+  "validateOnBlur": true,
+  "validateOnChange": true,
+  "validateOnMount": false,
+  "values": Object {
+    "hasEmailNotification": true,
+    "hasSmsNotification": true,
+    "isMandatoryAdditionalInformationRequired": false,
+    "isSameResponsiblePerson": true,
+    "isSharingDataAccepted": true,
+    "language": "FI",
+    "maxGroupSize": 20,
+    "minGroupSize": 10,
+    "person": Object {
+      "emailAddress": "",
+      "name": "",
+      "phoneNumber": "",
+    },
+    "studyGroup": Object {
+      "amountOfAdult": 2,
+      "extraNeeds": "Lisätietoja ilmoittautumiseen",
+      "groupName": "4a",
+      "groupSize": 10,
+      "name": "Testikoulu",
+      "person": Object {
+        "emailAddress": "testi@testi.fi",
+        "name": "Nimi Niminen",
+        "phoneNumber": "123321123123321123",
+      },
+      "studyLevels": Array [
+        "GRADE_4",
+        "GRADE_2",
+      ],
+    },
+  },
+}
+`;

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { Formik, Field, useFormikContext } from 'formik';
 import { Button, Notification } from 'hds-react';
 import isEmpty from 'lodash/isEmpty';
@@ -12,7 +13,8 @@ import TextAreaField from '../../../common/components/form/fields/TextAreaField'
 import TextInputField from '../../../common/components/form/fields/TextInputField';
 import FormErrorNotification from '../../../common/components/form/FormErrorNotification';
 import FormGroup from '../../../common/components/form/FormGroup';
-import { PRIVACY_POLICY_LINKS } from '../../../constants';
+import FormikPersist from '../../../common/components/formikPersist/FormikPersist';
+import { FORM_NAMES, PRIVACY_POLICY_LINKS } from '../../../constants';
 import { Language } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import keyify from '../../../utils/keyify';
@@ -54,7 +56,15 @@ const EnrolmentForm: React.FC<Props> = ({
       onSubmit={onSubmit}
       validationSchema={ValidationSchema}
     >
-      {({ errors, handleSubmit, touched, submitCount, values }) => {
+      {({
+        errors,
+        handleSubmit,
+        touched,
+        submitCount,
+        values,
+        dirty,
+        resetForm,
+      }) => {
         const {
           isSameResponsiblePerson,
           isMandatoryAdditionalInformationRequired,
@@ -70,6 +80,10 @@ const EnrolmentForm: React.FC<Props> = ({
             onSubmit={handleSubmit}
             noValidate
           >
+            <FormikPersist
+              name={FORM_NAMES.ENROLMENT_FORM}
+              initialValues={initialValues}
+            />
             <Container size="small">
               <h2>{t('enrolment:enrolmentForm.studyGroup.titleNotifier')}</h2>
               <FormErrorNotification
@@ -84,6 +98,16 @@ const EnrolmentForm: React.FC<Props> = ({
               >
                 {t('enrolment:enrolmentForm.studyGroup.notificationText')}
               </Notification>
+              <button
+                onClick={() => resetForm()}
+                type="button"
+                aria-hidden={!dirty}
+                className={classNames(styles.resetFormButton, {
+                  [styles.resetFormButtonVisible]: dirty,
+                })}
+              >
+                {t('enrolment:enrolmentForm.buttonResetForm')}
+              </button>
               <FormGroup>
                 <Field
                   label={t(nameToLabelPath['studyGroup.person.name'])}

--- a/src/domain/enrolment/enrolmentForm/enrolmentForm.module.scss
+++ b/src/domain/enrolment/enrolmentForm/enrolmentForm.module.scss
@@ -30,6 +30,17 @@
     margin-top: 18px;
   }
 
+  .resetFormButton {
+    margin-top: -var(--spacing-s);
+    margin-bottom: var(--spacing-m);
+    visibility: hidden;
+    text-decoration: underline;
+
+    &Visible {
+      visibility: visible;
+    }
+  }
+
   .divider {
     margin: var(--spacing-layout-s) 0 var(--spacing-layout-xs);
     width: 100%;
@@ -50,7 +61,7 @@
   }
 
   .enrolButton {
-    color: var(--color-bus) ;
+    color: var(--color-bus);
     background-color: rgb(0, 215, 167);
   }
 

--- a/src/hooks/useIsMounted.ts
+++ b/src/hooks/useIsMounted.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const useIsMounted = (): React.MutableRefObject<boolean> => {
+  const isMounted = React.useRef(false);
+
+  React.useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  return isMounted;
+};
+
+export default useIsMounted;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import dotenv from 'dotenv';
 import { toHaveNoViolations } from 'jest-axe';
 import './tests/initI18n';
+import 'jest-localstorage-mock';
 
 import { server } from './tests/msw/server';
 
@@ -17,6 +18,10 @@ afterEach(() => {
 });
 afterAll(() => {
   server.close();
+});
+
+beforeEach(() => {
+  localStorage.clear();
 });
 
 jest.mock('next/config', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7763,6 +7763,11 @@ jest-leak-detector@^27.0.6:
     jest-get-type "^27.0.6"
     pretty-format "^27.0.6"
 
+jest-localstorage-mock@^2.4.18:
+  version "2.4.18"
+  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.4.18.tgz#6cf5f84fdc5d8e279f2b45a9417bac1d4fc765d6"
+  integrity sha512-zQTrtPeyGXvqM9Vw8nYd39Z0YAD2SK2hptyxLLaR/Ci5X72pcPBaiTDTfTeNq8FOuH/aVUSp8jhJUeFHMhuNeg==
+
 jest-matcher-utils@27.0.2:
   version "27.0.2"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.0.2.tgz#f14c060605a95a466cdc759acc546c6f4cbfc4f0"


### PR DESCRIPTION
## Description :sparkles:

- Add FormikPersts component to handle persisting and filling form from local storage

## Issues :bug:

### Closes :no_good_woman:

**[PT-1252](https://helsinkisolutionoffice.atlassian.net/browse/PT-1252):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
