### PR TITLE
feat: event back button navigates to correct page

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,5 +1,6 @@
 {
   "appName": "Kultus beta",
+  "buttonBack": "Go back",
   "bannerHero": {
     "title": "Arts, culture, and events for daycare and schools"
   },

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -1,5 +1,6 @@
 {
   "appName": "Kultus beta",
+  "buttonBack": "Takaisin",
   "bannerHero": {
     "title": "Oppimisen elämyksiä koko kaupungissa"
   },

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -1,5 +1,6 @@
 {
   "appName": "Kultus beta",
+  "buttonBack": "Tillbaka",
   "bannerHero": {
     "title": "Konst, kultur och evenemang för skolor och dagis"
   },

--- a/src/domain/event/EventPage.tsx
+++ b/src/domain/event/EventPage.tsx
@@ -14,6 +14,7 @@ import {
   useEventQuery,
 } from '../../generated/graphql';
 import useLocale from '../../hooks/useLocale';
+import { extractLatestReturnPath } from '../../utils/extractLatestReturnPath';
 import { translateValue } from '../../utils/translateUtils';
 import Container from '../app/layout/Container';
 import PageWrapper from '../app/layout/PageWrapper';
@@ -187,12 +188,15 @@ const EventHero: React.FC<{
   photographerName?: string | null;
 }> = ({ imageAltText, imageUrl, photographerName }) => {
   const { t } = useTranslation();
+  const { asPath } = useRouter();
+  const [, search] = asPath.split('?');
+  const { returnPath, remainingQueryString } = extractLatestReturnPath(search);
 
   return (
     <div className={styles.eventHero}>
       <Container className={styles.backButtonContainer}>
-        <Link href="/">
-          <a>
+        <Link href={{ pathname: returnPath, search: remainingQueryString }}>
+          <a aria-label={t('common:buttonBack')}>
             <IconArrowLeft size="m" />
           </a>
         </Link>

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -825,3 +825,36 @@ it('shows inquire registration notification after enrolment is done', async () =
     /lähetämme sinulle vahvistuksen sähköpostitse ja tekstiviestillä\./i
   );
 });
+
+describe('back button', () => {
+  it('back button renders href correctly based on returnPath query param', async () => {
+    render(<EventPage />, {
+      mocks: apolloMocks,
+      query: { eventId: eventData.id },
+      path: `/fi${ROUTES.EVENT_DETAILS.replace(
+        ':id',
+        data.id
+      )}?returnPath=%2Fsearch&text=rock`,
+    });
+    await waitForRequestsToComplete();
+
+    const backLink = screen.getByRole('link', {
+      name: /takaisin/i,
+    });
+    expect(backLink).toHaveAttribute('href', '/search?text=rock');
+  });
+
+  it('back button renders href correctly returnPath to front page', async () => {
+    render(<EventPage />, {
+      mocks: apolloMocks,
+      query: { eventId: eventData.id },
+      path: `/fi${ROUTES.EVENT_DETAILS.replace(':id', data.id)}?returnPath=%2F`,
+    });
+    await waitForRequestsToComplete();
+
+    const backLink = screen.getByRole('link', {
+      name: /takaisin/i,
+    });
+    expect(backLink).toHaveAttribute('href', '/');
+  });
+});

--- a/src/domain/events/eventList/EventList.tsx
+++ b/src/domain/events/eventList/EventList.tsx
@@ -1,9 +1,11 @@
 import { Button, Select, IconArrowDown } from 'hds-react';
 import { useTranslation } from 'next-i18next';
+import { useRouter } from 'next/router';
 import React, { ReactElement } from 'react';
 
 import LoadingSpinner from '../../../common/components/loadingSpinner/LoadingSpinner';
 import { EventsFieldsFragment } from '../../../generated/graphql';
+import { addParamsToQueryString } from '../../../utils/queryString';
 import { translateValue } from '../../../utils/translateUtils';
 import { ROUTES } from '../../app/routes/constants';
 import EventCard from '../../event/eventCard/EventCard';
@@ -29,6 +31,13 @@ const EventList = ({
   eventsCount = 0,
   setSort,
 }: Props): ReactElement => {
+  const { asPath } = useRouter();
+
+  const [pathname, search] = asPath.split('?');
+  const queryString = addParamsToQueryString(search, {
+    returnPath: pathname,
+  });
+
   const { t } = useTranslation();
   const sortOptions = React.useMemo(() => {
     return Object.keys(EVENT_SORT_OPTIONS).map((key) => {
@@ -69,13 +78,11 @@ const EventList = ({
       </div>
       <div className={styles.eventCardsContainer}>
         {events.map((event, index) => {
-          return (
-            <EventCard
-              key={index}
-              event={event}
-              link={ROUTES.EVENT_DETAILS.replace(':id', event.id)}
-            />
-          );
+          const eventUrl = `${ROUTES.EVENT_DETAILS.replace(
+            ':id',
+            event.id
+          )}${queryString}`;
+          return <EventCard key={index} event={event} link={eventUrl} />;
         })}
       </div>
       {shouldShowLoadMore && (

--- a/src/utils/extractLatestReturnPath.ts
+++ b/src/utils/extractLatestReturnPath.ts
@@ -1,0 +1,29 @@
+import { ROUTES } from '../domain/app/routes/constants';
+
+export type ReturnParams = {
+  returnPath: string;
+  remainingQueryString?: string;
+};
+
+/**
+ * Extracts latest return path from queryString. For example on:
+ * http://localhost:3000/fi/event/kulke:53397?returnPath=%2Fevents&returnPath=%2Fevent%2Fhelsinki%3Aaf3pnza3zi
+ * latest return path is in the last returnPath param on queryString : %2Fevent%2Fhelsinki%3Aaf3pnza3zi
+ */
+export const extractLatestReturnPath = (queryString: string): ReturnParams => {
+  const searchParams = new URLSearchParams(queryString);
+  const returnPaths = searchParams.getAll('returnPath');
+  // latest path is the last item, it can be popped. If empty, defaults to /events
+  const extractedPath = returnPaths.pop() ?? ROUTES.EVENTS_SEARCH;
+  // there is no support to delete all but extracted item from same parameter list. This is a workaround to it:
+  // 1) delete all first
+  searchParams.delete('returnPath');
+  // 2) then append all except latest
+  returnPaths.forEach((returnPath) =>
+    searchParams.append('returnPath', returnPath)
+  );
+  return {
+    returnPath: extractedPath,
+    remainingQueryString: searchParams.toString(),
+  };
+};

--- a/src/utils/queryString.ts
+++ b/src/utils/queryString.ts
@@ -1,0 +1,50 @@
+import { SUPPORTED_LANGUAGES } from '../constants';
+import { assertUnreachable } from './typescript.utils';
+
+type QueryParamValue = string | string[];
+
+export type QueryParams = {
+  returnPath?: QueryParamValue;
+};
+
+export type QueryParam = keyof QueryParams;
+
+const langPathRegExp = new RegExp(
+  `/(${Object.values(SUPPORTED_LANGUAGES).join('|')})`
+);
+
+const stripLanguageFromPath = (path: string) =>
+  path.replace(langPathRegExp, '');
+
+const getParamValue = ({
+  param,
+  value,
+}: {
+  param: QueryParam;
+  value: string;
+}) => {
+  switch (param) {
+    case 'returnPath':
+      return stripLanguageFromPath(value);
+    default:
+      return assertUnreachable(param, 'Unknown query parameter');
+  }
+};
+
+export const addParamsToQueryString = (
+  queryString: string,
+  queryParams: QueryParams
+): string => {
+  const searchParams = new URLSearchParams(queryString);
+  Object.entries(queryParams).forEach(([key, values]) => {
+    const param = key as QueryParam;
+    if (Array.isArray(values)) {
+      values.forEach((value) =>
+        searchParams.append(param, getParamValue({ param, value }))
+      );
+    } else if (values) {
+      searchParams.append(param, getParamValue({ param, value: values }));
+    }
+  });
+  return '?' + searchParams.toString();
+};


### PR DESCRIPTION
## Description :sparkles:

- Event page back button now navigates to correct page preserving query parameters

## Issues :bug:

### Closes :no_good_woman:

**[PT-1293](https://helsinkisolutionoffice.atlassian.net/browse/PT-1293):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
