### PR TITLE
PT-1477 |  Update organisation events link to target correct page

### DIFF
--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -53,6 +53,7 @@ const data = {
   name: 'Testitapahtuma',
   description: 'Tapahtuman pitkä kuvaus',
   organisationName: 'Testiorganisaatio',
+  organisationId: 'organisationId-test',
   contactPersonName: 'contact person',
   contactPersonEmail: 'testi@testaaja.fi',
   contactPersonPhoneNumber: '123321123',
@@ -144,7 +145,10 @@ const occurrences = [
 const pEventData = fakePEvent({
   enrolmentEndDays: 1,
   enrolmentStart: '2020-07-13T06:00:00+00:00',
-  organisation: fakeOrganisation({ name: data.organisationName }),
+  organisation: fakeOrganisation({
+    name: data.organisationName,
+    id: data.organisationId,
+  }),
   contactPhoneNumber: data.contactPersonPhoneNumber,
   contactEmail: data.contactPersonEmail,
   contactPerson: fakePerson({
@@ -332,6 +336,14 @@ it('renders page and event information correctly', async () => {
       screen.getByRole(item.role, { name: item.name })
     ).toBeInTheDocument();
   });
+
+  const organisationEventsLink = screen.getByRole('link', {
+    name: /näytä järjestäjän tapahtumat/i,
+  });
+  expect(organisationEventsLink).toHaveAttribute(
+    'href',
+    `${ROUTES.EVENTS_SEARCH}?organisation=${data.organisationId}`
+  );
 
   // Event image should have correct src url
   const eventImage = screen.queryByRole('img', {

--- a/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
+++ b/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
@@ -9,6 +9,7 @@ import { EventFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import IconTicket from '../../../icons/IconTicket';
 import addUrlSlashes from '../../../utils/addUrlSlashes';
+import { ROUTES } from '../../app/routes/constants';
 import { getEventFields } from '../utils';
 import styles from './eventBasicInfo.module.scss';
 import EventCategorisation from './EventCategorisation';
@@ -99,7 +100,7 @@ const OrganisationInfo: React.FC<{
   contactPhoneNumber,
 }) => {
   const { t } = useTranslation();
-  const organisationSearchUrl = `/?organisation=${organisationId}`;
+  const organisationSearchUrl = `${ROUTES.EVENTS_SEARCH}/?organisation=${organisationId}`;
   return (
     <div>
       <p className={styles.organisation}>{organisation}</p>


### PR DESCRIPTION
## Description :sparkles:

Show organisations other event button was linking to front page which doesn't support searching with organisation id. Update link to go to event search page.

## Issues :bug:

### Closes :no_good_woman:

**[PT-1477](https://helsinkisolutionoffice.atlassian.net/browse/PT-1477):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
