### PR TITLE
PT-1350 | Show date span in occurrence table for multi day occurrences

### DIFF
--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -78,6 +78,7 @@ const createFakeKeyword = (k: string) =>
 const occurrences = [
   {
     startTime: '2020-07-15T09:00:00+00:00',
+    endTime: '2020-07-17T09:00:00+00:00',
     placeId: data.placeId,
     id: data.placeId1,
     amountOfSeats: 30,
@@ -276,6 +277,25 @@ it('shows cancelled events correctly in list', async () => {
   expect(tableRows[4]).toHaveTextContent(cancelledOccurrenceRowText);
 });
 
+it('renders upcoming occurrencec correctly', async () => {
+  renderComponent();
+  await waitForRequestsToComplete();
+
+  const tableRows = screen.queryAllByRole('row');
+  expect(tableRows[1]).toHaveTextContent(
+    '15.7.2020 – 17.7.2020englanti, suomi, ruotsien, fi, svSoukan kirjasto30 / 30Näytä tiedot'
+  );
+  expect(tableRows[2]).toHaveTextContent(
+    '16.7.2020 to12:00 – 13:00suomifiSoukan kirjasto30 / 30Näytä tiedot'
+  );
+  expect(tableRows[3]).toHaveTextContent(
+    '19.7.2020 su12:00 – 13:00englanti, suomien, fiSoukan kirjasto30 / 30Näytä tiedot'
+  );
+  expect(tableRows[5]).toHaveTextContent(
+    '21.7.2020 ti12:00 – 13:00englanti, suomien, fiSoukan kirjasto30 / 30Näytä tiedot'
+  );
+});
+
 it('renders page and event information correctly', async () => {
   renderComponent();
   await waitForRequestsToComplete();
@@ -418,8 +438,10 @@ it('hides seats left column header when event has external enrolment', async () 
   ).not.toBeInTheDocument();
 
   const tableRows = screen.getAllByRole('row');
+
+  // shows multi day occurrence correctly
   expect(tableRows[1]).toHaveTextContent(
-    '15.7.2020 ke12:00 – 13:00englanti, suomi, ruotsien, fi, svSoukan kirjastoNäytä tiedot'
+    '15.7.2020 – 17.7.2020englanti, suomi, ruotsien, fi, svSoukan kirjastoNäytä tiedot'
   );
 
   userEvent.click(

--- a/src/domain/event/occurrences/OccurrencesTable.tsx
+++ b/src/domain/event/occurrences/OccurrencesTable.tsx
@@ -18,7 +18,11 @@ import {
 } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import formatTimeRange from '../../../utils/formatTimeRange';
-import { DATE_FORMAT, formatLocalizedDate } from '../../../utils/time/format';
+import {
+  DATE_FORMAT,
+  formatDateRange,
+  formatLocalizedDate,
+} from '../../../utils/time/format';
 import { translateValue } from '../../../utils/translateUtils';
 import { skipFalsyType } from '../../../utils/typescript.utils';
 import { ENROLMENT_ERRORS } from '../../enrolment/constants';
@@ -194,11 +198,13 @@ const OccurrenceEnrolmentTable: React.FC<{
               )}
             />
           )}
-          {formatLocalizedDate(
-            new Date(row.startTime),
-            `${DATE_FORMAT} eeeeee`,
-            locale
-          )}
+          {isMultidayOccurrence(row)
+            ? formatDateRange(new Date(row.startTime), new Date(row.endTime))
+            : formatLocalizedDate(
+                new Date(row.startTime),
+                `${DATE_FORMAT} eeeeee`,
+                locale
+              )}
         </div>
       ),
       id: 'date',


### PR DESCRIPTION
## Description :sparkles:

-  Show date span in occurrence table for multi day occurrences

## Issues :bug:

### Closes :no_good_woman:

**[PT-1350](https://helsinkisolutionoffice.atlassian.net/browse/PT-1350):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

<img width="1073" alt="Screenshot 2021-11-26 at 12 38 47" src="https://user-images.githubusercontent.com/15219142/143569294-7d5b8ba9-c50e-4041-b81e-d04719e1a86d.png">

## Additional notes :spiral_notepad:
