### PR TITLE
feat: unit place selector uses schoolsAndKindergartens query

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -63,5 +63,8 @@
     },
     "loading": "Loading ...",
     "noResults": "No results"
+  },
+  "unitPlaceSelector": {
+    "noPlaceFoundError": "Unit is selected, but there was a problem loading the name"
   }
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -63,5 +63,8 @@
     },
     "loading": "Ladataan ...",
     "noResults": "Ei tuloksia"
+  },
+  "unitPlaceSelector": {
+    "noPlaceFoundError": "Paikka on valittu, mutta nimen latauksessa esiintyi ongelma"
   }
 }

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -62,5 +62,8 @@
     },
     "loading": "Laddning ...",
     "noResults": "Inga resultat"
+  },
+  "unitPlaceSelector": {
+    "noPlaceFoundError": "Platsen har valts, men det gick inte att läsa in namnet"
   }
 }

--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -607,21 +607,12 @@ test('Allow sms notifications if any of the phone numbers are given', async () =
 });
 
 describe('UnitField', () => {
-  let enrolOccurrenceMock = jest.fn();
-
   const getUnitFieldInput = () =>
     screen.getByRole('textbox', {
       name: /päiväkoti \/ koulu \/ oppilaitos/i,
     });
 
   const setupUnitFieldTest = async (testMocks: MockedResponse[] = []) => {
-    enrolOccurrenceMock = jest.fn();
-    // eslint-disable-next-line import/namespace
-    jest
-      .spyOn(graphqlFns, 'useEnrolOccurrenceMutation')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockReturnValue([enrolOccurrenceMock] as any);
-
     const mocks = [
       ...testMocks,
       ...createPageMock(

--- a/src/domain/place/placeText/PlaceText.tsx
+++ b/src/domain/place/placeText/PlaceText.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { usePlaceQuery } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
@@ -6,15 +7,17 @@ import getLocalisedString from '../../../utils/getLocalisedString';
 
 interface Props {
   placeId: string;
+  errorText?: string;
 }
 
-const PlaceText: React.FC<Props> = ({ placeId }) => {
+const PlaceText: React.FC<Props> = ({ placeId, errorText = '' }) => {
   const locale = useLocale();
+  const { t } = useTranslation();
   const { data } = usePlaceQuery({
     variables: { id: placeId },
   });
-
-  return <>{getLocalisedString(data?.place?.name || {}, locale)}</>;
+  const text = getLocalisedString(data?.place?.name || {}, locale);
+  return <>{text || errorText}</>;
 };
 
 export default PlaceText;

--- a/src/domain/place/placeText/PlaceText.tsx
+++ b/src/domain/place/placeText/PlaceText.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import { usePlaceQuery } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
@@ -12,12 +11,12 @@ interface Props {
 
 const PlaceText: React.FC<Props> = ({ placeId, errorText = '' }) => {
   const locale = useLocale();
-  const { t } = useTranslation();
-  const { data } = usePlaceQuery({
+  const { data, loading } = usePlaceQuery({
     variables: { id: placeId },
   });
   const text = getLocalisedString(data?.place?.name || {}, locale);
-  return <>{text || errorText}</>;
+
+  return !loading ? <>{text || errorText}</> : null;
 };
 
 export default PlaceText;

--- a/src/domain/place/query.ts
+++ b/src/domain/place/query.ts
@@ -51,4 +51,19 @@ export const QUERY_PLACE = gql`
       }
     }
   }
+  query SchoolsAndKindergartensList {
+    schoolsAndKindergartensList {
+      meta {
+        count
+      }
+      data {
+        id
+        name {
+          fi
+          sv
+          en
+        }
+      }
+    }
+  }
 `;

--- a/src/domain/place/unitSelector/UnitPlaceSelector.tsx
+++ b/src/domain/place/unitSelector/UnitPlaceSelector.tsx
@@ -44,6 +44,8 @@ const UnitPlaceSelector: React.FC<Props> = ({
   required,
   disabled,
 }) => {
+  const locale = useLocale();
+  const { t } = useTranslation();
   const [inputValue, setInputValue] = React.useState('');
   const searchValue = useDebounce(inputValue, 100);
 
@@ -52,9 +54,6 @@ const UnitPlaceSelector: React.FC<Props> = ({
   const { data: unitsData, loading } = useSchoolsAndKindergartensListQuery({
     skip: !searchValue,
   });
-
-  const locale = useLocale();
-  const { t } = useTranslation();
 
   const optionLabelToString = (option: AutoSuggestOption, locale: Language) => {
     const data = apolloClient.readQuery<PlaceQuery>({

--- a/src/domain/place/unitSelector/UnitPlaceSelector.tsx
+++ b/src/domain/place/unitSelector/UnitPlaceSelector.tsx
@@ -1,15 +1,15 @@
 import { useApolloClient } from '@apollo/client';
 import * as React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import AutoSuggest, {
   AutoSuggestOption,
 } from '../../../common/components/autoSuggest/AutoSuggest';
-import { AUTOSUGGEST_OPTIONS_AMOUNT } from '../../../common/components/autoSuggest/contants';
 import {
   Place,
   PlaceDocument,
   PlaceQuery,
-  usePlacesQuery,
+  useSchoolsAndKindergartensListQuery,
 } from '../../../generated/graphql';
 import useDebounce from '../../../hooks/useDebounce';
 import useLocale from '../../../hooks/useLocale';
@@ -46,40 +46,36 @@ const UnitPlaceSelector: React.FC<Props> = ({
 }) => {
   const [inputValue, setInputValue] = React.useState('');
   const searchValue = useDebounce(inputValue, 100);
+
   const apolloClient = useApolloClient();
 
-  const { data: placesData, loading } = usePlacesQuery({
+  const { data: unitsData, loading } = useSchoolsAndKindergartensListQuery({
     skip: !searchValue,
-    variables: {
-      dataSource: 'tprek',
-      pageSize: AUTOSUGGEST_OPTIONS_AMOUNT,
-      showAllPlaces: true,
-      text: searchValue,
-    },
   });
 
   const locale = useLocale();
+  const { t } = useTranslation();
 
   const optionLabelToString = (option: AutoSuggestOption, locale: Language) => {
     const data = apolloClient.readQuery<PlaceQuery>({
       query: PlaceDocument,
       variables: { id: option.value },
     });
-
     return getLocalisedString(data?.place?.name || {}, locale);
   };
 
-  const getOptionLabel = (place: Place) =>
-    `${getLocalisedString(place.name || {}, locale)}, ${getLocalisedString(
-      place.streetAddress || {},
-      locale
-    )}`;
+  const getOptionLabel = (place: Place) => {
+    return getLocalisedString(place.name || {}, locale);
+  };
 
   const placeOptions =
-    placesData?.places?.data.map((place) => ({
-      label: getOptionLabel(place),
-      value: place.id || '',
-    })) || [];
+    unitsData?.schoolsAndKindergartensList?.data
+      .map((place) => ({
+        label: getOptionLabel(place as Place),
+        value: place.id || '',
+      }))
+      // Filter the results with a search value!
+      .filter((place) => place.label.includes(searchValue)) || [];
 
   const handleBlur = (
     option: AutoSuggestOption | AutoSuggestOption[] | null
@@ -108,7 +104,15 @@ const UnitPlaceSelector: React.FC<Props> = ({
         value: item,
       }));
     } else if (value) {
-      return { label: <PlaceText placeId={value} />, value: value };
+      return {
+        label: (
+          <PlaceText
+            placeId={value}
+            errorText={t('unitPlaceSelector.noPlaceFoundError')}
+          />
+        ),
+        value: value,
+      };
     }
 
     return null;

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -67,7 +67,11 @@ export type AddEventMutationInput = {
   audienceMinAge?: Maybe<Scalars['String']>;
   audienceMaxAge?: Maybe<Scalars['String']>;
   superEventType?: Maybe<Scalars['String']>;
-  extensionCourse?: Maybe<IdObjectInput>;
+  enrolmentStartTime?: Maybe<Scalars['String']>;
+  enrolmentEndTime?: Maybe<Scalars['String']>;
+  maximumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  minimumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  remainingAttendeeCapacity?: Maybe<Scalars['Int']>;
   name: LocalisedObjectInput;
   localizationExtraInfo?: Maybe<LocalisedObjectInput>;
   shortDescription: LocalisedObjectInput;
@@ -360,7 +364,11 @@ export type Event = {
   audienceMinAge?: Maybe<Scalars['String']>;
   audienceMaxAge?: Maybe<Scalars['String']>;
   superEventType?: Maybe<Scalars['String']>;
-  extensionCourse?: Maybe<ExtensionCourse>;
+  enrolmentStartTime?: Maybe<Scalars['String']>;
+  enrolmentEndTime?: Maybe<Scalars['String']>;
+  maximumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  minimumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  remainingAttendeeCapacity?: Maybe<Scalars['Int']>;
   name: LocalisedObject;
   localizationExtraInfo?: Maybe<LocalisedObject>;
   shortDescription: LocalisedObject;
@@ -396,15 +404,6 @@ export type EventSearchListResponse = {
   __typename?: 'EventSearchListResponse';
   meta: Meta;
   data: Array<Event>;
-};
-
-export type ExtensionCourse = {
-  __typename?: 'ExtensionCourse';
-  enrolmentStartTime?: Maybe<Scalars['String']>;
-  enrolmentEndTime?: Maybe<Scalars['String']>;
-  maximumAttendeeCapacity?: Maybe<Scalars['Int']>;
-  minimumAttendeeCapacity?: Maybe<Scalars['Int']>;
-  remainingAttendeeCapacity?: Maybe<Scalars['Int']>;
 };
 
 export type ExternalLink = {
@@ -1303,7 +1302,11 @@ export type PublishEventMutationInput = {
   audienceMinAge?: Maybe<Scalars['String']>;
   audienceMaxAge?: Maybe<Scalars['String']>;
   superEventType?: Maybe<Scalars['String']>;
-  extensionCourse?: Maybe<IdObjectInput>;
+  enrolmentStartTime?: Maybe<Scalars['String']>;
+  enrolmentEndTime?: Maybe<Scalars['String']>;
+  maximumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  minimumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  remainingAttendeeCapacity?: Maybe<Scalars['Int']>;
   name: LocalisedObjectInput;
   localizationExtraInfo?: Maybe<LocalisedObjectInput>;
   shortDescription: LocalisedObjectInput;
@@ -1354,6 +1357,8 @@ export type Query = {
   image?: Maybe<Image>;
   keywords?: Maybe<KeywordListResponse>;
   keyword?: Maybe<Keyword>;
+  /** Keywords related to Kultus ordered by the number of events */
+  popularKultusKeywords?: Maybe<KeywordListResponse>;
   keywordSet?: Maybe<KeywordSet>;
   eventsSearch?: Maybe<EventSearchListResponse>;
   placesSearch?: Maybe<PlaceSearchListResponse>;
@@ -1496,12 +1501,6 @@ export type QueryOrganisationsArgs = {
 };
 
 
-export type QuerySchoolsAndKindergartensListArgs = {
-  page?: Maybe<Scalars['Int']>;
-  pageSize?: Maybe<Scalars['Int']>;
-};
-
-
 export type QueryEventsArgs = {
   division?: Maybe<Array<Maybe<Scalars['String']>>>;
   end?: Maybe<Scalars['String']>;
@@ -1569,6 +1568,12 @@ export type QueryKeywordsArgs = {
 
 export type QueryKeywordArgs = {
   id: Scalars['ID'];
+};
+
+
+export type QueryPopularKultusKeywordsArgs = {
+  amount?: Maybe<Scalars['Int']>;
+  showAllKeywords?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -1789,7 +1794,11 @@ export type UpdateEventMutationInput = {
   audienceMinAge?: Maybe<Scalars['String']>;
   audienceMaxAge?: Maybe<Scalars['String']>;
   superEventType?: Maybe<Scalars['String']>;
-  extensionCourse?: Maybe<IdObjectInput>;
+  enrolmentStartTime?: Maybe<Scalars['String']>;
+  enrolmentEndTime?: Maybe<Scalars['String']>;
+  maximumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  minimumAttendeeCapacity?: Maybe<Scalars['Int']>;
+  remainingAttendeeCapacity?: Maybe<Scalars['Int']>;
   name: LocalisedObjectInput;
   localizationExtraInfo?: Maybe<LocalisedObjectInput>;
   shortDescription: LocalisedObjectInput;
@@ -2132,6 +2141,11 @@ export type PlacesQueryVariables = Exact<{
 
 
 export type PlacesQuery = { __typename?: 'Query', places?: Maybe<{ __typename?: 'PlaceListResponse', meta: { __typename?: 'Meta', count?: Maybe<number>, next?: Maybe<string>, previous?: Maybe<string> }, data: Array<{ __typename?: 'Place', id?: Maybe<string>, internalId: string, name?: Maybe<{ __typename?: 'LocalisedObject', en?: Maybe<string>, fi?: Maybe<string>, sv?: Maybe<string> }>, streetAddress?: Maybe<{ __typename?: 'LocalisedObject', en?: Maybe<string>, fi?: Maybe<string>, sv?: Maybe<string> }>, addressLocality?: Maybe<{ __typename?: 'LocalisedObject', en?: Maybe<string>, fi?: Maybe<string>, sv?: Maybe<string> }>, telephone?: Maybe<{ __typename?: 'LocalisedObject', en?: Maybe<string>, fi?: Maybe<string>, sv?: Maybe<string> }> }> }> };
+
+export type SchoolsAndKindergartensListQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type SchoolsAndKindergartensListQuery = { __typename?: 'Query', schoolsAndKindergartensList?: Maybe<{ __typename?: 'ServiceUnitNameListResponse', meta: { __typename?: 'Meta', count?: Maybe<number> }, data: Array<{ __typename?: 'ServiceUnitNode', id: string, name?: Maybe<{ __typename?: 'LocalisedObject', fi?: Maybe<string>, sv?: Maybe<string>, en?: Maybe<string> }> }> }> };
 
 export type StudyGroupFieldsFragment = { __typename?: 'StudyGroupNode', id: string, unitId?: Maybe<string>, unitName: string, groupSize: number, amountOfAdult: number, groupName: string, extraNeeds: string, unit?: Maybe<{ __typename?: 'ExternalPlace', name?: Maybe<{ __typename?: 'LocalisedObject', en?: Maybe<string>, fi?: Maybe<string>, sv?: Maybe<string> }> } | { __typename?: 'Place', internalId: string, id?: Maybe<string>, name?: Maybe<{ __typename?: 'LocalisedObject', en?: Maybe<string>, fi?: Maybe<string>, sv?: Maybe<string> }> }>, studyLevels: { __typename?: 'StudyLevelNodeConnection', edges: Array<Maybe<{ __typename?: 'StudyLevelNodeEdge', node?: Maybe<{ __typename?: 'StudyLevelNode', id: string, label?: Maybe<string>, level: number, translations: Array<{ __typename?: 'StudyLevelTranslationType', languageCode: Language, label: string }> }> }>> }, person: { __typename?: 'PersonNode', id: string, emailAddress: string, name: string, phoneNumber: string, language: Language } };
 
@@ -3020,6 +3034,50 @@ export function usePlacesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Pla
 export type PlacesQueryHookResult = ReturnType<typeof usePlacesQuery>;
 export type PlacesLazyQueryHookResult = ReturnType<typeof usePlacesLazyQuery>;
 export type PlacesQueryResult = Apollo.QueryResult<PlacesQuery, PlacesQueryVariables>;
+export const SchoolsAndKindergartensListDocument = gql`
+    query SchoolsAndKindergartensList {
+  schoolsAndKindergartensList {
+    meta {
+      count
+    }
+    data {
+      id
+      name {
+        fi
+        sv
+        en
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useSchoolsAndKindergartensListQuery__
+ *
+ * To run a query within a React component, call `useSchoolsAndKindergartensListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSchoolsAndKindergartensListQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSchoolsAndKindergartensListQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useSchoolsAndKindergartensListQuery(baseOptions?: Apollo.QueryHookOptions<SchoolsAndKindergartensListQuery, SchoolsAndKindergartensListQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SchoolsAndKindergartensListQuery, SchoolsAndKindergartensListQueryVariables>(SchoolsAndKindergartensListDocument, options);
+      }
+export function useSchoolsAndKindergartensListLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SchoolsAndKindergartensListQuery, SchoolsAndKindergartensListQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SchoolsAndKindergartensListQuery, SchoolsAndKindergartensListQueryVariables>(SchoolsAndKindergartensListDocument, options);
+        }
+export type SchoolsAndKindergartensListQueryHookResult = ReturnType<typeof useSchoolsAndKindergartensListQuery>;
+export type SchoolsAndKindergartensListLazyQueryHookResult = ReturnType<typeof useSchoolsAndKindergartensListLazyQuery>;
+export type SchoolsAndKindergartensListQueryResult = Apollo.QueryResult<SchoolsAndKindergartensListQuery, SchoolsAndKindergartensListQueryVariables>;
 export const StudyLevelsDocument = gql`
     query StudyLevels {
   studyLevels {

--- a/src/tests/apollo-mocks/schoolsAndKindergartensListMock.ts
+++ b/src/tests/apollo-mocks/schoolsAndKindergartensListMock.ts
@@ -1,0 +1,22 @@
+import { MockedResponse } from '@apollo/client/testing';
+
+import {
+  Place,
+  SchoolsAndKindergartensListDocument,
+} from '../../generated/graphql';
+import { fakePlaces } from '../../utils/mockDataUtils';
+
+export const createSchoolsAndKindergartensListQueryMock = (
+  count = 1,
+  places?: Partial<Place>[]
+): MockedResponse => ({
+  request: {
+    query: SchoolsAndKindergartensListDocument,
+    variables: {},
+  },
+  result: {
+    data: {
+      schoolsAndKindergartensList: fakePlaces(count, places),
+    },
+  },
+});


### PR DESCRIPTION
API returns all the units (1000+ pcs) all at once from schoolsAndKindergartens graphql query. The Enrolment form autosuggest field for unit selection should be able to filter the list of units with an input value.

PT-1314.

----
The list of schools and kindergartens is from Servicemap API, but the selected place is queried from LinkedEvents places-API

Selected:
![image](https://user-images.githubusercontent.com/389204/141281607-fab0bff7-eff1-4ea5-853c-8094213af4c6.png)


With error:
![image](https://user-images.githubusercontent.com/389204/141281518-8b83e706-6750-485b-8cff-d384ccf26553.png)
