### PR TITLE
PT-1358 | Disallow enrolling when it has not begun

### DIFF
--- a/public/locales/en/event.json
+++ b/public/locales/en/event.json
@@ -34,7 +34,8 @@
     "showAllLocationEvents": "Show all events of this location",
     "labelStartDateFilter": "Start date of occurrences filter",
     "labelEndDateFilter": "End date of occurrences filter",
-    "eventIsFree": "Free"
+    "eventIsFree": "Free",
+    "enrolmentStartText": "EN: Ilmoittautuminen aukeaa {{date}}"
   },
   "location": {
     "labelLocation": "Default venue",

--- a/public/locales/en/event.json
+++ b/public/locales/en/event.json
@@ -35,7 +35,7 @@
     "labelStartDateFilter": "Start date of occurrences filter",
     "labelEndDateFilter": "End date of occurrences filter",
     "eventIsFree": "Free",
-    "enrolmentStartText": "EN: Ilmoittautuminen aukeaa {{date}}"
+    "enrolmentStartsAt": "Enrolments start {{date}} at {{time}}"
   },
   "location": {
     "labelLocation": "Default venue",

--- a/public/locales/fi/event.json
+++ b/public/locales/fi/event.json
@@ -35,7 +35,7 @@
     "labelStartDateFilter": "Tapahtuma-aikojen rajauksen alkupäivä",
     "labelEndDateFilter": "Tapahtuma-aikojen rajauksen loppupäivä",
     "eventIsFree": "Maksuton",
-    "enrolmentStartText": "Ilmoittautuminen aukeaa {{date}}"
+    "enrolmentStartsAt": "Ilmoittautuminen alkaa {{date}} klo {{time}}"
   },
   "location": {
     "labelLocation": "Oletustapahtumapaikka",

--- a/public/locales/fi/event.json
+++ b/public/locales/fi/event.json
@@ -34,7 +34,8 @@
     "showAllLocationEvents": "Näytä paikan kaikki tapahtumat",
     "labelStartDateFilter": "Tapahtuma-aikojen rajauksen alkupäivä",
     "labelEndDateFilter": "Tapahtuma-aikojen rajauksen loppupäivä",
-    "eventIsFree": "Maksuton"
+    "eventIsFree": "Maksuton",
+    "enrolmentStartText": "Ilmoittautuminen aukeaa {{date}}"
   },
   "location": {
     "labelLocation": "Oletustapahtumapaikka",

--- a/public/locales/sv/event.json
+++ b/public/locales/sv/event.json
@@ -34,7 +34,8 @@
     "showAllLocationEvents": "Visa alla händelser på den här platsen",
     "labelStartDateFilter": "Startdatum för händelsefilter",
     "labelEndDateFilter": "Slutdatum för händelsefilter",
-    "eventIsFree": "Fri"
+    "eventIsFree": "Fri",
+    "enrolmentStartText": "SV: Ilmoittautuminen aukeaa {{date}}"
   },
   "location": {
     "labelLocation": "Standard venue",

--- a/public/locales/sv/event.json
+++ b/public/locales/sv/event.json
@@ -35,7 +35,7 @@
     "labelStartDateFilter": "Startdatum för händelsefilter",
     "labelEndDateFilter": "Slutdatum för händelsefilter",
     "eventIsFree": "Fri",
-    "enrolmentStartText": "SV: Ilmoittautuminen aukeaa {{date}}"
+    "enrolmentStartsAt": "Registreringen börjar {{date}} kl. {{time}}"
   },
   "location": {
     "labelLocation": "Standard venue",

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -560,8 +560,20 @@ it('opens expanded area with enrolment button when clicked', async () => {
 });
 
 it('expanded area does not have an enrolment button if enrollment has not yet begun', async () => {
-  advanceTo(new Date(2020, 6, 12)); // Before enrolmentStart (2020-07-13T06:00:00+00:00)
-  renderComponent();
+  advanceTo(new Date(2020, 6, 10)); // Before enrolmentStart (2020-07-13T06:00:00+00:00)
+  renderComponent({
+    mocks: [
+      createEventQueryMockIncludeLanguageAndAudience({
+        ...eventData,
+        id: eventData.id as string,
+        pEvent: fakePEvent({
+          ...eventData.pEvent,
+          neededOccurrences: 1,
+        }),
+      }),
+      ...apolloMocks.slice(1),
+    ],
+  });
   await waitForRequestsToComplete();
 
   const occurrenceRow = within(screen.getAllByRole('row')[8]);

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -581,7 +581,7 @@ it('expanded area does not have an enrolment button if enrollment has not yet be
       name: 'Ilmoittaudu',
     })
   ).toEqual(null);
-  expect(screen.queryByText(/Ilmoittautuminen aukeaa/)).toBeInTheDocument();
+  expect(screen.queryByText(/Ilmoittautuminen alkaa/)).toBeInTheDocument();
 });
 
 it('filters occurrence list correctly when sate filters are selected', async () => {

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -224,8 +224,6 @@ const apolloMocks = [
   ]),
 ];
 
-advanceTo(new Date(2020, 6, 14));
-
 const renderComponent = (options?: CustomRenderOptions) => {
   return render(<EventPage />, {
     mocks: apolloMocks,
@@ -250,6 +248,10 @@ beforeAll(() => {
 
 afterAll(() => {
   jest.setTimeout(5000);
+});
+
+beforeEach(() => {
+  advanceTo(new Date(2020, 6, 14));
 });
 
 it('shows full events correctly in occurrences list', async () => {
@@ -555,6 +557,31 @@ it('opens expanded area with enrolment button when clicked', async () => {
   ].forEach((amenity) => {
     expect(screen.queryByText(amenity)).toBeInTheDocument();
   });
+});
+
+it('expanded area does not have an enrolment button if enrollment has not yet begun', async () => {
+  advanceTo(new Date(2020, 6, 12)); // Before enrolmentStart (2020-07-13T06:00:00+00:00)
+  renderComponent();
+  await waitForRequestsToComplete();
+
+  const occurrenceRow = within(screen.getAllByRole('row')[8]);
+
+  userEvent.click(
+    occurrenceRow.getByRole('button', {
+      name: occurrenceMessages.buttonShowDetails,
+    })
+  );
+
+  await waitFor(() => {
+    expect(screen.queryByText(data.venueDescription)).toBeInTheDocument();
+  });
+
+  expect(
+    screen.queryByRole('button', {
+      name: 'Ilmoittaudu',
+    })
+  ).toEqual(null);
+  expect(screen.queryByText(/Ilmoittautuminen aukeaa/)).toBeInTheDocument();
 });
 
 it('filters occurrence list correctly when sate filters are selected', async () => {

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -580,7 +580,7 @@ it('expanded area does not have an enrolment button if enrollment has not yet be
     screen.queryByRole('button', {
       name: 'Ilmoittaudu',
     })
-  ).toEqual(null);
+  ).not.toBeInTheDocument();
   expect(screen.queryByText(/Ilmoittautuminen alkaa/)).toBeInTheDocument();
 });
 

--- a/src/domain/event/occurrences/EnrolmentButtonCell.tsx
+++ b/src/domain/event/occurrences/EnrolmentButtonCell.tsx
@@ -3,25 +3,19 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import ExternalLink from '../../../common/components/externalLink/ExternalLink';
-import ErrorMessage from '../../../common/components/form/ErrorMessage';
 import {
   EventFieldsFragment,
   OccurrenceFieldsFragment,
 } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import { formatIntoDate, formatIntoTime } from '../../../utils/time/format';
-import { translateValue } from '../../../utils/translateUtils';
-import { ENROLMENT_ERRORS } from '../../enrolment/constants';
-import {
-  isEnrolmentClosed,
-  hasOccurrenceSpace,
-  isOccurrenceCancelled,
-  isEnrolmentStarted,
-} from '../../occurrence/utils';
+import { isEnrolmentStarted } from '../../occurrence/utils';
 import { EnrolmentType } from '../constants';
 import { getEventFields, getEnrolmentType } from '../utils';
+import EnrolmentError from './EnrolmentError';
 import styles from './occurrences.module.scss';
 import { enrolButtonColumnWidth } from './OccurrencesTable';
+import { getEnrolmentError } from './utils';
 
 type Props = {
   event: EventFieldsFragment;
@@ -51,7 +45,6 @@ const EnrolmentButtonCell: React.FC<Props> = (props) => {
     deselectOccurrence,
     selectOccurrence,
     getMultipleOccurrencesButtonText,
-    getEnrolmentError,
   } = useEnrolmentButtonUtils(props);
 
   if (isNotEnrollable) {
@@ -61,11 +54,7 @@ const EnrolmentButtonCell: React.FC<Props> = (props) => {
   // Show error message if enrolment is not available
   const error = getEnrolmentError(value, event);
   if (error) {
-    return (
-      <ErrorMessage>
-        {translateValue('enrolment:errors.label.', error, t)}
-      </ErrorMessage>
-    );
+    return <EnrolmentError error={error} />;
   }
 
   if (event.pEvent.enrolmentStart && enrolmentHasNotStarted) {
@@ -132,20 +121,6 @@ const useEnrolmentButtonUtils = ({
   const enrolmentHasNotStarted = !isEnrolmentStarted(event);
   const externalEnrolmentUrl = event.pEvent.externalEnrolmentUrl ?? '';
   const hasExternalEnrolment = !!event.pEvent.externalEnrolmentUrl;
-
-  const getEnrolmentError = (
-    occurrence: OccurrenceFieldsFragment,
-    event: EventFieldsFragment
-  ) => {
-    if (isEnrolmentClosed(occurrence, event))
-      return ENROLMENT_ERRORS.ENROLMENT_CLOSED_ERROR;
-    if (!hasOccurrenceSpace(occurrence))
-      return ENROLMENT_ERRORS.NOT_ENOUGH_CAPACITY_ERROR;
-    if (isOccurrenceCancelled(occurrence)) {
-      return ENROLMENT_ERRORS.ENROLMENT_CANCDELLED_ERROR;
-    }
-    return null;
-  };
 
   const selectionDisabled =
     selectedOccurrences?.length === neededOccurrences &&

--- a/src/domain/event/occurrences/EnrolmentError.tsx
+++ b/src/domain/event/occurrences/EnrolmentError.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from 'next-i18next';
+
+import ErrorMessage from '../../../common/components/form/ErrorMessage';
+import { translateValue } from '../../../utils/translateUtils';
+import { ENROLMENT_ERRORS } from '../../enrolment/constants';
+
+interface Props {
+  error: ENROLMENT_ERRORS;
+}
+
+const EnrolmentError = ({ error }: Props): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <ErrorMessage>
+      {translateValue('enrolment:errors.label.', error, t)}
+    </ErrorMessage>
+  );
+};
+
+export default EnrolmentError;

--- a/src/domain/event/occurrences/OccurrenceEnrolmentButton.tsx
+++ b/src/domain/event/occurrences/OccurrenceEnrolmentButton.tsx
@@ -40,7 +40,11 @@ const OccurrenceEnrolmentButton: React.FC<Props> = ({
   const enrolmentError = getEnrolmentError(occurrence, event);
 
   if (enrolmentError) {
-    return <EnrolmentError error={enrolmentError} />;
+    return (
+      <div className={styles.enrolmentNotice}>
+        <EnrolmentError error={enrolmentError} />
+      </div>
+    );
   }
 
   if (externalEnrolmentUrl) {
@@ -56,7 +60,7 @@ const OccurrenceEnrolmentButton: React.FC<Props> = ({
 
   if (neededOccurrences === 1 && !isEnrolmentOpen) {
     return (
-      <div className={styles.enrolmentStartNotice}>
+      <div className={styles.enrolmentNotice}>
         {t('event:occurrenceList.enrolmentStartsAt', {
           date: formatIntoDate(new Date(enrolmentStart)),
           time: formatIntoTime(new Date(enrolmentStart)),

--- a/src/domain/event/occurrences/OccurrenceEnrolmentButton.tsx
+++ b/src/domain/event/occurrences/OccurrenceEnrolmentButton.tsx
@@ -1,0 +1,100 @@
+import classNames from 'classnames';
+import { IconAngleUp, Button } from 'hds-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import ExternalLink from '../../../common/components/externalLink/ExternalLink';
+import {
+  EventFieldsFragment,
+  OccurrenceFieldsFragment,
+} from '../../../generated/graphql';
+import { formatIntoDate, formatIntoTime } from '../../../utils/time/format';
+import { isEnrolmentStarted } from '../../occurrence/utils';
+import EnrolmentError from './EnrolmentError';
+import styles from './occurrences.module.scss';
+import { enrolButtonColumnWidth } from './OccurrencesTable';
+import { getEnrolmentError } from './utils';
+
+interface Props {
+  event: EventFieldsFragment;
+  occurrence: OccurrenceFieldsFragment;
+  showEnrolmentForm: boolean;
+  toggleForm: () => void;
+  enrolButtonRef: React.Ref<HTMLButtonElement>;
+}
+
+const OccurrenceEnrolmentButton: React.FC<Props> = ({
+  event,
+  occurrence,
+  showEnrolmentForm,
+  toggleForm,
+  enrolButtonRef,
+}) => {
+  const { t } = useTranslation();
+
+  const externalEnrolmentUrl = event.pEvent.externalEnrolmentUrl;
+  const enrolmentStart = event.pEvent.enrolmentStart;
+  const isEnrolmentOpen = isEnrolmentStarted(event);
+  const autoAcceptance = event.pEvent?.autoAcceptance;
+  const neededOccurrences = event.pEvent.neededOccurrences;
+  const enrolmentError = getEnrolmentError(occurrence, event);
+
+  if (enrolmentError) {
+    return <EnrolmentError error={enrolmentError} />;
+  }
+
+  if (externalEnrolmentUrl) {
+    return (
+      <ExternalLink
+        href={externalEnrolmentUrl}
+        className={styles.externalEnrolmentLink}
+      >
+        {t('occurrence:labelExternalEnrolmentLink')}
+      </ExternalLink>
+    );
+  }
+
+  if (neededOccurrences === 1 && !isEnrolmentOpen) {
+    return (
+      <div className={styles.enrolmentStartNotice}>
+        {t('event:occurrenceList.enrolmentStartsAt', {
+          date: formatIntoDate(new Date(enrolmentStart)),
+          time: formatIntoTime(new Date(enrolmentStart)),
+        })}
+      </div>
+    );
+  }
+
+  if (neededOccurrences === 1) {
+    return (
+      <Button
+        className={classNames(styles.expandEnrolButton, {
+          [styles.enquiryButton]: !showEnrolmentForm && !autoAcceptance,
+          [styles.enrolButton]: autoAcceptance,
+        })}
+        style={{ width: enrolButtonColumnWidth }}
+        size="small"
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        variant={showEnrolmentForm ? ('supplementary' as any) : 'primary'}
+        iconRight={showEnrolmentForm ? <IconAngleUp /> : null}
+        onClick={() => toggleForm()}
+        aria-expanded={showEnrolmentForm}
+        ref={enrolButtonRef}
+      >
+        {showEnrolmentForm
+          ? t('enrolment:enrolmentForm.buttonCancelAndCloseForm')
+          : t(
+              `event:occurrenceList.${
+                autoAcceptance
+                  ? 'enrolOccurrenceButton'
+                  : 'reservationEnquiryButton'
+              }`
+            )}
+      </Button>
+    );
+  }
+
+  return null;
+};
+
+export default OccurrenceEnrolmentButton;

--- a/src/domain/event/occurrences/OccurrenceInfo.tsx
+++ b/src/domain/event/occurrences/OccurrenceInfo.tsx
@@ -1,6 +1,6 @@
 import { useApolloClient } from '@apollo/client';
 import classNames from 'classnames';
-import { isSameDay } from 'date-fns';
+import isSameDay from 'date-fns/isSameDay';
 import {
   IconAngleUp,
   Button,

--- a/src/domain/event/occurrences/OccurrenceInfo.tsx
+++ b/src/domain/event/occurrences/OccurrenceInfo.tsx
@@ -26,7 +26,6 @@ import {
   formatIntoTime,
   formatLocalizedDate,
   DATE_FORMAT,
-  formatIntoDateTime,
 } from '../../../utils/time/format';
 import OccurrenceGroupInfo from '../../occurrence/occurrenceGroupInfo/OccurrenceGroupInfo';
 import OccurrenceGroupLanguageInfo from '../../occurrence/occurrenceGroupInfo/OccurrenceGroupLanguageInfo';
@@ -229,8 +228,9 @@ const OccurrenceInfo: React.FC<{
         </Button>
       ) : (
         <div className={styles.enrolmentStartNotice}>
-          {t('event:occurrenceList.enrolmentStartText', {
-            date: formatIntoDateTime(new Date(enrolmentStart)),
+          {t('event:occurrenceList.enrolmentStartsAt', {
+            date: formatIntoDate(new Date(enrolmentStart)),
+            time: formatIntoTime(new Date(enrolmentStart)),
           })}
         </div>
       )}

--- a/src/domain/event/occurrences/OccurrenceInfo.tsx
+++ b/src/domain/event/occurrences/OccurrenceInfo.tsx
@@ -1,19 +1,11 @@
 import { useApolloClient } from '@apollo/client';
-import classNames from 'classnames';
 import isSameDay from 'date-fns/isSameDay';
-import {
-  IconAngleUp,
-  Button,
-  IconLocation,
-  IconClock,
-  IconGlyphEuro,
-} from 'hds-react';
+import { Button, IconLocation, IconClock, IconGlyphEuro } from 'hds-react';
 import { capitalize } from 'lodash';
 import { useTranslation } from 'next-i18next';
 import Link from 'next/link';
 import React from 'react';
 
-import ExternalLink from '../../../common/components/externalLink/ExternalLink';
 import {
   OccurrenceFieldsFragment,
   EventFieldsFragment,
@@ -29,14 +21,13 @@ import {
 } from '../../../utils/time/format';
 import OccurrenceGroupInfo from '../../occurrence/occurrenceGroupInfo/OccurrenceGroupInfo';
 import OccurrenceGroupLanguageInfo from '../../occurrence/occurrenceGroupInfo/OccurrenceGroupLanguageInfo';
-import { isEnrolmentStarted } from '../../occurrence/utils';
 import PlaceInfo, { PlaceInfoLinks } from '../../place/placeInfo/PlaceInfo';
 import CalendarButton from '../calendarButton/CalendarButton';
 import { EnrolmentType } from '../constants';
 import { getEnrolmentType } from '../utils';
 import EnrolmentFormSection from './EnrolmentFormSection';
+import OccurrenceEnrolmentButton from './OccurrenceEnrolmentButton';
 import styles from './occurrences.module.scss';
-import { enrolButtonColumnWidth } from './OccurrencesTable';
 
 const OccurrenceInfo: React.FC<{
   occurrence: OccurrenceFieldsFragment;
@@ -57,12 +48,6 @@ const OccurrenceInfo: React.FC<{
   const priceDescription = offer?.description?.[locale];
   const isFree = offer?.isFree ?? !price;
   const priceInfoUrl = offer?.infoUrl?.[locale];
-  const neededOccurrences = event.pEvent.neededOccurrences;
-  const autoAcceptance = event.pEvent?.autoAcceptance;
-  const externalEnrolmentUrl = event.pEvent.externalEnrolmentUrl ?? '';
-  const hasExternalEnrolment = !!event.pEvent.externalEnrolmentUrl;
-  const enrolmentStart = event.pEvent.enrolmentStart;
-  const isEnrolmentOpen = isEnrolmentStarted(event);
 
   React.useEffect(() => {
     if (showEnrolmentForm) {
@@ -194,47 +179,13 @@ const OccurrenceInfo: React.FC<{
         language={locale}
         variant="button"
       />
-      {hasExternalEnrolment && (
-        <ExternalLink
-          href={externalEnrolmentUrl}
-          className={styles.externalEnrolmentLink}
-        >
-          {t('occurrence:labelExternalEnrolmentLink')}
-        </ExternalLink>
-      )}
-      {!hasExternalEnrolment && neededOccurrences === 1 && !isEnrolmentOpen ? (
-        <Button
-          className={classNames(styles.expandEnrolButton, {
-            [styles.enquiryButton]: !showEnrolmentForm && !autoAcceptance,
-            [styles.enrolButton]: autoAcceptance,
-          })}
-          style={{ width: enrolButtonColumnWidth }}
-          size="small"
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          variant={showEnrolmentForm ? ('supplementary' as any) : 'primary'}
-          iconRight={showEnrolmentForm ? <IconAngleUp /> : null}
-          onClick={() => toggleForm()}
-          aria-expanded={showEnrolmentForm}
-          ref={enrolButtonRef}
-        >
-          {showEnrolmentForm
-            ? t('enrolment:enrolmentForm.buttonCancelAndCloseForm')
-            : t(
-                `event:occurrenceList.${
-                  autoAcceptance
-                    ? 'enrolOccurrenceButton'
-                    : 'reservationEnquiryButton'
-                }`
-              )}
-        </Button>
-      ) : (
-        <div className={styles.enrolmentStartNotice}>
-          {t('event:occurrenceList.enrolmentStartsAt', {
-            date: formatIntoDate(new Date(enrolmentStart)),
-            time: formatIntoTime(new Date(enrolmentStart)),
-          })}
-        </div>
-      )}
+      <OccurrenceEnrolmentButton
+        event={event}
+        occurrence={occurrence}
+        showEnrolmentForm={showEnrolmentForm}
+        enrolButtonRef={enrolButtonRef}
+        toggleForm={toggleForm}
+      />
     </>
   );
 

--- a/src/domain/event/occurrences/OccurrenceInfo.tsx
+++ b/src/domain/event/occurrences/OccurrenceInfo.tsx
@@ -1,6 +1,6 @@
 import { useApolloClient } from '@apollo/client';
 import classNames from 'classnames';
-import { isSameDay } from 'date-fns';
+import { isSameDay, isAfter } from 'date-fns';
 import {
   IconAngleUp,
   Button,
@@ -26,6 +26,7 @@ import {
   formatIntoTime,
   formatLocalizedDate,
   DATE_FORMAT,
+  formatIntoDateTime,
 } from '../../../utils/time/format';
 import OccurrenceGroupInfo from '../../occurrence/occurrenceGroupInfo/OccurrenceGroupInfo';
 import OccurrenceGroupLanguageInfo from '../../occurrence/occurrenceGroupInfo/OccurrenceGroupLanguageInfo';
@@ -60,6 +61,8 @@ const OccurrenceInfo: React.FC<{
   const autoAcceptance = event.pEvent?.autoAcceptance;
   const externalEnrolmentUrl = event.pEvent.externalEnrolmentUrl ?? '';
   const hasExternalEnrolment = !!event.pEvent.externalEnrolmentUrl;
+  const enrolmentStart = event.pEvent.enrolmentStart;
+  const isEnrollmentOpen = isAfter(new Date(enrolmentStart), new Date());
 
   React.useEffect(() => {
     if (showEnrolmentForm) {
@@ -191,14 +194,15 @@ const OccurrenceInfo: React.FC<{
         language={locale}
         variant="button"
       />
-      {hasExternalEnrolment ? (
+      {hasExternalEnrolment && (
         <ExternalLink
           href={externalEnrolmentUrl}
           className={styles.externalEnrolmentLink}
         >
           {t('occurrence:labelExternalEnrolmentLink')}
         </ExternalLink>
-      ) : neededOccurrences === 1 ? (
+      )}
+      {!hasExternalEnrolment && neededOccurrences === 1 && !isEnrollmentOpen ? (
         <Button
           className={classNames(styles.expandEnrolButton, {
             [styles.enquiryButton]: !showEnrolmentForm && !autoAcceptance,
@@ -223,7 +227,13 @@ const OccurrenceInfo: React.FC<{
                 }`
               )}
         </Button>
-      ) : null}
+      ) : (
+        <div className={styles.enrolmentStartNotice}>
+          {t('event:occurrenceList.enrolmentStartText', {
+            date: formatIntoDateTime(new Date(enrolmentStart)),
+          })}
+        </div>
+      )}
     </>
   );
 

--- a/src/domain/event/occurrences/OccurrenceInfo.tsx
+++ b/src/domain/event/occurrences/OccurrenceInfo.tsx
@@ -1,6 +1,6 @@
 import { useApolloClient } from '@apollo/client';
 import classNames from 'classnames';
-import { isSameDay, isAfter } from 'date-fns';
+import { isSameDay } from 'date-fns';
 import {
   IconAngleUp,
   Button,
@@ -29,6 +29,7 @@ import {
 } from '../../../utils/time/format';
 import OccurrenceGroupInfo from '../../occurrence/occurrenceGroupInfo/OccurrenceGroupInfo';
 import OccurrenceGroupLanguageInfo from '../../occurrence/occurrenceGroupInfo/OccurrenceGroupLanguageInfo';
+import { isEnrolmentStarted } from '../../occurrence/utils';
 import PlaceInfo, { PlaceInfoLinks } from '../../place/placeInfo/PlaceInfo';
 import CalendarButton from '../calendarButton/CalendarButton';
 import { EnrolmentType } from '../constants';
@@ -61,7 +62,7 @@ const OccurrenceInfo: React.FC<{
   const externalEnrolmentUrl = event.pEvent.externalEnrolmentUrl ?? '';
   const hasExternalEnrolment = !!event.pEvent.externalEnrolmentUrl;
   const enrolmentStart = event.pEvent.enrolmentStart;
-  const isEnrolmentOpen = isAfter(new Date(enrolmentStart), new Date());
+  const isEnrolmentOpen = isEnrolmentStarted(event);
 
   React.useEffect(() => {
     if (showEnrolmentForm) {

--- a/src/domain/event/occurrences/OccurrenceInfo.tsx
+++ b/src/domain/event/occurrences/OccurrenceInfo.tsx
@@ -61,7 +61,7 @@ const OccurrenceInfo: React.FC<{
   const externalEnrolmentUrl = event.pEvent.externalEnrolmentUrl ?? '';
   const hasExternalEnrolment = !!event.pEvent.externalEnrolmentUrl;
   const enrolmentStart = event.pEvent.enrolmentStart;
-  const isEnrollmentOpen = isAfter(new Date(enrolmentStart), new Date());
+  const isEnrolmentOpen = isAfter(new Date(enrolmentStart), new Date());
 
   React.useEffect(() => {
     if (showEnrolmentForm) {
@@ -201,7 +201,7 @@ const OccurrenceInfo: React.FC<{
           {t('occurrence:labelExternalEnrolmentLink')}
         </ExternalLink>
       )}
-      {!hasExternalEnrolment && neededOccurrences === 1 && !isEnrollmentOpen ? (
+      {!hasExternalEnrolment && neededOccurrences === 1 && !isEnrolmentOpen ? (
         <Button
           className={classNames(styles.expandEnrolButton, {
             [styles.enquiryButton]: !showEnrolmentForm && !autoAcceptance,

--- a/src/domain/event/occurrences/OccurrencesTable.tsx
+++ b/src/domain/event/occurrences/OccurrencesTable.tsx
@@ -9,7 +9,6 @@ import take from 'lodash/take';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 
-import ErrorMessage from '../../../common/components/form/ErrorMessage';
 import SrOnly from '../../../common/components/SrOnly/SrOnly';
 import Table from '../../../common/components/table/Table';
 import {
@@ -23,24 +22,21 @@ import {
   formatDateRange,
   formatLocalizedDate,
 } from '../../../utils/time/format';
-import { translateValue } from '../../../utils/translateUtils';
 import { skipFalsyType } from '../../../utils/typescript.utils';
-import { ENROLMENT_ERRORS } from '../../enrolment/constants';
 import {
   getAmountOfSeatsLeft,
-  hasOccurrenceSpace,
-  isEnrolmentClosed,
   isMultidayOccurrence,
-  isOccurrenceCancelled,
   isUnenrollableOccurrence,
 } from '../../occurrence/utils';
 import PlaceText from '../../place/placeText/PlaceText';
 import { EnrolmentType, OCCURRENCE_LIST_PAGE_SIZE } from '../constants';
 import DateFilter from '../dateFilter/DateFilter';
 import { getEnrolmentType } from '../utils';
+import EnrolmentError from './EnrolmentError';
 import OccurrenceInfo from './OccurrenceInfo';
 import styles from './occurrences.module.scss';
 import { useDateFiltering } from './useDateFiltering';
+import { getEnrolmentError } from './utils';
 
 interface Props {
   event: EventFieldsFragment;
@@ -314,28 +310,10 @@ const OccurrenceExpandButton: React.FC<
 > = ({ isExpanded, event, occurrence, ...props }) => {
   const { t } = useTranslation();
 
-  const getEnrolmentError = (
-    occurrence: OccurrenceFieldsFragment,
-    event: EventFieldsFragment
-  ) => {
-    if (isEnrolmentClosed(occurrence, event))
-      return ENROLMENT_ERRORS.ENROLMENT_CLOSED_ERROR;
-    if (!hasOccurrenceSpace(occurrence))
-      return ENROLMENT_ERRORS.NOT_ENOUGH_CAPACITY_ERROR;
-    if (isOccurrenceCancelled(occurrence)) {
-      return ENROLMENT_ERRORS.ENROLMENT_CANCDELLED_ERROR;
-    }
-    return null;
-  };
-
   // Show error message if enrolment is not available
   const error = getEnrolmentError(occurrence, event);
   if (error) {
-    return (
-      <ErrorMessage>
-        {translateValue('enrolment:errors.label.', error, t)}
-      </ErrorMessage>
-    );
+    return <EnrolmentError error={error} />;
   }
 
   return (

--- a/src/domain/event/occurrences/occurrences.module.scss
+++ b/src/domain/event/occurrences/occurrences.module.scss
@@ -122,3 +122,9 @@
   margin-top: auto;
   align-self: flex-end;
 }
+
+.enrolmentStartNotice {
+  margin-top: var(--spacing-m);
+  padding-left: var(--spacing-m);
+  line-height: var(--lineheight-l);
+}

--- a/src/domain/event/occurrences/occurrences.module.scss
+++ b/src/domain/event/occurrences/occurrences.module.scss
@@ -123,7 +123,7 @@
   align-self: flex-end;
 }
 
-.enrolmentStartNotice {
+.enrolmentNotice {
   margin-top: var(--spacing-m);
   padding-left: var(--spacing-m);
   line-height: var(--lineheight-l);

--- a/src/domain/event/occurrences/utils.ts
+++ b/src/domain/event/occurrences/utils.ts
@@ -1,0 +1,25 @@
+import {
+  EventFieldsFragment,
+  OccurrenceFieldsFragment,
+} from '../../../generated/graphql';
+import { ENROLMENT_ERRORS } from '../../enrolment/constants';
+import {
+  hasOccurrenceSpace,
+  isEnrolmentClosed,
+  isOccurrenceCancelled,
+} from '../../occurrence/utils';
+
+export function getEnrolmentError(
+  occurrence: OccurrenceFieldsFragment,
+  event: EventFieldsFragment
+): ENROLMENT_ERRORS | null {
+  if (isEnrolmentClosed(occurrence, event))
+    return ENROLMENT_ERRORS.ENROLMENT_CLOSED_ERROR;
+  if (!hasOccurrenceSpace(occurrence))
+    return ENROLMENT_ERRORS.NOT_ENOUGH_CAPACITY_ERROR;
+  if (isOccurrenceCancelled(occurrence)) {
+    return ENROLMENT_ERRORS.ENROLMENT_CANCDELLED_ERROR;
+  }
+
+  return null;
+}

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -1,5 +1,6 @@
-import { isToday, isTomorrow } from 'date-fns';
 import isBefore from 'date-fns/isBefore';
+import isToday from 'date-fns/isToday';
+import isTomorrow from 'date-fns/isTomorrow';
 import parseISO from 'date-fns/parseISO';
 import startOfDay from 'date-fns/startOfDay';
 import { TFunction } from 'next-i18next';

--- a/src/domain/occurrence/utils.ts
+++ b/src/domain/occurrence/utils.ts
@@ -1,4 +1,6 @@
-import { isPast, isSameDay, subDays } from 'date-fns';
+import isPast from 'date-fns/isPast';
+import isSameDay from 'date-fns/isSameDay';
+import subDays from 'date-fns/subDays';
 
 import {
   EventFieldsFragment,

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,4 +1,4 @@
-import { format as formatDateStr } from 'date-fns';
+import formatDateStr from 'date-fns/format';
 import isAfter from 'date-fns/isAfter';
 import isBefore from 'date-fns/isBefore';
 import isSameDay from 'date-fns/isSameDay';

--- a/src/utils/time/format.ts
+++ b/src/utils/time/format.ts
@@ -1,4 +1,4 @@
-import { format, format as formatDateStr } from 'date-fns';
+import formatDateStr from 'date-fns/format';
 import { enGB as en, fi, sv } from 'date-fns/locale';
 
 import { Language } from '../../types';
@@ -12,15 +12,15 @@ export const TIME_FORMAT = 'HH:mm';
 export const DATETIME_FORMAT = `${DATE_FORMAT} ${TIME_FORMAT}`;
 
 export function formatIntoTime(date: Date): string {
-  return format(date, TIME_FORMAT);
+  return formatDateStr(date, TIME_FORMAT);
 }
 
 export function formatIntoDateTime(date: Date): string {
-  return format(date, DATETIME_FORMAT);
+  return formatDateStr(date, DATETIME_FORMAT);
 }
 
 export function formatIntoDate(date: Date): string {
-  return format(date, DATE_FORMAT);
+  return formatDateStr(date, DATE_FORMAT);
 }
 
 export function formatDateRange(start: Date, end: Date): string {


### PR DESCRIPTION
## Description :sparkles:

Hide enrolment button until enrolling has begun.

Instead show text that describes when enrolment will begin.

Also contains:

* Handles error states within additional information

## Issues :bug:

### Closes :no_good_woman:

**[PT-1358](https://helsinkisolutionoffice.atlassian.net/browse/PT-1358):**

## Testing :alembic:

### Automated tests :gear:️

Added a test case to check that the button does not exist if enrolment has not begun. A lot of tests already so I was a bit hesitant whether I should add to the maintenance load. In the end I thought that this behaviour is worth testing as it has a big enough impact on UX and could be easy to break because there's a lot of boolean logic where this button is declared. Can be dropped if not.

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

<img width="1291" alt="Screenshot 2021-11-30 at 13 30 34" src="https://user-images.githubusercontent.com/9090689/144039736-fe04598c-41a9-4a0c-93cd-49f253518298.png">

## Additional notes :spiral_notepad:
