### PR TITLE
PT-1401 | Add notification on top of occurrences table if enrolment hasn't started

### DIFF
--- a/public/locales/en/event.json
+++ b/public/locales/en/event.json
@@ -35,6 +35,7 @@
     "labelStartDateFilter": "Start date of occurrences filter",
     "labelEndDateFilter": "End date of occurrences filter",
     "eventIsFree": "Free",
+    "enrolmentStartsLabel": "Enrolment",
     "enrolmentStartsAt": "Enrolments start {{date}} at {{time}}"
   },
   "location": {

--- a/public/locales/fi/event.json
+++ b/public/locales/fi/event.json
@@ -35,6 +35,7 @@
     "labelStartDateFilter": "Tapahtuma-aikojen rajauksen alkupäivä",
     "labelEndDateFilter": "Tapahtuma-aikojen rajauksen loppupäivä",
     "eventIsFree": "Maksuton",
+    "enrolmentStartsLabel": "Ilmoittautuminen",
     "enrolmentStartsAt": "Ilmoittautuminen alkaa {{date}} klo {{time}}"
   },
   "location": {

--- a/public/locales/sv/event.json
+++ b/public/locales/sv/event.json
@@ -35,6 +35,7 @@
     "labelStartDateFilter": "Startdatum för händelsefilter",
     "labelEndDateFilter": "Slutdatum för händelsefilter",
     "eventIsFree": "Fri",
+    "enrolmentStartsLabel": "Registrering",
     "enrolmentStartsAt": "Registreringen börjar {{date}} kl. {{time}}"
   },
   "location": {

--- a/src/domain/event/EventPage.tsx
+++ b/src/domain/event/EventPage.tsx
@@ -20,6 +20,7 @@ import Container from '../app/layout/Container';
 import PageWrapper from '../app/layout/PageWrapper';
 import { ENROLMENT_URL_PARAMS } from '../enrolment/constants';
 import NotFoundPage from '../notFoundPage/NotFoundPage';
+import { isEnrolmentStarted } from '../occurrence/utils';
 import EnrolmentButton from './enrolmentButton/EnrolmentButton';
 import EventBasicInfo from './eventBasicInfo/EventBasicInfo';
 import EventImage from './eventImage/EventImage';
@@ -54,6 +55,7 @@ const EventPage = (): ReactElement => {
       upcomingOccurrencesOnly: true,
     },
   });
+  const event = eventData?.event;
 
   // refetch event data (to get updated occurrences) if enrolment was created
   React.useEffect(() => {
@@ -98,7 +100,11 @@ const EventPage = (): ReactElement => {
 
   const requiredEnrolmentsSelected =
     selectedOccurrences.length === (neededOccurrences || 0);
-  const showEnrolmentButton = !!neededOccurrences && neededOccurrences > 1;
+  const showEnrolmentButton =
+    !!event &&
+    !!neededOccurrences &&
+    neededOccurrences > 1 &&
+    isEnrolmentStarted(event);
 
   return (
     <PageWrapper title={eventName || t('event:pageTitle')}>

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -372,6 +372,13 @@ it('renders occurrences table and related stuff correctly', async () => {
   renderComponent();
   await waitForRequestsToComplete();
 
+  // Notification about enrolment starting time shouldn't be rendered
+  expect(
+    screen.queryByRole('region', {
+      name: /notification/i,
+    })
+  ).not.toBeInTheDocument();
+
   const occurrencesTitle = screen.queryByText(
     eventMessages.occurrencesTitle.replace('{{count}}', '11')
   );
@@ -559,7 +566,8 @@ it('opens expanded area with enrolment button when clicked', async () => {
   });
 });
 
-it('expanded area does not have an enrolment button if enrollment has not yet begun', async () => {
+// eslint-disable-next-line max-len
+it('renders enrolment notification and expanded area does not have an enrolment button if enrollment has not yet begun', async () => {
   advanceTo(new Date(2020, 6, 10)); // Before enrolmentStart (2020-07-13T06:00:00+00:00)
   renderComponent({
     mocks: [
@@ -575,6 +583,12 @@ it('expanded area does not have an enrolment button if enrollment has not yet be
     ],
   });
   await waitForRequestsToComplete();
+
+  // Enrolment notification
+  const region = screen.getByRole('region', {
+    name: /notification/i,
+  });
+  within(region).getByText(/ilmoittautuminen alkaa 13\.7\.2020 klo 09:00/i);
 
   const occurrenceRow = within(screen.getAllByRole('row')[8]);
 
@@ -593,7 +607,9 @@ it('expanded area does not have an enrolment button if enrollment has not yet be
       name: 'Ilmoittaudu',
     })
   ).not.toBeInTheDocument();
-  expect(screen.queryByText(/Ilmoittautuminen alkaa/)).toBeInTheDocument();
+
+  // expanded info and notification on top of table has this text
+  expect(screen.queryAllByText(/Ilmoittautuminen alkaa/i)).toHaveLength(2);
 });
 
 it('filters occurrence list correctly when sate filters are selected', async () => {

--- a/src/domain/event/occurrences/OccurrencesTable.tsx
+++ b/src/domain/event/occurrences/OccurrencesTable.tsx
@@ -20,11 +20,14 @@ import formatTimeRange from '../../../utils/formatTimeRange';
 import {
   DATE_FORMAT,
   formatDateRange,
+  formatIntoDate,
+  formatIntoTime,
   formatLocalizedDate,
 } from '../../../utils/time/format';
 import { skipFalsyType } from '../../../utils/typescript.utils';
 import {
   getAmountOfSeatsLeft,
+  isEnrolmentStarted,
   isMultidayOccurrence,
   isUnenrollableOccurrence,
 } from '../../occurrence/utils';
@@ -88,9 +91,21 @@ const OccurrencesTable: React.FC<Props> = ({
   const visibleOccurrences = take(filteredOccurrences, occurrencesVisible);
   const showMoreButtonVisible =
     filteredOccurrences.length > occurrencesVisible && !hideLoadMoreButton;
+  const enrolmentStart = event.pEvent.enrolmentStart;
 
   return (
     <section className={styles.occurrenceTable}>
+      {!isEnrolmentStarted(event) && (
+        <Notification
+          className={styles.enrolmentNotification}
+          label={t('event:occurrenceList.enrolmentStartsLabel')}
+        >
+          {t('event:occurrenceList.enrolmentStartsAt', {
+            date: formatIntoDate(new Date(enrolmentStart)),
+            time: formatIntoTime(new Date(enrolmentStart)),
+          })}
+        </Notification>
+      )}
       <div className={styles.titleAndFilters}>
         <p className={styles.occurrencesTitle}>
           {t('event:occurrencesTitle', { count: occurrences.length })}{' '}
@@ -171,6 +186,7 @@ const OccurrenceEnrolmentTable: React.FC<{
 
   const isDisabledOccurrenceCheckbox = (occurrence: OccurrenceFieldsFragment) =>
     isUnenrollableOccurrence(occurrence, event) ||
+    !isEnrolmentStarted(event) ||
     (requiredOccurrencesSelected && !isSelectedOccurrence(occurrence));
 
   const columns = [

--- a/src/domain/event/occurrences/occurrences.module.scss
+++ b/src/domain/event/occurrences/occurrences.module.scss
@@ -5,7 +5,7 @@
   --date-filter-width: 160px;
   --inactive-date-filter-color: lightgrey;
 
-  margin-top: var(--spacing-xl);
+  margin-top: var(--spacing-m);
 
   .occurrencesTitle {
     font-weight: bold;
@@ -27,6 +27,13 @@
     justify-self: flex-end;
     padding: var(--spacing-s) 0;
     align-items: center;
+  }
+
+  .enrolmentNotification {
+    @include respond-above(sm) {
+      margin: 0 var(--spacing-2-xl);
+      width: auto;
+    }
   }
 
   .loadMoreButtonWrapper {


### PR DESCRIPTION
## Description :sparkles:

- Disable checkboxes in occurrence table if enrolment hasn't started
- Hide disabled enrolment button for multi occurrence events if enrolment hasn't started
- Add notification about enrolment starting time if it hasn't started yet


## Issues :bug:

### Closes :no_good_woman:

**[PT-1401](https://helsinkisolutionoffice.atlassian.net/browse/PT-1401):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

- Couple additions to current tests to test notification

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

<img width="1298" alt="Screenshot 2021-12-09 at 11 39 16" src="https://user-images.githubusercontent.com/15219142/145372129-4172fa6c-5012-49b0-86cb-718e6b57e60e.png">


## Additional notes :spiral_notepad:
