### PR TITLE
fix: change language order in occurrence table to be fi, sv first

### DIFF
--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -258,25 +258,23 @@ it('shows full events correctly in occurrences list', async () => {
   renderComponent();
   await waitForRequestsToComplete();
 
-  const fullOccurrenceRowText1 =
-    '23.7.2020 to12:00 – 13:00englanti, suomien, fiSoukan kirjasto0 / 1Tapahtuma on täynnä';
-  const fullOccurrenceRowText2 =
-    '29.7.2020 ke12:00 – 13:00englanti, suomien, fiSoukan kirjasto0 / 30Tapahtuma on täynnä';
-
   const tableRows = screen.queryAllByRole('row');
-  expect(tableRows[7]).toHaveTextContent(fullOccurrenceRowText1);
-  expect(tableRows[10]).toHaveTextContent(fullOccurrenceRowText2);
+  expect(tableRows[7].textContent).toMatchInlineSnapshot(
+    `"23.7.2020 to12:00 – 13:00suomi, englantifi, enSoukan kirjasto0 / 1Tapahtuma on täynnä"`
+  );
+  expect(tableRows[10].textContent).toMatchInlineSnapshot(
+    `"29.7.2020 ke12:00 – 13:00suomi, englantifi, enSoukan kirjasto0 / 30Tapahtuma on täynnä"`
+  );
 });
 
 it('shows cancelled events correctly in list', async () => {
   renderComponent();
   await waitForRequestsToComplete();
 
-  const cancelledOccurrenceRowText =
-    '20.7.2020 ma12:00 – 13:00englanti, suomien, fiSoukan kirjasto30 / 30Tapahtuma on peruttu';
-
   const tableRows = screen.queryAllByRole('row');
-  expect(tableRows[4]).toHaveTextContent(cancelledOccurrenceRowText);
+  expect(tableRows[4].textContent).toMatchInlineSnapshot(
+    `"20.7.2020 ma12:00 – 13:00suomi, englantifi, enSoukan kirjasto30 / 30Tapahtuma on peruttu"`
+  );
 });
 
 it('renders upcoming occurrencec correctly', async () => {
@@ -284,17 +282,17 @@ it('renders upcoming occurrencec correctly', async () => {
   await waitForRequestsToComplete();
 
   const tableRows = screen.queryAllByRole('row');
-  expect(tableRows[1]).toHaveTextContent(
-    '15.7.2020 – 17.7.2020englanti, suomi, ruotsien, fi, svSoukan kirjasto30 / 30Näytä tiedot'
+  expect(tableRows[1].textContent).toMatchInlineSnapshot(
+    `"15.7.2020 – 17.7.2020suomi, ruotsi, englantifi, sv, enSoukan kirjasto30 / 30Näytä tiedot"`
   );
-  expect(tableRows[2]).toHaveTextContent(
-    '16.7.2020 to12:00 – 13:00suomifiSoukan kirjasto30 / 30Näytä tiedot'
+  expect(tableRows[2].textContent).toMatchInlineSnapshot(
+    `"16.7.2020 to12:00 – 13:00suomifiSoukan kirjasto30 / 30Näytä tiedot"`
   );
-  expect(tableRows[3]).toHaveTextContent(
-    '19.7.2020 su12:00 – 13:00englanti, suomien, fiSoukan kirjasto30 / 30Näytä tiedot'
+  expect(tableRows[3].textContent).toMatchInlineSnapshot(
+    `"19.7.2020 su12:00 – 13:00suomi, englantifi, enSoukan kirjasto30 / 30Näytä tiedot"`
   );
-  expect(tableRows[5]).toHaveTextContent(
-    '21.7.2020 ti12:00 – 13:00englanti, suomien, fiSoukan kirjasto30 / 30Näytä tiedot'
+  expect(tableRows[5].textContent).toMatchInlineSnapshot(
+    `"21.7.2020 ti12:00 – 13:00suomi, englantifi, enSoukan kirjasto30 / 30Näytä tiedot"`
   );
 });
 
@@ -404,10 +402,10 @@ it('renders occurrences table and related stuff correctly', async () => {
     ).toBeInTheDocument();
   });
 
-  const rowText = `27.7.2020 ma12:00 – 13:00englanti, suomien, fiSoukan kirjasto30 / 30Näytä tiedot`;
-
   const tableRows = screen.getAllByRole('row');
-  expect(tableRows[8]).toHaveTextContent(rowText);
+  expect(tableRows[8].textContent).toMatchInlineSnapshot(
+    `"27.7.2020 ma12:00 – 13:00suomi, englantifi, enSoukan kirjasto30 / 30Näytä tiedot"`
+  );
 });
 
 it('hides seats left column header when event has external enrolment', async () => {
@@ -442,8 +440,8 @@ it('hides seats left column header when event has external enrolment', async () 
   const tableRows = screen.getAllByRole('row');
 
   // shows multi day occurrence correctly
-  expect(tableRows[1]).toHaveTextContent(
-    '15.7.2020 – 17.7.2020englanti, suomi, ruotsien, fi, svSoukan kirjastoNäytä tiedot'
+  expect(tableRows[1].textContent).toMatchInlineSnapshot(
+    `"15.7.2020 – 17.7.2020suomi, ruotsi, englantifi, sv, enSoukan kirjastoNäytä tiedot"`
   );
 
   userEvent.click(

--- a/src/domain/event/__tests__/__snapshots__/enrolmentFormIntegration.test.tsx.snap
+++ b/src/domain/event/__tests__/__snapshots__/enrolmentFormIntegration.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`user can select multiple occurrences and enrol to them with enrolment form 1`] = `
+exports[`user can select multiple occurrences and enrol to them with enrolment form 4`] = `
 Object {
   "dirty": true,
   "errors": Object {},
@@ -103,7 +103,7 @@ Object {
 }
 `;
 
-exports[`user can select single occurrences and enrol to it with enrolment form 1`] = `
+exports[`user can select single occurrences and enrol to it with enrolment form 2`] = `
 Object {
   "dirty": true,
   "errors": Object {},

--- a/src/domain/event/__tests__/enrolmentFormIntegration.test.tsx
+++ b/src/domain/event/__tests__/enrolmentFormIntegration.test.tsx
@@ -126,8 +126,8 @@ test('user can select single occurrences and enrol to it with enrolment form', a
 
   const rows = await screen.findAllByRole('row');
 
-  expect(rows[1]).toHaveTextContent(
-    '25.9.2020 pe12:30 – 13:30englanti, suomien, fiKirjasto30 / 30Näytä tiedot'
+  expect(rows[1].textContent).toMatchInlineSnapshot(
+    `"25.9.2020 pe12:30 – 13:30suomi, englantifi, enKirjasto30 / 30Näytä tiedot"`
   );
 
   userEvent.click(
@@ -205,14 +205,14 @@ test('user can select multiple occurrences and enrol to them with enrolment form
 
   const rows = await screen.findAllByRole('row');
 
-  expect(rows[1]).toHaveTextContent(
-    '25.9.2020 pe12:30 – 13:30englanti, suomien, fiKirjasto30 / 30Näytä tiedot'
+  expect(rows[1].textContent).toMatchInlineSnapshot(
+    `"25.9.2020 pe12:30 – 13:30suomi, englantifi, enKirjasto30 / 30Näytä tiedot"`
   );
-  expect(rows[2]).toHaveTextContent(
-    '26.9.2020 la13:20 – 14:20englanti, suomien, fiKirjasto30 / 30Näytä tiedot'
+  expect(rows[2].textContent).toMatchInlineSnapshot(
+    `"26.9.2020 la13:20 – 14:20suomi, englantifi, enKirjasto30 / 30Näytä tiedot"`
   );
-  expect(rows[3]).toHaveTextContent(
-    '26.9.2020 la14:20 – 15:20englanti, suomien, fiKirjasto30 / 30Näytä tiedot'
+  expect(rows[3].textContent).toMatchInlineSnapshot(
+    `"26.9.2020 la14:20 – 15:20suomi, englantifi, enKirjasto30 / 30Näytä tiedot"`
   );
 
   userEvent.click(

--- a/src/domain/event/occurrences/OccurrencesTable.tsx
+++ b/src/domain/event/occurrences/OccurrencesTable.tsx
@@ -36,7 +36,7 @@ import EnrolmentError from './EnrolmentError';
 import OccurrenceInfo from './OccurrenceInfo';
 import styles from './occurrences.module.scss';
 import { useDateFiltering } from './useDateFiltering';
-import { getEnrolmentError } from './utils';
+import { getEnrolmentError, getOrderedLanguages } from './utils';
 
 interface Props {
   event: EventFieldsFragment;
@@ -219,19 +219,29 @@ const OccurrenceEnrolmentTable: React.FC<{
     },
     {
       Header: t('enrolment:occurrenceTable.columnLanguage'),
-      accessor: (row: OccurrenceFieldsFragment) => (
-        <div>
-          <SrOnly>
-            {row.languages.edges
-              .map((lang) => t(`common:languages.${lang?.node?.id}`))
-              .join(', ') ?? '-'}
-          </SrOnly>
-          <span aria-hidden="true">
-            {row.languages.edges.map((lang) => lang?.node?.id).join(', ') ??
-              '-'}
-          </span>
-        </div>
-      ),
+      accessor: (row: OccurrenceFieldsFragment) => {
+        const languages = row.languages.edges
+          .map((lang) => lang?.node)
+          .filter(skipFalsyType);
+
+        if (!languages) {
+          return '–';
+        }
+
+        const orderedLanguages = getOrderedLanguages(languages);
+        return (
+          <div>
+            <SrOnly>
+              {orderedLanguages
+                .map((lang) => t(`common:languages.${lang}`))
+                .join(', ') ?? '-'}
+            </SrOnly>
+            <span aria-hidden="true">
+              {orderedLanguages.map((lang) => lang).join(', ') ?? '-'}
+            </span>
+          </div>
+        );
+      },
       id: 'languages',
     },
     {

--- a/src/domain/event/occurrences/utils.ts
+++ b/src/domain/event/occurrences/utils.ts
@@ -23,3 +23,31 @@ export function getEnrolmentError(
 
   return null;
 }
+
+export function getOrderedLanguages(
+  languages: { id: string; name: string }[]
+): string[] {
+  const languageOrder = ['fi', 'sv', 'en'];
+  const languageStrings = languages.map((l) => l.id.split('_')[0]);
+
+  // order languages based on languageOrder, other languages go
+  // to the end of the array
+  return languageStrings.sort((a, b) => {
+    const aIndex = languageOrder.indexOf(a);
+    const bIndex = languageOrder.indexOf(b);
+
+    if (aIndex > -1 && bIndex > -1) {
+      return aIndex - bIndex;
+    }
+
+    if (aIndex > -1 && bIndex === -1) {
+      return -1;
+    }
+
+    if (bIndex > -1 && aIndex === -1) {
+      return 1;
+    }
+
+    return 0;
+  });
+}


### PR DESCRIPTION
## Description :sparkles:

- Update some test to use inline snapshot
- Fix issue with languages that have underscore in their ID
- Order languages correctly (fi, sv...)

## Issues :bug:

### Closes :no_good_woman:

**[PT-1316](https://helsinkisolutionoffice.atlassian.net/browse/PT-1316):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
