### PR TITLE
fix: event card should show upcoming occurrences only, no matter the enrolment time

### DIFF
--- a/src/domain/event/eventCard/EventCard.tsx
+++ b/src/domain/event/eventCard/EventCard.tsx
@@ -107,6 +107,7 @@ const EventTime: React.FC<{
         cancelled: false,
         pEvent: event.pEvent.id,
         orderBy: 'startTime',
+        upcoming: true,
       },
     });
 

--- a/src/domain/events/__tests__/EventCard.test.tsx
+++ b/src/domain/events/__tests__/EventCard.test.tsx
@@ -1,4 +1,5 @@
 import { MockedResponse } from '@apollo/client/testing';
+import { advanceTo } from 'jest-date-mock';
 import React from 'react';
 
 import * as graphql from '../../../generated/graphql';
@@ -55,6 +56,7 @@ it('renders a button to view multiple occurrences when event has them', async ()
           cancelled: false,
           pEvent: event.pEvent.id,
           orderBy: 'startTime',
+          upcoming: true,
         },
       },
       result: {
@@ -159,6 +161,7 @@ it('renders multiday occurrence time correctly', async () => {
           cancelled: false,
           pEvent: event.pEvent.id,
           orderBy: 'startTime',
+          upcoming: true,
         },
       },
       result: {
@@ -189,4 +192,21 @@ it('renders multiday occurrence time correctly', async () => {
   screen.getByText('22.11.2020 – 25.11.2020');
 
   expect(container).toMatchSnapshot();
+});
+
+it('renders date as tomorrow and ignores enrolment days', async () => {
+  advanceTo(new Date(2020, 8, 19));
+  const occurrences = fakeOccurrences(3, [
+    { startTime: new Date(2020, 8, 20, 10, 30).toISOString() },
+  ]);
+  const event = fakeEvent({
+    pEvent: fakePEvent({
+      nextOccurrence: occurrences,
+      enrolmentEndDays: 10,
+    }),
+  });
+  render(<EventCard event={event} link={'#'} />);
+  await waitFor(() => {
+    expect(screen.getByText(/huomenna klo 10:30/i)).toBeInTheDocument();
+  });
 });

--- a/src/domain/occurrences/query.ts
+++ b/src/domain/occurrences/query.ts
@@ -9,6 +9,8 @@ export const QUERY_OCCURRENCES = gql`
     $cancelled: Boolean
     $pEvent: ID
     $orderBy: [String]
+    $upcoming: Boolean
+    $enrollable: Boolean
   ) {
     occurrences(
       after: $after
@@ -18,6 +20,8 @@ export const QUERY_OCCURRENCES = gql`
       cancelled: $cancelled
       pEvent: $pEvent
       orderBy: $orderBy
+      upcoming: $upcoming
+      enrollable: $enrollable
     ) {
       pageInfo {
         hasNextPage

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -1093,12 +1093,14 @@ export type PalvelutarjotinEventNode = Node & {
 
 
 export type PalvelutarjotinEventNodeOccurrencesArgs = {
+  orderBy?: Maybe<Array<Maybe<Scalars['String']>>>;
   offset?: Maybe<Scalars['Int']>;
   before?: Maybe<Scalars['String']>;
   after?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   upcoming?: Maybe<Scalars['Boolean']>;
+  enrollable?: Maybe<Scalars['Boolean']>;
   date?: Maybe<Scalars['Date']>;
   time?: Maybe<Scalars['Time']>;
   pEvent?: Maybe<Scalars['ID']>;
@@ -1178,6 +1180,7 @@ export type PersonNodeOccurrencesArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   upcoming?: Maybe<Scalars['Boolean']>;
+  enrollable?: Maybe<Scalars['Boolean']>;
   date?: Maybe<Scalars['Date']>;
   time?: Maybe<Scalars['Time']>;
   pEvent?: Maybe<Scalars['ID']>;
@@ -1377,6 +1380,7 @@ export type QueryOccurrencesArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   upcoming?: Maybe<Scalars['Boolean']>;
+  enrollable?: Maybe<Scalars['Boolean']>;
   date?: Maybe<Scalars['Date']>;
   time?: Maybe<Scalars['Time']>;
   pEvent?: Maybe<Scalars['ID']>;
@@ -1676,6 +1680,7 @@ export type StudyGroupNodeOccurrencesArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   upcoming?: Maybe<Scalars['Boolean']>;
+  enrollable?: Maybe<Scalars['Boolean']>;
   date?: Maybe<Scalars['Date']>;
   time?: Maybe<Scalars['Time']>;
   pEvent?: Maybe<Scalars['ID']>;
@@ -2138,6 +2143,7 @@ export type OccurrencesQueryVariables = Exact<{
   cancelled?: Maybe<Scalars['Boolean']>;
   pEvent?: Maybe<Scalars['ID']>;
   orderBy?: Maybe<Array<Maybe<Scalars['String']>> | Maybe<Scalars['String']>>;
+  upcoming?: Maybe<Scalars['Boolean']>;
 }>;
 
 
@@ -2997,7 +3003,7 @@ export type OccurrenceQueryHookResult = ReturnType<typeof useOccurrenceQuery>;
 export type OccurrenceLazyQueryHookResult = ReturnType<typeof useOccurrenceLazyQuery>;
 export type OccurrenceQueryResult = Apollo.QueryResult<OccurrenceQuery, OccurrenceQueryVariables>;
 export const OccurrencesDocument = gql`
-    query Occurrences($after: String, $before: String, $first: Int, $last: Int, $cancelled: Boolean, $pEvent: ID, $orderBy: [String]) {
+    query Occurrences($after: String, $before: String, $first: Int, $last: Int, $cancelled: Boolean, $pEvent: ID, $orderBy: [String], $upcoming: Boolean) {
   occurrences(
     after: $after
     before: $before
@@ -3006,6 +3012,7 @@ export const OccurrencesDocument = gql`
     cancelled: $cancelled
     pEvent: $pEvent
     orderBy: $orderBy
+    upcoming: $upcoming
   ) {
     pageInfo {
       hasNextPage
@@ -3042,6 +3049,7 @@ export const OccurrencesDocument = gql`
  *      cancelled: // value for 'cancelled'
  *      pEvent: // value for 'pEvent'
  *      orderBy: // value for 'orderBy'
+ *      upcoming: // value for 'upcoming'
  *   },
  * });
  */

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -142,6 +142,7 @@ export const fakeEnrolment = (
   overrides?: Partial<EnrolmentNode>
 ): EnrolmentNode => ({
   enrolmentTime: '2020-08-18T06:37:40.755109+00:00',
+  updatedAt: '2020-08-18T06:37:40.755109+00:00',
   id: faker.datatype.uuid(),
   occurrence: fakeOccurrence(),
   studyGroup: fakeStudyGroup(),
@@ -149,7 +150,6 @@ export const fakeEnrolment = (
   __typename: 'EnrolmentNode',
   person: fakePerson(),
   status: EnrolmentStatus.Approved,
-  updatedAt: '',
   ...overrides,
 });
 


### PR DESCRIPTION
PT-1310. NOTE: this needs https://github.com/City-of-Helsinki/palvelutarjotin/pull/229 to be merged.