### PR TITLE
PT-1321 | Add support for email link for enrolment button

### DIFF
--- a/src/common/components/externalLink/ExternalLink.tsx
+++ b/src/common/components/externalLink/ExternalLink.tsx
@@ -6,18 +6,12 @@ import SrOnly from '../SrOnly/SrOnly';
 
 type Props = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
   href: string;
-  isEmail?: boolean;
 };
 
-const ExternalLink: React.FC<Props> = ({ children, isEmail, ...props }) => {
+const ExternalLink: React.FC<Props> = ({ children, ...props }) => {
   const { t } = useTranslation();
   return (
-    <a
-      {...props}
-      href={isEmail ? `mailto:${props.href}` : getExternalUrl(props.href)}
-      target="_blank"
-      rel="noreferrer"
-    >
+    <a {...props} href={props.href} target="_blank" rel="noreferrer">
       {children}
       <IconLinkExternal
         style={{ verticalAlign: 'middle', marginLeft: '0.5rem' }}
@@ -27,7 +21,7 @@ const ExternalLink: React.FC<Props> = ({ children, isEmail, ...props }) => {
   );
 };
 
-const getExternalUrl = (url: string) => {
+export const getExternalUrl = (url: string): string => {
   if (url.match(/^https?:\/\//)) {
     return url;
   }

--- a/src/common/components/externalLink/ExternalLink.tsx
+++ b/src/common/components/externalLink/ExternalLink.tsx
@@ -4,14 +4,17 @@ import * as React from 'react';
 
 import SrOnly from '../SrOnly/SrOnly';
 
-type Props = React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string };
+type Props = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+  href: string;
+  isEmail?: boolean;
+};
 
-const ExternalLink: React.FC<Props> = ({ children, ...props }) => {
+const ExternalLink: React.FC<Props> = ({ children, isEmail, ...props }) => {
   const { t } = useTranslation();
   return (
     <a
       {...props}
-      href={getExternalUrl(props.href)}
+      href={isEmail ? `mailto:${props.href}` : getExternalUrl(props.href)}
       target="_blank"
       rel="noreferrer"
     >

--- a/src/common/components/externalLink/__tests__/ExternalLink.test.tsx
+++ b/src/common/components/externalLink/__tests__/ExternalLink.test.tsx
@@ -21,3 +21,15 @@ it('contains link and sr texts + srOnly className', () => {
     'srOnly'
   );
 });
+
+it('renders email link with mailto: prefix', () => {
+  const email = 'test_email@email.com';
+  render(
+    <ExternalLink href={email} isEmail>
+      {linkText}
+    </ExternalLink>
+  );
+
+  const link = screen.queryByText(linkText);
+  expect(link).toHaveAttribute('href', `mailto:${email}`);
+});

--- a/src/common/components/externalLink/__tests__/ExternalLink.test.tsx
+++ b/src/common/components/externalLink/__tests__/ExternalLink.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import isEmail from '../../../../utils/isEmail';
 import { render, screen } from '../../../../utils/testUtils';
 import ExternalLink from '../ExternalLink';
 
@@ -22,10 +23,11 @@ it('contains link and sr texts + srOnly className', () => {
   );
 });
 
+// basically testing that isEmail function works
 it('renders email link with mailto: prefix', () => {
   const email = 'test_email@email.com';
   render(
-    <ExternalLink href={email} isEmail>
+    <ExternalLink href={isEmail(email) ? `mailto:${email}` : email}>
       {linkText}
     </ExternalLink>
   );

--- a/src/domain/event/occurrences/EnrolmentButtonCell.tsx
+++ b/src/domain/event/occurrences/EnrolmentButtonCell.tsx
@@ -8,6 +8,7 @@ import {
   OccurrenceFieldsFragment,
 } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
+import isEmail from '../../../utils/isEmail';
 import { formatIntoDate, formatIntoTime } from '../../../utils/time/format';
 import { isEnrolmentStarted } from '../../occurrence/utils';
 import { EnrolmentType } from '../constants';

--- a/src/domain/event/occurrences/OccurrenceEnrolmentButton.tsx
+++ b/src/domain/event/occurrences/OccurrenceEnrolmentButton.tsx
@@ -8,6 +8,7 @@ import {
   EventFieldsFragment,
   OccurrenceFieldsFragment,
 } from '../../../generated/graphql';
+import isEmail from '../../../utils/isEmail';
 import { formatIntoDate, formatIntoTime } from '../../../utils/time/format';
 import { isEnrolmentStarted } from '../../occurrence/utils';
 import EnrolmentError from './EnrolmentError';
@@ -52,6 +53,7 @@ const OccurrenceEnrolmentButton: React.FC<Props> = ({
       <ExternalLink
         href={externalEnrolmentUrl}
         className={styles.externalEnrolmentLink}
+        isEmail={isEmail(externalEnrolmentUrl)}
       >
         {t('occurrence:labelExternalEnrolmentLink')}
       </ExternalLink>

--- a/src/domain/event/occurrences/OccurrenceEnrolmentButton.tsx
+++ b/src/domain/event/occurrences/OccurrenceEnrolmentButton.tsx
@@ -3,7 +3,9 @@ import { IconAngleUp, Button } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import ExternalLink from '../../../common/components/externalLink/ExternalLink';
+import ExternalLink, {
+  getExternalUrl,
+} from '../../../common/components/externalLink/ExternalLink';
 import {
   EventFieldsFragment,
   OccurrenceFieldsFragment,
@@ -51,9 +53,13 @@ const OccurrenceEnrolmentButton: React.FC<Props> = ({
   if (externalEnrolmentUrl) {
     return (
       <ExternalLink
-        href={externalEnrolmentUrl}
+        href={
+          // users can also enter email as enrolment link
+          isEmail(externalEnrolmentUrl)
+            ? `mailto:${externalEnrolmentUrl}`
+            : getExternalUrl(externalEnrolmentUrl)
+        }
         className={styles.externalEnrolmentLink}
-        isEmail={isEmail(externalEnrolmentUrl)}
       >
         {t('occurrence:labelExternalEnrolmentLink')}
       </ExternalLink>

--- a/src/utils/isEmail.ts
+++ b/src/utils/isEmail.ts
@@ -1,0 +1,5 @@
+const isEmail = (url: string): boolean => {
+  return /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/.test(url);
+};
+
+export default isEmail;


### PR DESCRIPTION
## Description :sparkles:

- Add support for email link for enrolment button

## Issues :bug:

### Closes :no_good_woman:

**[PT-1321](https://helsinkisolutionoffice.atlassian.net/browse/PT-1321):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

- Should open email client when clicking enrolment link:

test url: http://localhost:3000/event/palvelutarjotin:af6z672j6m

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
