### PR TITLE
PT-1496 | Add root navigation item as the first link

### DIFF
--- a/src/domain/app/header/Header.tsx
+++ b/src/domain/app/header/Header.tsx
@@ -100,6 +100,13 @@ const Header: React.FC = () => {
                       closeOnItemClick
                       active={isTabActive(getCmsPath(item?.uri ?? ''))}
                     >
+                      <Navigation.Item
+                        label={item.title}
+                        as={Link}
+                        href={getCmsPath(stripLocaleFromUri(item.uri ?? ''))}
+                        lang={locale}
+                        locale={locale}
+                      />
                       {item.children.map((child) => {
                         return (
                           <Navigation.Item

--- a/src/domain/app/header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/domain/app/header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -585,6 +585,17 @@ exports[`navigation renders menus and dropdown menus 1`] = `
                   >
                     <a
                       class="Menu-module_item__3yQdE "
+                      href="/cms-page/helsinki-liikkuu"
+                      lang="fi"
+                    >
+                      <span
+                        class="NavigationItem-module_label__1UsXG button_hds-button__label__3r3Mi"
+                      >
+                        Mikä Kultus?
+                      </span>
+                    </a>
+                    <a
+                      class="Menu-module_item__3yQdE "
                       href="/cms-page/helsinki-liikkuu/alisivu"
                       lang="fi"
                     >


### PR DESCRIPTION
## Description :sparkles:

Adds root page links as the first link in the dropdown so that the root page is more easily accessible.

## Issues :bug:

### Closes :no_good_woman:

**[PT-1496](https://helsinkisolutionoffice.atlassian.net/browse/PT-1496)**

## Screenshots :camera_flash:

<img width="800" alt="Screenshot 2022-04-20 at 13 55 23" src="https://user-images.githubusercontent.com/9090689/164216357-de7968fb-e4d6-45c7-a6b5-55eb0e9518a8.png">
