### PR TITLE
feat(search): added a isFree -filter to the events search

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "waait": "^1.0.5"
   },
   "lint-staged": {
-    "src/**/*.{tsx,ts}": [
+    "src/**/*.{tsx,ts,scss}": [
       "eslint --fix",
       "stylelint --fix",
       "prettier --write",

--- a/public/locales/en/events.json
+++ b/public/locales/en/events.json
@@ -28,6 +28,7 @@
     "labelEndDate": "To",
     "labelPlaces": "Places",
     "labelDivisions": "Areas",
+    "labelIsFree": "Show only events that are free",
     "divisionInputPlaceholder": "Write search word",
     "selectAllDivisions": "All areas",
     "labelCategories": "Categories",

--- a/public/locales/fi/events.json
+++ b/public/locales/fi/events.json
@@ -28,6 +28,7 @@
     "labelEndDate": "Päättyen",
     "labelPlaces": "Paikat",
     "labelDivisions": "Alueet",
+    "labelIsFree": "Näytä vain maksuttomat",
     "divisionInputPlaceholder": "Kirjoita hakusana",
     "selectAllDivisions": "Kaikki alueet",
     "labelCategories": "Kategoriat",

--- a/public/locales/sv/events.json
+++ b/public/locales/sv/events.json
@@ -28,6 +28,7 @@
     "labelEndDate": "I slutet",
     "labelPlaces": "Platser",
     "labelDivisions": "Områden",
+    "labelIsFree": "Visa endast avgiftsfria",
     "selectAllDivisions": "Alla områden",
     "divisionInputPlaceholder": "Skriv sökord",
     "labelCategories": "Kategorier",

--- a/src/common/components/form/fields/CheckboxField.tsx
+++ b/src/common/components/form/fields/CheckboxField.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { FieldProps } from 'formik';
 import { Checkbox, CheckboxProps } from 'hds-react';
 import { useTranslation } from 'next-i18next';
@@ -12,6 +13,7 @@ const CheckboxField: React.FC<Props> = (props) => {
   const {
     field: { name, ...field },
     form: { errors, touched },
+    className,
     ...rest
   } = props;
 
@@ -24,7 +26,7 @@ const CheckboxField: React.FC<Props> = (props) => {
       {...rest}
       id={name}
       checked={field.value}
-      className={errorText ? invalidFieldClass : undefined}
+      className={classNames(className, { [invalidFieldClass]: errorText })}
     />
   );
 };

--- a/src/domain/events/EventsSearchPage.tsx
+++ b/src/domain/events/EventsSearchPage.tsx
@@ -117,8 +117,16 @@ export const useEventsSearch = () => {
     [router.query]
   );
 
-  const { allOngoingAnd, division, end, inLanguage, start, keyword, location } =
-    variables;
+  const {
+    allOngoingAnd,
+    division,
+    end,
+    inLanguage,
+    start,
+    keyword,
+    location,
+    isFree,
+  } = variables;
 
   const filterActive =
     !!allOngoingAnd?.length ||
@@ -127,6 +135,7 @@ export const useEventsSearch = () => {
     !!keyword?.length ||
     !!location ||
     !!end ||
+    !!isFree ||
     start !== 'now';
 
   const [sort, setSort] = React.useState<EVENT_SORT_OPTIONS>(

--- a/src/domain/events/__tests__/EventsSearchPage.test.tsx
+++ b/src/domain/events/__tests__/EventsSearchPage.test.tsx
@@ -290,6 +290,7 @@ const advancedSearchInputLabels = [
   'Aktiviteetit',
   'Alueet',
   'Kielet',
+  'Näytä vain maksuttomat',
 ];
 
 function testAdvancedSearchNotVisible() {

--- a/src/domain/events/eventSearchForm/EventSearchForm.tsx
+++ b/src/domain/events/eventSearchForm/EventSearchForm.tsx
@@ -4,6 +4,7 @@ import { Button, IconSearch } from 'hds-react';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 
+import CheckboxField from '../../../common/components/form/fields/CheckboxField';
 import DateInputField from '../../../common/components/form/fields/DateInputField';
 import DivisionSelectorField from '../../../common/components/form/fields/DivisionSelectorField';
 import MultiDropdownField from '../../../common/components/form/fields/MultiDropdownField';
@@ -24,6 +25,7 @@ export type EventSearchFormValues = {
   divisions: string[];
   organisation?: string;
   organisationId?: string;
+  isFree: boolean;
   [KEYWORD_QUERY_PARAMS.TARGET_GROUPS]: string[];
   [KEYWORD_QUERY_PARAMS.CATEGORIES]: string[];
   [KEYWORD_QUERY_PARAMS.ADDITIONAL_CRITERIA]: string[];
@@ -41,6 +43,7 @@ const defaultEnrolmentInitialValues: EventSearchFormValues = {
   divisions: [],
   organisation: '',
   organisationId: '',
+  isFree: false,
 };
 
 export enum PanelState {
@@ -170,57 +173,67 @@ const EventSearchForm = ({
                 </div>
               )}
               {isAdvancedSearch && (
-                <div className={styles.filtersRow4}>
-                  <Field
-                    hideLabel
-                    name="categories"
-                    className={styles.selectInput}
-                    component={MultiDropdownField}
-                    label={t('events:search.labelCategories')}
-                    placeholder={t('events:search.labelCategories')}
-                    clearButtonAriaLabel={t(
-                      'events:search.accessibility.categoryDropdown.clearButtonAriaLabel'
-                    )}
-                    selectedItemRemoveButtonAriaLabel={t(
-                      'events:search.accessibility.categoryDropdown.selectedItemRemoveButtonAriaLabel'
-                    )}
-                    options={categoryKeywords}
-                  />
-                  <Field
-                    hideLabel
-                    name="additionalCriteria"
-                    className={styles.selectInput}
-                    component={MultiDropdownField}
-                    label={t('events:search.labelActivities')}
-                    placeholder={t('events:search.labelActivities')}
-                    clearButtonAriaLabel={t(
-                      'events:search.accessibility.activityDropdown.clearButtonAriaLabel'
-                    )}
-                    selectedItemRemoveButtonAriaLabel={t(
-                      'events:search.accessibility.activityDropdown.selectedItemRemoveButtonAriaLabel'
-                    )}
-                    options={additionalCriteriaKeywords}
-                  />
-                  <Field
-                    component={DivisionSelectorField}
-                    className={styles.selectInput}
-                    name="divisions"
-                    showSearch={true}
-                    title={t('events:search.labelDivisions')}
-                    inputPlaceholder={t(
-                      'events:search.divisionInputPlaceholder'
-                    )}
-                  />
-                  <Field
-                    hideLabel
-                    name="inLanguage"
-                    className={styles.selectInput}
-                    component={MultiDropdownField}
-                    label={t('events:search.labelLanguage')}
-                    placeholder={t('events:search.labelLanguage')}
-                    options={languageOptions}
-                  />
-                </div>
+                <>
+                  <div className={styles.filtersRow4}>
+                    <Field
+                      hideLabel
+                      name="categories"
+                      className={styles.selectInput}
+                      component={MultiDropdownField}
+                      label={t('events:search.labelCategories')}
+                      placeholder={t('events:search.labelCategories')}
+                      clearButtonAriaLabel={t(
+                        'events:search.accessibility.categoryDropdown.clearButtonAriaLabel'
+                      )}
+                      selectedItemRemoveButtonAriaLabel={t(
+                        'events:search.accessibility.categoryDropdown.selectedItemRemoveButtonAriaLabel'
+                      )}
+                      options={categoryKeywords}
+                    />
+                    <Field
+                      hideLabel
+                      name="additionalCriteria"
+                      className={styles.selectInput}
+                      component={MultiDropdownField}
+                      label={t('events:search.labelActivities')}
+                      placeholder={t('events:search.labelActivities')}
+                      clearButtonAriaLabel={t(
+                        'events:search.accessibility.activityDropdown.clearButtonAriaLabel'
+                      )}
+                      selectedItemRemoveButtonAriaLabel={t(
+                        'events:search.accessibility.activityDropdown.selectedItemRemoveButtonAriaLabel'
+                      )}
+                      options={additionalCriteriaKeywords}
+                    />
+                    <Field
+                      component={DivisionSelectorField}
+                      className={styles.selectInput}
+                      name="divisions"
+                      showSearch={true}
+                      title={t('events:search.labelDivisions')}
+                      inputPlaceholder={t(
+                        'events:search.divisionInputPlaceholder'
+                      )}
+                    />
+                    <Field
+                      hideLabel
+                      name="inLanguage"
+                      className={styles.selectInput}
+                      component={MultiDropdownField}
+                      label={t('events:search.labelLanguage')}
+                      placeholder={t('events:search.labelLanguage')}
+                      options={languageOptions}
+                    />
+                  </div>
+                  <div className={styles.filtersRow4}>
+                    <Field
+                      component={CheckboxField}
+                      name="isFree"
+                      label={t('events:search.labelIsFree')}
+                      className={styles.checkboxInput}
+                    />
+                  </div>
+                </>
               )}
               <div>
                 <FilterSummary filters={initialValues} />

--- a/src/domain/events/eventSearchForm/eventSearchForm.module.scss
+++ b/src/domain/events/eventSearchForm/eventSearchForm.module.scss
@@ -70,6 +70,12 @@
   }
 }
 
+.checkboxInput {
+  --size: 30px !important;
+  --label-color: var(--color-white) !important;
+  --background-unselected: var(--color-white) !important;
+}
+
 .contentWrapper {
   display: grid;
   grid-gap: var(--grid-gap-mobile);

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -18,6 +18,7 @@ export const getSearchQueryObject = (
     ...values,
     date: values.date?.toISOString(),
     endDate: values.endDate?.toISOString(),
+    isFree: values.isFree ? 'true' : undefined,
   });
 };
 
@@ -51,6 +52,7 @@ export const getEventFilterVariables = (
     location: getTextFromDict(query, 'places', undefined),
     organisationId: getTextFromDict(query, 'organisation', undefined),
     division: getTextFromDict(query, 'divisions', undefined),
+    isFree: query.isFree === 'true' ? true : undefined,
     ...options,
   };
 };
@@ -91,6 +93,7 @@ export const getInitialValues = (
     inLanguage: queryParameterToArray(query.inLanguage as EVENT_LANGUAGES),
     places: queryParameterToArray(query.places),
     divisions: queryParameterToArray(query.divisions),
+    isFree: query.isFree === 'true',
     [KEYWORD_QUERY_PARAMS.TARGET_GROUPS]: queryParameterToArray(
       query[KEYWORD_QUERY_PARAMS.TARGET_GROUPS]
     ),


### PR DESCRIPTION
PT-1437 PT-1440

3 results without filter (2 of them are free):
<img width="995" alt="image" src="https://user-images.githubusercontent.com/389204/162761250-85cee066-0d09-42b6-a4f1-82f67d3580b9.png">

When the isFree checkbox is checked, only 2 results are visible (and they both are free)
<img width="1009" alt="image" src="https://user-images.githubusercontent.com/389204/162761302-7390f909-a8de-4e34-bcff-adee7ad64f69.png">
