### PR TITLE
PT-1288, PT-1342 | Save recommended events variables from enrolment form to local storage

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,10 @@ export enum FORM_NAMES {
   ENROLMENT_FORM = 'enrolment-form',
 }
 
+export enum LOCAL_STORAGE {
+  RECOMMENDED_EVENTS_VARIABLES = 'recommended-events-variables',
+}
+
 export enum SUPPORTED_LANGUAGES {
   FI = 'fi',
   SV = 'sv',

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -22,7 +22,7 @@ import keyify from '../../../utils/keyify';
 import { translateValue } from '../../../utils/translateUtils';
 import useStudyLevels from '../../studyLevel/useStudyLevels';
 import {
-  defaultInitialValues,
+  defaultEnrolmentInitialValues,
   EnrolmentFormFields,
   nameToLabelPath,
 } from './constants';
@@ -38,7 +38,7 @@ export interface Props {
 }
 
 const EnrolmentForm: React.FC<Props> = ({
-  initialValues = defaultInitialValues,
+  initialValues = defaultEnrolmentInitialValues,
   enquiry,
   onSubmit,
   submitting,

--- a/src/domain/enrolment/enrolmentForm/__tests__/EnrolmentForm.test.tsx
+++ b/src/domain/enrolment/enrolmentForm/__tests__/EnrolmentForm.test.tsx
@@ -21,7 +21,7 @@ import {
   configure,
   within,
 } from '../../../../utils/testUtils';
-import { defaultInitialValues } from '../constants';
+import { defaultEnrolmentInitialValues } from '../constants';
 import EnrolmentForm, { Props } from '../EnrolmentForm';
 
 configure({ defaultHidden: true });
@@ -55,7 +55,7 @@ const renderComponent = ({
       onCloseForm={onCloseFormMock}
       onSubmit={onSubmitMock}
       submitting={false}
-      initialValues={{ ...defaultInitialValues, ...initialValues }}
+      initialValues={{ ...defaultEnrolmentInitialValues, ...initialValues }}
       {...restProps}
     />,
     { mocks: [...defaultMocks, ...mocks] }
@@ -401,7 +401,7 @@ if (isFeatureEnabled('FORMIK_PERSIST')) {
       isSubmitting: false,
       isValidating: false,
       submitCount: 0,
-      initialValues: defaultInitialValues,
+      initialValues: defaultEnrolmentInitialValues,
       initialErrors: {},
       initialTouched: {},
       isValid: true,

--- a/src/domain/enrolment/enrolmentForm/constants.ts
+++ b/src/domain/enrolment/enrolmentForm/constants.ts
@@ -28,7 +28,7 @@ export type EnrolmentFormFields = {
   };
 };
 
-export const defaultInitialValues: EnrolmentFormFields = {
+export const defaultEnrolmentInitialValues: EnrolmentFormFields = {
   hasEmailNotification: true,
   hasSmsNotification: false,
   isSameResponsiblePerson: true,

--- a/src/domain/event/__tests__/enrolmentFormIntegration.test.tsx
+++ b/src/domain/event/__tests__/enrolmentFormIntegration.test.tsx
@@ -18,6 +18,7 @@ import {
   fakePEvent,
   fakePlace,
 } from '../../../utils/mockDataUtils';
+import { getRecommendedEventsQueryVariables } from '../../../utils/recommendedEventsUtils';
 import {
   render,
   configure,
@@ -151,6 +152,13 @@ test('user can select single occurrences and enrol to it with enrolment form', a
       JSON.parse(localStorage.getItem(FORM_NAMES.ENROLMENT_FORM)!)
     ).toMatchSnapshot();
   }
+
+  await waitFor(() => {
+    expect(getRecommendedEventsQueryVariables()).toEqual({
+      unitIds: [null],
+      studyLevels: ['kultus:55', 'kultus:56'],
+    });
+  });
 
   await waitFor(() => {
     expect(enrolOccurrenceMock).toHaveBeenCalledWith({

--- a/src/domain/event/occurrences/EnrolmentFormSection.tsx
+++ b/src/domain/event/occurrences/EnrolmentFormSection.tsx
@@ -11,6 +11,7 @@ import {
   OccurrenceSeatType,
 } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
+import { saveDataForRecommendedEventsQuery } from '../../../utils/recommendedEventsUtils';
 import { assertUnreachable } from '../../../utils/typescript.utils';
 import { ROUTES } from '../../app/routes/constants';
 import { ENROLMENT_URL_PARAMS } from '../../enrolment/constants';
@@ -52,6 +53,7 @@ const EnrolmentFormSection: React.FC<{
           },
         },
       });
+      saveDataForRecommendedEventsQuery(values);
       router.push({
         pathname: ROUTES.EVENT_DETAILS.replace(':id', event.id as string),
         query: {

--- a/src/domain/event/occurrences/EnrolmentFormSection.tsx
+++ b/src/domain/event/occurrences/EnrolmentFormSection.tsx
@@ -17,7 +17,7 @@ import { ROUTES } from '../../app/routes/constants';
 import { ENROLMENT_URL_PARAMS } from '../../enrolment/constants';
 import {
   EnrolmentFormFields,
-  defaultInitialValues,
+  defaultEnrolmentInitialValues,
 } from '../../enrolment/enrolmentForm/constants';
 import EnrolmentForm from '../../enrolment/enrolmentForm/EnrolmentForm';
 import { getCAPTCHAToken, getEnrolmentPayload } from '../../enrolment/utils';
@@ -76,7 +76,7 @@ const EnrolmentFormSection: React.FC<{
 
   const initialValues = React.useMemo(
     () => ({
-      ...defaultInitialValues,
+      ...defaultEnrolmentInitialValues,
       language: locale.toUpperCase(),
       // some of the values used only for validation purposes
       minGroupSize: Math.max(

--- a/src/domain/events/eventSearchForm/EventSearchForm.tsx
+++ b/src/domain/events/eventSearchForm/EventSearchForm.tsx
@@ -29,7 +29,7 @@ export type EventSearchFormValues = {
   [KEYWORD_QUERY_PARAMS.ADDITIONAL_CRITERIA]: string[];
 };
 
-const defaultInitialValues: EventSearchFormValues = {
+const defaultEnrolmentInitialValues: EventSearchFormValues = {
   text: '',
   inLanguage: [],
   [KEYWORD_QUERY_PARAMS.TARGET_GROUPS]: [],
@@ -57,7 +57,7 @@ interface Props {
 }
 
 const EventSearchForm = ({
-  initialValues = defaultInitialValues,
+  initialValues = defaultEnrolmentInitialValues,
   onSubmit,
   onToggleAdvancedSearch,
   panelState,

--- a/src/domain/keyword/constants.ts
+++ b/src/domain/keyword/constants.ts
@@ -1,0 +1,16 @@
+export const STUDY_LEVEL_TO_KEYWORD_MAP = {
+  AGE_0_2: 'helsinki:af4prk7e5y',
+  AGE_3_4: 'kultus:44',
+  PRESCHOOL: 'kultus:52',
+  GRADE_1: 'kultus:55',
+  GRADE_2: 'kultus:55',
+  GRADE_3: 'kultus:56',
+  GRADE_4: 'kultus:56',
+  GRADE_5: 'kultus:56',
+  GRADE_6: 'kultus:56',
+  GRADE_7: 'kultus:57',
+  GRADE_8: 'kultus:57',
+  GRADE_9: 'kultus:57',
+  GRADE_10: 'kultus:57',
+  SECONDARY: 'kultus:58',
+};

--- a/src/utils/__tests__/recommendedEventsUtils.test.ts
+++ b/src/utils/__tests__/recommendedEventsUtils.test.ts
@@ -1,0 +1,88 @@
+import { LOCAL_STORAGE } from '../../constants';
+import { defaultEnrolmentInitialValues } from '../../domain/enrolment/enrolmentForm/constants';
+import {
+  getRecommendedEventsQueryVariables,
+  saveDataForRecommendedEventsQuery,
+} from '../recommendedEventsUtils';
+
+describe('getRecommendedEventsQueryVariables', () => {
+  it('returns empty studyLevels when they dont match with hard coded study levels', () => {
+    assertGetRecommendedEventsQueryVariables(
+      {
+        unitIds: ['123', '312'],
+        studyLevels: ['level1', 'level2'],
+      },
+      {
+        unitIds: ['123', '312'],
+        studyLevels: [],
+      }
+    );
+  });
+
+  it('returns mapped unique studyLevels from local storage', () => {
+    assertGetRecommendedEventsQueryVariables(
+      {
+        unitIds: ['123', '312'],
+        studyLevels: ['GRADE_1', 'GRADE_2', 'GRADE_6'],
+      },
+      {
+        unitIds: ['123', '312'],
+        studyLevels: ['kultus:55', 'kultus:56'],
+      }
+    );
+  });
+
+  it('returns empty arrays when no variables have been saved before', () => {
+    assertGetRecommendedEventsQueryVariables(
+      {},
+      {
+        unitIds: [],
+        studyLevels: [],
+      }
+    );
+  });
+});
+
+describe('saveDataForRecommendedEventsQuery', () => {
+  it('saves recommended event query variables to local storage correctly', () => {
+    assertSaveDataForRecommendedEventsQuery(
+      {
+        unitId: '123',
+        studyLevels: ['GRADE_1', 'GRADE_2', 'GRADE_6'],
+      },
+      {
+        unitIds: ['123'],
+        studyLevels: ['GRADE_1', 'GRADE_2', 'GRADE_6'],
+      }
+    );
+  });
+});
+
+const assertGetRecommendedEventsQueryVariables = (
+  value: Record<string, unknown>,
+  expected: Record<string, unknown>
+) => {
+  localStorage.setItem(
+    LOCAL_STORAGE.RECOMMENDED_EVENTS_VARIABLES,
+    JSON.stringify(value)
+  );
+  expect(getRecommendedEventsQueryVariables()).toEqual(expected);
+};
+
+const assertSaveDataForRecommendedEventsQuery = (
+  value: Record<string, unknown>,
+  expected: Record<string, unknown>
+) => {
+  saveDataForRecommendedEventsQuery({
+    ...defaultEnrolmentInitialValues,
+    studyGroup: {
+      ...defaultEnrolmentInitialValues.studyGroup,
+      ...value,
+    },
+  });
+  expect(
+    JSON.parse(
+      localStorage.getItem(LOCAL_STORAGE.RECOMMENDED_EVENTS_VARIABLES) as string
+    )
+  ).toEqual(expected);
+};

--- a/src/utils/recommendedEventsUtils.ts
+++ b/src/utils/recommendedEventsUtils.ts
@@ -1,0 +1,48 @@
+import uniq from 'lodash/uniq';
+
+import { LOCAL_STORAGE } from '../constants';
+import { EnrolmentFormFields } from '../domain/enrolment/enrolmentForm/constants';
+import { STUDY_LEVEL_TO_KEYWORD_MAP } from '../domain/keyword/constants';
+import { skipFalsyType } from './typescript.utils';
+
+export const saveDataForRecommendedEventsQuery = (
+  values: EnrolmentFormFields
+): void => {
+  const {
+    studyGroup: { unitId, studyLevels },
+  } = values;
+
+  const savedVariables = JSON.parse(
+    localStorage.getItem(LOCAL_STORAGE.RECOMMENDED_EVENTS_VARIABLES) as string
+  );
+  const previousUnitIds = savedVariables?.unitIds ?? [];
+  const previousStudyLevels = savedVariables?.studyLevels ?? [];
+  const newUnitIds = uniq([...previousUnitIds, unitId]);
+  const newStudyLevels = uniq([...previousStudyLevels, ...studyLevels]);
+
+  localStorage.setItem(
+    LOCAL_STORAGE.RECOMMENDED_EVENTS_VARIABLES,
+    JSON.stringify({ unitIds: newUnitIds, studyLevels: newStudyLevels })
+  );
+};
+
+export const getRecommendedEventsQueryVariables = (): {
+  unitIds?: string[];
+  studyLevels?: string[];
+} => {
+  const savedVariables = JSON.parse(
+    localStorage.getItem(LOCAL_STORAGE.RECOMMENDED_EVENTS_VARIABLES) as string
+  );
+
+  const mappedStudyLevels = savedVariables?.studyLevels
+    ?.map(
+      (studyLevel: keyof typeof STUDY_LEVEL_TO_KEYWORD_MAP) =>
+        STUDY_LEVEL_TO_KEYWORD_MAP[studyLevel]
+    )
+    .filter(skipFalsyType);
+
+  return {
+    unitIds: savedVariables?.unitIds ?? [],
+    studyLevels: uniq(mappedStudyLevels),
+  };
+};


### PR DESCRIPTION
## Description :sparkles:

- Save recommended events variables from enrolment form to local storage

## Issues :bug:

### Closes :no_good_woman:

**[PT-1288](https://helsinkisolutionoffice.atlassian.net/browse/PT-1288):**
**[PT-1342](https://helsinkisolutionoffice.atlassian.net/browse/PT-1342):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
