### PR TITLE
PT-1316 | Add language column to occurrences table in event page

### DIFF
--- a/public/locales/en/enrolment.json
+++ b/public/locales/en/enrolment.json
@@ -79,6 +79,7 @@
     "columnPlace": "Event location",
     "columnSeatsInfo": "Seats left",
     "columnTime": "Time",
+    "columnLanguage": "Language",
     "noOccurrences": "Event doesn't have occurrences",
     "noSelectedOccurrences": "No selected event times",
     "title": "Selected event times"

--- a/public/locales/fi/enrolment.json
+++ b/public/locales/fi/enrolment.json
@@ -79,6 +79,7 @@
     "columnPlace": "Tapahtumapaikka",
     "columnSeatsInfo": "Paikkoja jäljellä",
     "columnTime": "Kellonaika",
+    "columnLanguage": "Kieli",
     "noOccurrences": "Tapahtumalla ei ole tapahtuma-aikoja",
     "noSelectedOccurrences": "Ei valittuja tapahtuma-aikoja",
     "title": "Valitut tapahtuma-ajat"

--- a/public/locales/sv/enrolment.json
+++ b/public/locales/sv/enrolment.json
@@ -78,7 +78,8 @@
     "columnDate": "Datum",
     "columnPlace": "Evenemangplats",
     "columnSeatsInfo": "Platser kvar",
-    "columnTime": "Tid",
+    "columnTime": "Tid", 
+    "columnLanguage": "Språk",
     "noOccurrences": "Händelse har inga händelser",
     "noSelectedOccurrences": "Inga valda evenemangtider",
     "title": "Valda evenemangstider"

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -25,6 +25,7 @@ import {
   fakeImage,
   fakeInLanguage,
   fakeKeyword,
+  fakeLanguages,
   fakeLocalizedObject,
   fakeOccurrences,
   fakeOrganisation,
@@ -81,11 +82,17 @@ const occurrences = [
     amountOfSeats: 30,
     seatsApproved: 10,
     remainingSeats: 20,
+    languages: fakeLanguages([
+      { id: 'en', name: 'English' },
+      { id: 'fi', name: 'Finnish' },
+      { id: 'sv', name: 'Finnish' },
+    ]),
   },
   {
     startTime: '2020-07-16T09:00:00+00:00',
     placeId: data.placeId,
     id: data.placeId2,
+    languages: fakeLanguages([{ id: 'fi', name: 'Finnish' }]),
   },
   {
     startTime: '2020-07-19T09:00:00+00:00',
@@ -248,9 +255,9 @@ it('shows full events correctly in occurrences list', async () => {
   await waitForRequestsToComplete();
 
   const fullOccurrenceRowText1 =
-    '23.7.2020 to12:00 – 13:00Soukan kirjasto0 / 1Tapahtuma on täynnä';
+    '23.7.2020 to12:00 – 13:00en, fiSoukan kirjasto0 / 1Tapahtuma on täynnä';
   const fullOccurrenceRowText2 =
-    '29.7.2020 ke12:00 – 13:00Soukan kirjasto0 / 30Tapahtuma on täynnä';
+    '29.7.2020 ke12:00 – 13:00en, fiSoukan kirjasto0 / 30Tapahtuma on täynnä';
 
   const tableRows = screen.queryAllByRole('row');
   expect(tableRows[7]).toHaveTextContent(fullOccurrenceRowText1);
@@ -262,7 +269,7 @@ it('shows cancelled events correctly in list', async () => {
   await waitForRequestsToComplete();
 
   const cancelledOccurrenceRowText =
-    '20.7.2020 ma12:00 – 13:00Soukan kirjasto30 / 30Tapahtuma on peruttu';
+    '20.7.2020 ma12:00 – 13:00en, fiSoukan kirjasto30 / 30Tapahtuma on peruttu';
 
   const tableRows = screen.queryAllByRole('row');
   expect(tableRows[4]).toHaveTextContent(cancelledOccurrenceRowText);
@@ -374,7 +381,7 @@ it('renders occurrences table and related stuff correctly', async () => {
     ).toBeInTheDocument();
   });
 
-  const rowText = `27.7.2020 ma12:00 – 13:00Soukan kirjasto30 / 30Näytä tiedot`;
+  const rowText = `27.7.2020 ma12:00 – 13:00en, fiSoukan kirjasto30 / 30Näytä tiedot`;
 
   const tableRows = screen.getAllByRole('row');
   expect(tableRows[8]).toHaveTextContent(rowText);
@@ -411,7 +418,7 @@ it('hides seats left column header when event has external enrolment', async () 
 
   const tableRows = screen.getAllByRole('row');
   expect(tableRows[1]).toHaveTextContent(
-    '15.7.2020 ke12:00 – 13:00Soukan kirjastoNäytä tiedot'
+    '15.7.2020 ke12:00 – 13:00en, fi, svSoukan kirjastoNäytä tiedot'
   );
 
   userEvent.click(

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -255,9 +255,9 @@ it('shows full events correctly in occurrences list', async () => {
   await waitForRequestsToComplete();
 
   const fullOccurrenceRowText1 =
-    '23.7.2020 to12:00 – 13:00en, fiSoukan kirjasto0 / 1Tapahtuma on täynnä';
+    '23.7.2020 to12:00 – 13:00englanti, suomien, fiSoukan kirjasto0 / 1Tapahtuma on täynnä';
   const fullOccurrenceRowText2 =
-    '29.7.2020 ke12:00 – 13:00en, fiSoukan kirjasto0 / 30Tapahtuma on täynnä';
+    '29.7.2020 ke12:00 – 13:00englanti, suomien, fiSoukan kirjasto0 / 30Tapahtuma on täynnä';
 
   const tableRows = screen.queryAllByRole('row');
   expect(tableRows[7]).toHaveTextContent(fullOccurrenceRowText1);
@@ -269,7 +269,7 @@ it('shows cancelled events correctly in list', async () => {
   await waitForRequestsToComplete();
 
   const cancelledOccurrenceRowText =
-    '20.7.2020 ma12:00 – 13:00en, fiSoukan kirjasto30 / 30Tapahtuma on peruttu';
+    '20.7.2020 ma12:00 – 13:00englanti, suomien, fiSoukan kirjasto30 / 30Tapahtuma on peruttu';
 
   const tableRows = screen.queryAllByRole('row');
   expect(tableRows[4]).toHaveTextContent(cancelledOccurrenceRowText);
@@ -381,7 +381,7 @@ it('renders occurrences table and related stuff correctly', async () => {
     ).toBeInTheDocument();
   });
 
-  const rowText = `27.7.2020 ma12:00 – 13:00en, fiSoukan kirjasto30 / 30Näytä tiedot`;
+  const rowText = `27.7.2020 ma12:00 – 13:00englanti, suomien, fiSoukan kirjasto30 / 30Näytä tiedot`;
 
   const tableRows = screen.getAllByRole('row');
   expect(tableRows[8]).toHaveTextContent(rowText);
@@ -418,7 +418,7 @@ it('hides seats left column header when event has external enrolment', async () 
 
   const tableRows = screen.getAllByRole('row');
   expect(tableRows[1]).toHaveTextContent(
-    '15.7.2020 ke12:00 – 13:00en, fi, svSoukan kirjastoNäytä tiedot'
+    '15.7.2020 ke12:00 – 13:00englanti, suomi, ruotsien, fi, svSoukan kirjastoNäytä tiedot'
   );
 
   userEvent.click(

--- a/src/domain/event/__tests__/enrolmentFormIntegration.test.tsx
+++ b/src/domain/event/__tests__/enrolmentFormIntegration.test.tsx
@@ -127,7 +127,7 @@ test('user can select single occurrences and enrol to it with enrolment form', a
   const rows = await screen.findAllByRole('row');
 
   expect(rows[1]).toHaveTextContent(
-    '25.9.2020 pe12:30 – 13:30en, fiKirjasto30 / 30Näytä tiedot'
+    '25.9.2020 pe12:30 – 13:30englanti, suomien, fiKirjasto30 / 30Näytä tiedot'
   );
 
   userEvent.click(
@@ -206,13 +206,13 @@ test('user can select multiple occurrences and enrol to them with enrolment form
   const rows = await screen.findAllByRole('row');
 
   expect(rows[1]).toHaveTextContent(
-    '25.9.2020 pe12:30 – 13:30en, fiKirjasto30 / 30Näytä tiedot'
+    '25.9.2020 pe12:30 – 13:30englanti, suomien, fiKirjasto30 / 30Näytä tiedot'
   );
   expect(rows[2]).toHaveTextContent(
-    '26.9.2020 la13:20 – 14:20en, fiKirjasto30 / 30Näytä tiedot'
+    '26.9.2020 la13:20 – 14:20englanti, suomien, fiKirjasto30 / 30Näytä tiedot'
   );
   expect(rows[3]).toHaveTextContent(
-    '26.9.2020 la14:20 – 15:20en, fiKirjasto30 / 30Näytä tiedot'
+    '26.9.2020 la14:20 – 15:20englanti, suomien, fiKirjasto30 / 30Näytä tiedot'
   );
 
   userEvent.click(

--- a/src/domain/event/__tests__/enrolmentFormIntegration.test.tsx
+++ b/src/domain/event/__tests__/enrolmentFormIntegration.test.tsx
@@ -127,7 +127,7 @@ test('user can select single occurrences and enrol to it with enrolment form', a
   const rows = await screen.findAllByRole('row');
 
   expect(rows[1]).toHaveTextContent(
-    '25.9.2020 pe12:30 – 13:30Kirjasto30 / 30Näytä tiedot'
+    '25.9.2020 pe12:30 – 13:30en, fiKirjasto30 / 30Näytä tiedot'
   );
 
   userEvent.click(
@@ -206,13 +206,13 @@ test('user can select multiple occurrences and enrol to them with enrolment form
   const rows = await screen.findAllByRole('row');
 
   expect(rows[1]).toHaveTextContent(
-    '25.9.2020 pe12:30 – 13:30Kirjasto30 / 30Näytä tiedot'
+    '25.9.2020 pe12:30 – 13:30en, fiKirjasto30 / 30Näytä tiedot'
   );
   expect(rows[2]).toHaveTextContent(
-    '26.9.2020 la13:20 – 14:20Kirjasto30 / 30Näytä tiedot'
+    '26.9.2020 la13:20 – 14:20en, fiKirjasto30 / 30Näytä tiedot'
   );
   expect(rows[3]).toHaveTextContent(
-    '26.9.2020 la14:20 – 15:20Kirjasto30 / 30Näytä tiedot'
+    '26.9.2020 la14:20 – 15:20en, fiKirjasto30 / 30Näytä tiedot'
   );
 
   userEvent.click(

--- a/src/domain/event/occurrences/OccurrencesTable.tsx
+++ b/src/domain/event/occurrences/OccurrencesTable.tsx
@@ -216,6 +216,12 @@ const OccurrenceEnrolmentTable: React.FC<{
       id: 'time',
     },
     {
+      Header: t('enrolment:occurrenceTable.columnLanguage'),
+      accessor: (row: OccurrenceFieldsFragment) =>
+        row.languages.edges.map((lang) => lang?.node?.id).join(', ') ?? '-',
+      id: 'languages',
+    },
+    {
       Header: t('enrolment:occurrenceTable.columnPlace'),
       accessor: (row: OccurrenceFieldsFragment) => {
         const placeId = row.placeId || eventLocationId;

--- a/src/domain/event/occurrences/OccurrencesTable.tsx
+++ b/src/domain/event/occurrences/OccurrencesTable.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'next-i18next';
 import React from 'react';
 
 import ErrorMessage from '../../../common/components/form/ErrorMessage';
+import SrOnly from '../../../common/components/SrOnly/SrOnly';
 import Table from '../../../common/components/table/Table';
 import {
   EventFieldsFragment,
@@ -212,13 +213,23 @@ const OccurrenceEnrolmentTable: React.FC<{
               locale
             );
       },
-
       id: 'time',
     },
     {
       Header: t('enrolment:occurrenceTable.columnLanguage'),
-      accessor: (row: OccurrenceFieldsFragment) =>
-        row.languages.edges.map((lang) => lang?.node?.id).join(', ') ?? '-',
+      accessor: (row: OccurrenceFieldsFragment) => (
+        <div>
+          <SrOnly>
+            {row.languages.edges
+              .map((lang) => t(`common:languages.${lang?.node?.id}`))
+              .join(', ') ?? '-'}
+          </SrOnly>
+          <span aria-hidden="true">
+            {row.languages.edges.map((lang) => lang?.node?.id).join(', ') ??
+              '-'}
+          </span>
+        </div>
+      ),
       id: 'languages',
     },
     {


### PR DESCRIPTION
## Description :sparkles:

- Add language column to occurrences table in event page

## Issues :bug:

### Closes :no_good_woman:

**[PT-1316](https://helsinkisolutionoffice.atlassian.net/browse/PT-1316):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:
<img width="1332" alt="Screenshot 2021-11-26 at 9 35 59" src="https://user-images.githubusercontent.com/15219142/143543985-47363a1f-a64c-478f-a164-bf8205b191ef.png">



## Additional notes :spiral_notepad:
