### PR TITLE
PT-1406 | Add event language to the include list in evets and events search pages

### DIFF
--- a/src/domain/events/EventsPage.tsx
+++ b/src/domain/events/EventsPage.tsx
@@ -47,7 +47,7 @@ const EventsPage = (): ReactElement => {
     isLoadingMore,
   } = useUpcomingEvents({
     variables: {
-      include: ['keywords', 'location', 'audience'],
+      include: ['keywords', 'location', 'audience', 'in_language'],
     },
   });
 

--- a/src/domain/events/__tests__/EventsPage.test.tsx
+++ b/src/domain/events/__tests__/EventsPage.test.tsx
@@ -100,7 +100,7 @@ const mocks: MockedResponse[] = [
     request: {
       query: UpcomingEventsDocument,
       variables: {
-        include: ['keywords', 'location', 'audience'],
+        include: ['keywords', 'location', 'audience', 'in_language'],
       },
     },
     result: {

--- a/src/domain/events/__tests__/EventsSearchPage.test.tsx
+++ b/src/domain/events/__tests__/EventsSearchPage.test.tsx
@@ -95,7 +95,7 @@ const mocks: MockedResponse[] = [
     request: {
       query: EventsDocument,
       variables: {
-        include: ['keywords', 'location', 'audience'],
+        include: ['keywords', 'location', 'audience', 'in_language'],
         keyword: [],
         allOngoingAnd: null,
         inLanguage: '',

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -42,7 +42,7 @@ export const getEventFilterVariables = (
 ): EventsQueryVariables => {
   const search = getTextFromDict(query, 'text', undefined);
   return {
-    include: ['keywords', 'location', 'audience'],
+    include: ['keywords', 'location', 'audience', 'in_language'],
     allOngoingAnd: search ? [search] : null,
     inLanguage: getTextFromDict(query, 'inLanguage', undefined),
     keyword: getKeywordsToQuery(query),


### PR DESCRIPTION
## Description :sparkles:

There were some issues in listing languages in event details in single event page. This was cause by caching issue when in_language wasn't in include list when fetching events in events search page.

Not sure if we should just have one constant variable for include list and use it everywhere or do some other thing with inLanguages caching. Issue arised when event page is refreshed or navigated at first, then going to the search page where events are fetched and inLanguage field is overridden with null values. If previously fetched single event was viewed again, the would be no languages

## Issues :bug:

### Closes :no_good_woman:

**[PT-1406](https://helsinkisolutionoffice.atlassian.net/browse/PT-1406):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
