### PR TITLE
PT-1347 | Fix enrolment form group size validation bug

### DIFF
--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -27,7 +27,7 @@ import {
   nameToLabelPath,
 } from './constants';
 import styles from './enrolmentForm.module.scss';
-import ValidationSchema from './ValidationSchema';
+import getValidationSchema from './ValidationSchema';
 
 export interface Props {
   initialValues?: EnrolmentFormFields;
@@ -35,6 +35,8 @@ export interface Props {
   onSubmit: (values: EnrolmentFormFields) => void;
   submitting: boolean;
   onCloseForm: () => void;
+  minGroupSize?: number;
+  maxGroupSize?: number;
 }
 
 const EnrolmentForm: React.FC<Props> = ({
@@ -43,6 +45,8 @@ const EnrolmentForm: React.FC<Props> = ({
   onSubmit,
   submitting,
   onCloseForm,
+  minGroupSize = 10,
+  maxGroupSize = 20,
 }) => {
   const { t } = useTranslation();
   const locale = useLocale();
@@ -58,7 +62,10 @@ const EnrolmentForm: React.FC<Props> = ({
     <Formik
       initialValues={initialValues}
       onSubmit={onSubmit}
-      validationSchema={ValidationSchema}
+      validationSchema={getValidationSchema({
+        minGroupSize,
+        maxGroupSize,
+      })}
     >
       {({
         errors,

--- a/src/domain/enrolment/enrolmentForm/ValidationSchema.tsx
+++ b/src/domain/enrolment/enrolmentForm/ValidationSchema.tsx
@@ -2,158 +2,165 @@ import * as Yup from 'yup';
 
 import { VALIDATION_MESSAGE_KEYS } from '../../app/forms/constants';
 
-export default Yup.object().shape({
-  hasEmailNotification: Yup.bool().oneOf(
-    [true],
-    'enrolment:enrolmentForm.validation.hasEmailNotification'
-  ),
-  isSharingDataAccepted: Yup.bool().oneOf(
-    [true],
-    'enrolment:enrolmentForm.validation.isSharingDataAccepted'
-  ),
-  language: Yup.string().required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED),
-  person: Yup.object().when(
-    ['isSameResponsiblePerson'],
-    (isSameResponsiblePerson: boolean, schema: Yup.AnyObjectSchema) => {
-      return isSameResponsiblePerson
-        ? schema
-        : schema.shape({
-            name: Yup.string().required(
-              VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
-            ),
-            emailAddress: Yup.string()
-              .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
-              .email(VALIDATION_MESSAGE_KEYS.EMAIL),
-          });
-    }
-  ),
-  studyGroup: Yup.object().when(
-    [
-      'maxGroupSize',
-      'minGroupSize',
-      'isMandatoryAdditionalInformationRequired',
-    ],
-    ((
-      maxGroupSize: number,
-      minGroupSize: number,
-      isMandatoryAdditionalInformationRequired: boolean,
-      schema: Yup.AnyObjectSchema
-    ) => {
-      const validateSumOfSizePair = (
-        sizePair: number | undefined,
-        schema: Yup.NumberSchema,
-        totalMinLimitValidationMessage: string,
-        fieldMaxLimitValidationMessage: string,
-        totalMaxLimitValidationMessage: string
-      ): Yup.NumberSchema => {
-        // Validate a single field against the total min and max sizes.
-        // The used validation error message will be the same for both the fields.
-        // This is also preventing negative param.max to occur in validation.
-        if (
-          !sizePair ||
-          sizePair < 0 ||
-          sizePair < minGroupSize ||
-          sizePair > maxGroupSize
-        ) {
-          return (
-            schema
-              // Min-limit is current a gap to minimum group size.
-              .min(
-                sizePair != null ? minGroupSize - sizePair : minGroupSize,
-                () => ({
-                  min: minGroupSize,
-                  key: totalMinLimitValidationMessage,
-                })
-              )
-              // Max-limit is maximum group size
-              .max(maxGroupSize, (param) => ({
-                max: param.max,
-                key: totalMaxLimitValidationMessage,
-              }))
-          );
-        }
-
-        // After the field pair is given, count how many seats are left
-        // and use that as max limit.
-        // The used validation error message will be unique for both the fields.
-        return schema.max(maxGroupSize - sizePair, (param) => ({
-          max: param.max,
-          key: fieldMaxLimitValidationMessage,
-        }));
-      };
-
-      return schema.shape(
-        {
-          person: Yup.object().shape({
-            name: Yup.string().required(
-              VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
-            ),
-            emailAddress: Yup.string()
-              .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
-              .email(VALIDATION_MESSAGE_KEYS.EMAIL),
-          }),
-          unitName: Yup.string().when(
-            ['unitId'],
-            (unitId: string, schema: Yup.StringSchema) => {
-              if (!unitId) {
-                return schema.required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED);
-              }
-              return schema;
-            }
-          ),
-          unitId: Yup.string().when(
-            ['unitName'],
-            (unitName: string, schema: Yup.StringSchema) => {
-              if (!unitName) {
-                return schema
-                  .nullable()
-                  .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED);
-              }
-              return schema.nullable();
-            }
-          ),
-          groupName: Yup.string().required(
-            VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
-          ),
-          // NOTE: GroupSize is (currently) the amount of children
-          groupSize: Yup.number()
-            .required(VALIDATION_MESSAGE_KEYS.NUMBER_REQUIRED)
-            .when(
-              ['amountOfAdult'],
-              (sizePair: number, schema: Yup.NumberSchema) =>
-                validateSumOfSizePair(
-                  sizePair,
-                  schema,
-                  VALIDATION_MESSAGE_KEYS.STUDYGROUP_MIN_CHILDREN_WITH_ADULTS,
-                  VALIDATION_MESSAGE_KEYS.STUDYGROUP_MAX_WITH_ADULTS,
-                  VALIDATION_MESSAGE_KEYS.STUDYGROUP_MAX_CHILDREN_WITH_ADULTS
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export default function getValidationSchema({
+  maxGroupSize,
+  minGroupSize,
+}: {
+  minGroupSize: number;
+  maxGroupSize: number;
+}) {
+  return Yup.object().shape({
+    hasEmailNotification: Yup.bool().oneOf(
+      [true],
+      'enrolment:enrolmentForm.validation.hasEmailNotification'
+    ),
+    isSharingDataAccepted: Yup.bool().oneOf(
+      [true],
+      'enrolment:enrolmentForm.validation.isSharingDataAccepted'
+    ),
+    language: Yup.string().required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED),
+    person: Yup.object().when(
+      ['isSameResponsiblePerson'],
+      (isSameResponsiblePerson: boolean, schema: Yup.AnyObjectSchema) => {
+        return isSameResponsiblePerson
+          ? schema
+          : schema.shape({
+              name: Yup.string().required(
+                VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
+              ),
+              emailAddress: Yup.string()
+                .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
+                .email(VALIDATION_MESSAGE_KEYS.EMAIL),
+            });
+      }
+    ),
+    studyGroup: Yup.object().when(
+      ['isMandatoryAdditionalInformationRequired'],
+      ((
+        isMandatoryAdditionalInformationRequired: boolean,
+        schema: Yup.AnyObjectSchema
+      ) => {
+        const validateSumOfSizePair = (
+          sizePair: number | undefined,
+          schema: Yup.NumberSchema,
+          totalMinLimitValidationMessage: string,
+          fieldMaxLimitValidationMessage: string,
+          totalMaxLimitValidationMessage: string
+        ): Yup.NumberSchema => {
+          // Validate a single field against the total min and max sizes.
+          // The used validation error message will be the same for both the fields.
+          // This is also preventing negative param.max to occur in validation.
+          if (
+            !sizePair ||
+            sizePair < 0 ||
+            sizePair < minGroupSize ||
+            sizePair > maxGroupSize
+          ) {
+            return (
+              schema
+                // Min-limit is current a gap to minimum group size.
+                .min(
+                  sizePair != null ? minGroupSize - sizePair : minGroupSize,
+                  () => ({
+                    min: minGroupSize,
+                    key: totalMinLimitValidationMessage,
+                  })
                 )
+                // Max-limit is maximum group size
+                .max(maxGroupSize, (param) => ({
+                  max: param.max,
+                  key: totalMaxLimitValidationMessage,
+                }))
+            );
+          }
+
+          // After the field pair is given, count how many seats are left
+          // and use that as max limit.
+          // The used validation error message will be unique for both the fields.
+          return schema.max(maxGroupSize - sizePair, (param) => ({
+            max: param.max,
+            key: fieldMaxLimitValidationMessage,
+          }));
+        };
+
+        return schema.shape(
+          {
+            person: Yup.object().shape({
+              name: Yup.string().required(
+                VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
+              ),
+              emailAddress: Yup.string()
+                .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
+                .email(VALIDATION_MESSAGE_KEYS.EMAIL),
+            }),
+            unitName: Yup.string().when(
+              ['unitId'],
+              (unitId: string, schema: Yup.StringSchema) => {
+                if (!unitId) {
+                  return schema.required(
+                    VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
+                  );
+                }
+                return schema;
+              }
             ),
-          amountOfAdult: Yup.number()
-            .required(VALIDATION_MESSAGE_KEYS.NUMBER_REQUIRED)
-            .when(['groupSize'], (sizePair: number, schema: Yup.NumberSchema) =>
-              validateSumOfSizePair(
-                sizePair,
-                schema,
-                VALIDATION_MESSAGE_KEYS.STUDYGROUP_MIN_CHILDREN_WITH_ADULTS,
-                VALIDATION_MESSAGE_KEYS.STUDYGROUP_MAX_WITH_CHILDREN,
-                VALIDATION_MESSAGE_KEYS.STUDYGROUP_MAX_CHILDREN_WITH_ADULTS
-              )
+            unitId: Yup.string().when(
+              ['unitName'],
+              (unitName: string, schema: Yup.StringSchema) => {
+                if (!unitName) {
+                  return schema
+                    .nullable()
+                    .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED);
+                }
+                return schema.nullable();
+              }
             ),
-          extraNeeds: isMandatoryAdditionalInformationRequired
-            ? Yup.string().required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
-            : Yup.string(),
-          studyLevels: Yup.array()
-            .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
-            .min(1, VALIDATION_MESSAGE_KEYS.STRING_REQUIRED),
-        },
-        [
-          ['groupSize', 'amountOfAdult'],
-          ['unitId', 'unitName'],
-        ]
-      );
-      // For some reason typescript complains event though it is correct
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    }) as any
-  ),
-});
+            groupName: Yup.string().required(
+              VALIDATION_MESSAGE_KEYS.STRING_REQUIRED
+            ),
+            // NOTE: GroupSize is (currently) the amount of children
+            groupSize: Yup.number()
+              .required(VALIDATION_MESSAGE_KEYS.NUMBER_REQUIRED)
+              .when(
+                ['amountOfAdult'],
+                (sizePair: number, schema: Yup.NumberSchema) =>
+                  validateSumOfSizePair(
+                    sizePair,
+                    schema,
+                    VALIDATION_MESSAGE_KEYS.STUDYGROUP_MIN_CHILDREN_WITH_ADULTS,
+                    VALIDATION_MESSAGE_KEYS.STUDYGROUP_MAX_WITH_ADULTS,
+                    VALIDATION_MESSAGE_KEYS.STUDYGROUP_MAX_CHILDREN_WITH_ADULTS
+                  )
+              ),
+            amountOfAdult: Yup.number()
+              .required(VALIDATION_MESSAGE_KEYS.NUMBER_REQUIRED)
+              .when(
+                ['groupSize'],
+                (sizePair: number, schema: Yup.NumberSchema) =>
+                  validateSumOfSizePair(
+                    sizePair,
+                    schema,
+                    VALIDATION_MESSAGE_KEYS.STUDYGROUP_MIN_CHILDREN_WITH_ADULTS,
+                    VALIDATION_MESSAGE_KEYS.STUDYGROUP_MAX_WITH_CHILDREN,
+                    VALIDATION_MESSAGE_KEYS.STUDYGROUP_MAX_CHILDREN_WITH_ADULTS
+                  )
+              ),
+            extraNeeds: isMandatoryAdditionalInformationRequired
+              ? Yup.string().required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
+              : Yup.string(),
+            studyLevels: Yup.array()
+              .required(VALIDATION_MESSAGE_KEYS.STRING_REQUIRED)
+              .min(1, VALIDATION_MESSAGE_KEYS.STRING_REQUIRED),
+          },
+          [
+            ['groupSize', 'amountOfAdult'],
+            ['unitId', 'unitName'],
+          ]
+        );
+        // For some reason typescript complains event though it is correct
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any
+    ),
+  });
+}

--- a/src/domain/enrolment/enrolmentForm/__tests__/EnrolmentForm.test.tsx
+++ b/src/domain/enrolment/enrolmentForm/__tests__/EnrolmentForm.test.tsx
@@ -40,11 +40,9 @@ const renderComponent = ({
   props: { initialValues, ...restProps } = {},
   mocks = [],
 }: {
-  props?: Partial<
-    Omit<Props, 'initialValues'> & {
-      initialValues: Partial<Props['initialValues']>;
-    }
-  >;
+  props?: Partial<Omit<Props, 'initialValues'>> & {
+    initialValues?: Partial<Props['initialValues']>;
+  };
   mocks?: MockedResponse[];
 } = {}) => {
   const onCloseFormMock = jest.fn();
@@ -68,7 +66,7 @@ jest.setTimeout(30000);
 
 test('renders form and user can fill it and submit and form is saved to local storage', async () => {
   const { onSubmitMock } = renderComponent({
-    props: { initialValues: { minGroupSize: 10, maxGroupSize: 20 } },
+    props: { minGroupSize: 10, maxGroupSize: 20 },
   });
 
   await screen.findByRole('heading', { name: /ilmoittajan tiedot/i });
@@ -208,7 +206,7 @@ describe('max group size validation of the Children and Adults -fields', () => {
     adultsCount: string
   ) => {
     renderComponent({
-      props: { initialValues: { minGroupSize: 10, maxGroupSize: 20 } },
+      props: { minGroupSize: 10, maxGroupSize: 20 },
     });
     await screen.findByLabelText(/lapsia/i);
     childrenCount
@@ -372,8 +370,6 @@ if (isFeatureEnabled('FORMIK_PERSIST')) {
       isSharingDataAccepted: false,
       isMandatoryAdditionalInformationRequired: false,
       language: '',
-      maxGroupSize: 0,
-      minGroupSize: 0,
       studyGroup: {
         person: {
           name: 'Test person',
@@ -482,10 +478,8 @@ describe('UnitField', () => {
     renderComponent({
       mocks: testMocks,
       props: {
-        initialValues: {
-          minGroupSize: 10,
-          maxGroupSize: 20,
-        },
+        minGroupSize: 10,
+        maxGroupSize: 20,
       },
     });
 

--- a/src/domain/enrolment/enrolmentForm/__tests__/__snapshots__/EnrolmentForm.test.tsx.snap
+++ b/src/domain/enrolment/enrolmentForm/__tests__/__snapshots__/EnrolmentForm.test.tsx.snap
@@ -13,8 +13,6 @@ Object {
     "isSameResponsiblePerson": true,
     "isSharingDataAccepted": false,
     "language": "",
-    "maxGroupSize": 20,
-    "minGroupSize": 10,
     "person": Object {
       "emailAddress": "",
       "name": "",
@@ -46,8 +44,6 @@ Object {
     "isSameResponsiblePerson": true,
     "isSharingDataAccepted": true,
     "language": true,
-    "maxGroupSize": true,
-    "minGroupSize": true,
     "person": Object {
       "emailAddress": true,
       "name": true,
@@ -81,8 +77,6 @@ Object {
     "isSameResponsiblePerson": true,
     "isSharingDataAccepted": true,
     "language": "FI",
-    "maxGroupSize": 20,
-    "minGroupSize": 10,
     "person": Object {
       "emailAddress": "",
       "name": "",
@@ -118,8 +112,6 @@ Array [
     "isSameResponsiblePerson": true,
     "isSharingDataAccepted": true,
     "language": "FI",
-    "maxGroupSize": 20,
-    "minGroupSize": 10,
     "person": Object {
       "emailAddress": "",
       "name": "",

--- a/src/domain/enrolment/enrolmentForm/constants.ts
+++ b/src/domain/enrolment/enrolmentForm/constants.ts
@@ -5,8 +5,6 @@ export type EnrolmentFormFields = {
   isSharingDataAccepted: boolean;
   isMandatoryAdditionalInformationRequired: boolean;
   language: string;
-  maxGroupSize: number;
-  minGroupSize: number;
   person: {
     name: string;
     phoneNumber: string;
@@ -35,8 +33,6 @@ export const defaultEnrolmentInitialValues: EnrolmentFormFields = {
   isSharingDataAccepted: false,
   isMandatoryAdditionalInformationRequired: false,
   language: '',
-  maxGroupSize: 0,
-  minGroupSize: 0,
   person: {
     name: '',
     phoneNumber: '',

--- a/src/domain/event/__tests__/__snapshots__/enrolmentFormIntegration.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/enrolmentFormIntegration.test.tsx.snap
@@ -13,8 +13,6 @@ Object {
     "isSameResponsiblePerson": true,
     "isSharingDataAccepted": false,
     "language": "FI",
-    "maxGroupSize": 20,
-    "minGroupSize": 10,
     "person": Object {
       "emailAddress": "",
       "name": "",
@@ -46,8 +44,6 @@ Object {
     "isSameResponsiblePerson": true,
     "isSharingDataAccepted": true,
     "language": true,
-    "maxGroupSize": true,
-    "minGroupSize": true,
     "person": Object {
       "emailAddress": true,
       "name": true,
@@ -81,8 +77,6 @@ Object {
     "isSameResponsiblePerson": true,
     "isSharingDataAccepted": true,
     "language": "FI",
-    "maxGroupSize": 20,
-    "minGroupSize": 10,
     "person": Object {
       "emailAddress": "",
       "name": "",
@@ -122,8 +116,6 @@ Object {
     "isSameResponsiblePerson": true,
     "isSharingDataAccepted": false,
     "language": "FI",
-    "maxGroupSize": 20,
-    "minGroupSize": 10,
     "person": Object {
       "emailAddress": "",
       "name": "",
@@ -155,8 +147,6 @@ Object {
     "isSameResponsiblePerson": true,
     "isSharingDataAccepted": true,
     "language": true,
-    "maxGroupSize": true,
-    "minGroupSize": true,
     "person": Object {
       "emailAddress": true,
       "name": true,
@@ -190,8 +180,6 @@ Object {
     "isSameResponsiblePerson": true,
     "isSharingDataAccepted": true,
     "language": "FI",
-    "maxGroupSize": 20,
-    "minGroupSize": 10,
     "person": Object {
       "emailAddress": "",
       "name": "",

--- a/src/domain/event/occurrences/EnrolmentFormSection.tsx
+++ b/src/domain/event/occurrences/EnrolmentFormSection.tsx
@@ -78,6 +78,14 @@ const EnrolmentFormSection: React.FC<{
     () => ({
       ...defaultEnrolmentInitialValues,
       language: locale.toUpperCase(),
+      isMandatoryAdditionalInformationRequired:
+        !!isMandatoryAdditionalInformationRequired,
+    }),
+    [locale, isMandatoryAdditionalInformationRequired]
+  );
+
+  const { minGroupSize, maxGroupSize } = React.useMemo(
+    () => ({
       // some of the values used only for validation purposes
       minGroupSize: Math.max(
         ...occurrences.map((item) => item?.minGroupSize || 0)
@@ -89,7 +97,10 @@ const EnrolmentFormSection: React.FC<{
           switch (item.seatType) {
             case OccurrenceSeatType.ChildrenCount:
               return Math.min(
-                item?.maxGroupSize || item.amountOfSeats,
+                Math.min(
+                  item?.maxGroupSize ?? item.amountOfSeats,
+                  item.remainingSeats
+                ),
                 getAmountOfSeatsLeft(item)
               );
             case OccurrenceSeatType.EnrolmentCount:
@@ -99,10 +110,8 @@ const EnrolmentFormSection: React.FC<{
           }
         })
       ),
-      isMandatoryAdditionalInformationRequired:
-        !!isMandatoryAdditionalInformationRequired,
     }),
-    [locale, isMandatoryAdditionalInformationRequired, occurrences]
+    [occurrences]
   );
 
   return (
@@ -112,6 +121,8 @@ const EnrolmentFormSection: React.FC<{
       onSubmit={submit}
       submitting={enrolmentLoading}
       onCloseForm={onCloseForm}
+      minGroupSize={minGroupSize}
+      maxGroupSize={maxGroupSize}
     />
   );
 };

--- a/src/domain/event/occurrences/OccurrenceInfo.tsx
+++ b/src/domain/event/occurrences/OccurrenceInfo.tsx
@@ -1,3 +1,4 @@
+import { useApolloClient } from '@apollo/client';
 import classNames from 'classnames';
 import { isSameDay } from 'date-fns';
 import {
@@ -16,6 +17,7 @@ import ExternalLink from '../../../common/components/externalLink/ExternalLink';
 import {
   OccurrenceFieldsFragment,
   EventFieldsFragment,
+  EventDocument,
 } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import formatTimeRange from '../../../utils/formatTimeRange';
@@ -40,6 +42,7 @@ const OccurrenceInfo: React.FC<{
   event: EventFieldsFragment;
   eventLocationId: string;
 }> = ({ occurrence, event, eventLocationId }) => {
+  const apolloClient = useApolloClient();
   const [showEnrolmentForm, setShowEnrolmentForm] = React.useState(false);
   const enrolmentFormRef = React.useRef<HTMLDivElement>(null);
   const enrolButtonRef = React.useRef<HTMLButtonElement>(null);
@@ -73,6 +76,13 @@ const OccurrenceInfo: React.FC<{
   const handleCloseForm = () => {
     setShowEnrolmentForm(false);
     enrolButtonRef.current?.focus();
+  };
+
+  const handleOnEnrol = async () => {
+    // refetch event query for the page to get updated occurrences
+    await apolloClient.refetchQueries({
+      include: [EventDocument],
+    });
   };
 
   const getOccurrenceDateTimeString = () => {
@@ -239,6 +249,7 @@ const OccurrenceInfo: React.FC<{
             event={event}
             occurrences={[occurrence]}
             onCloseForm={handleCloseForm}
+            onEnrol={handleOnEnrol}
           />
         </div>
       )}


### PR DESCRIPTION
## Description :sparkles:

Persisting min and maxGroupSize values that were only used for validation was causing problems because previous values would be taken from local storage. To fix this min and MaxGroupSize values are now passed ar parameters to getValidationSchema to avoid persisting them to local storage.

## Issues :bug:

### Closes :no_good_woman:

**[PT-1347](https://helsinkisolutionoffice.atlassian.net/browse/PT-1347):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
