### PR TITLE
PT-1334 | Add notice about new service to 404 page

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -25,7 +25,8 @@
     "returnToHome": "Return to homepage"
   },
   "notFound": {
-    "textNotFound": "The page you were looking for was not found"
+    "textNotFound": "The page you're looking for was not found.",
+    "textNotFoundDescription": "A warm welcome to explore the new <a>Kultus</a>!"
   },
   "shareLink": {
     "shareOnFacebook": "Share on Facebook",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -25,7 +25,8 @@
     "returnToHome": "Palaa etusivulle"
   },
   "notFound": {
-    "textNotFound": "Etsimääsi sivua ei löytynyt"
+    "textNotFound": "Valitettavasti hakemaanne sivua ei löytynyt.",
+    "textNotFoundDescription": "Tervetuloa tutustumaan uudistuneen <a>Kultuksen</a> monipuoliseen tarjontaan!"
   },
   "shareLink": {
     "shareOnFacebook": "Jaa Facebookissa",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -25,7 +25,8 @@
     "returnToHome": "Återgå till hemsidan"
   },
   "notFound": {
-    "textNotFound": "Sidan du sökte hittades inte"
+    "textNotFound": "Tyvärr hittades inte sidan du sökte.",
+    "textNotFoundDescription": "Välkommen och bekanta dig med utbudet på den förnyade <a>Kultus</a>!"
   },
   "shareLink": {
     "shareOnFacebook": "Dela på Facebook",

--- a/src/domain/errorPage/ErrorPage.tsx
+++ b/src/domain/errorPage/ErrorPage.tsx
@@ -7,31 +7,29 @@ import Container from '../app/layout/Container';
 import { ROUTES } from '../app/routes/constants';
 import styles from './errorPage.module.scss';
 
-const ErrorPage: React.FC<{ title?: string; description?: string }> = ({
-  title,
-  description,
-}) => {
-  const { t } = useTranslation();
-  const router = useRouter();
+const ErrorPage: React.FC<{ title?: string; description?: React.ReactNode }> =
+  ({ title, description }) => {
+    const { t } = useTranslation();
+    const router = useRouter();
 
-  const goToFrontPage = () => {
-    router.push(ROUTES.HOME);
+    const goToFrontPage = () => {
+      router.push(ROUTES.HOME);
+    };
+
+    return (
+      <Container className={styles.container}>
+        <div className={styles.content}>
+          <IconInfoCircle size="l" />
+          <h1>{title || t('common:errorPage.title')}</h1>
+          <p className={styles.description}>
+            {description || t('common:errorPage.description')}
+          </p>
+          <Button onClick={goToFrontPage}>
+            {t('common:errorPage.returnToHome')}
+          </Button>
+        </div>
+      </Container>
+    );
   };
-
-  return (
-    <Container className={styles.container}>
-      <div className={styles.content}>
-        <IconInfoCircle size="l" />
-        <h1>{title || t('common:errorPage.title')}</h1>
-        <p className={styles.description}>
-          {description || t('common:errorPage.description')}
-        </p>
-        <Button onClick={goToFrontPage}>
-          {t('common:errorPage.returnToHome')}
-        </Button>
-      </div>
-    </Container>
-  );
-};
 
 export default ErrorPage;

--- a/src/domain/notFoundPage/NotFoundPage.tsx
+++ b/src/domain/notFoundPage/NotFoundPage.tsx
@@ -1,12 +1,36 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation, Trans } from 'next-i18next';
+import Link from 'next/link';
 import React, { ReactElement } from 'react';
 
 import ErrorPage from '../errorPage/ErrorPage';
 
+interface RootLinkProps {
+  children?: React.ReactNode;
+}
+
+const RootLink = ({ children }: RootLinkProps) => (
+  <Link href="/">
+    {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+    <a>{children}</a>
+  </Link>
+);
+
 const NotFoundPage = (): ReactElement => {
   const { t } = useTranslation();
 
-  return <ErrorPage title={t('common:notFound.textNotFound')} />;
+  return (
+    <ErrorPage
+      title={t('common:notFound.textNotFound')}
+      description={
+        <Trans
+          i18nKey="common:notFound.textNotFoundDescription"
+          components={{
+            a: <RootLink />,
+          }}
+        />
+      }
+    />
+  );
 };
 
 export default NotFoundPage;

--- a/src/domain/notFoundPage/__tests__/NotFoundPage.test.tsx
+++ b/src/domain/notFoundPage/__tests__/NotFoundPage.test.tsx
@@ -7,13 +7,12 @@ test('renders correctly', () => {
   render(<NotFoundPage />);
 
   expect(
-    screen.getByRole('heading', { name: 'Etsimääsi sivua ei löytynyt' })
+    screen.getByRole('heading', {
+      name: 'Valitettavasti hakemaanne sivua ei löytynyt.',
+    })
   ).toBeInTheDocument();
   expect(
-    screen.getByText(
-      'Pahoittelemme, mutta palvelussa ilmeni virhe. Voit yrittää uudestaan, mutta jos tilanne toistuu, ' +
-        'kerro siitä meille alalaidan palautelinkin kautta.'
-    )
+    screen.getByText(/Tervetuloa tutustumaan uudistuneen/)
   ).toBeInTheDocument();
   expect(
     screen.queryByRole('button', { name: 'Palaa etusivulle' })

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,17 @@
+import { NextPage, GetStaticPropsResult, GetStaticPropsContext } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import React from 'react';
+
+import NotFoundPage from '../domain/notFoundPage/NotFoundPage';
+
+const Error404: NextPage = () => <NotFoundPage />;
+
+export async function getStaticProps({
+  locale,
+}: GetStaticPropsContext): Promise<GetStaticPropsResult<unknown>> {
+  return {
+    props: await serverSideTranslations(locale ?? 'fi', ['common']),
+  };
+}
+
+export default Error404;

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -1,12 +1,17 @@
-import { NextPage, NextPageContext } from 'next';
+import { NextPage, GetStaticPropsResult, GetStaticPropsContext } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import React from 'react';
 
 import NotFoundPage from '../domain/notFoundPage/NotFoundPage';
-import getLocalizationProps from '../utils/getLocalizationProps';
 
 const Error: NextPage = () => <NotFoundPage />;
 
-Error.getInitialProps = async ({ locale }: NextPageContext) =>
-  getLocalizationProps(locale ?? 'fi');
+export async function getStaticProps({
+  locale,
+}: GetStaticPropsContext): Promise<GetStaticPropsResult<unknown>> {
+  return {
+    props: await serverSideTranslations(locale ?? 'fi', ['common']),
+  };
+}
 
 export default Error;


### PR DESCRIPTION
## Description :sparkles:

Adds a dedicated 404 page. Currently the generic error page and 404 page are identical in content.

Changes copy within the not found page to hint of the release of the new kultus, as described in the ticket.

Updates `_error.tsx` to use static generation.

## Issues :bug:

### Closes :no_good_woman:

**[PT-1334](https://helsinkisolutionoffice.atlassian.net/browse/PT-1334):**

## Screenshots :camera_flash:

<img width="1005" alt="Screenshot 2021-11-30 at 14 44 59" src="https://user-images.githubusercontent.com/9090689/144049654-a4a005c6-43f7-4e99-89ba-3a1c90ccd625.png">
<img width="1005" alt="Screenshot 2021-11-30 at 14 45 06" src="https://user-images.githubusercontent.com/9090689/144049661-80702740-1c96-48d3-9a39-dd06f839f755.png">
