### PR TITLE
PT-1573 | fix study level grade translations, e.g. "3rd class"

### DIFF
--- a/public/locales/en/enrolment.json
+++ b/public/locales/en/enrolment.json
@@ -85,10 +85,12 @@
     "title": "Selected event times"
   },
   "studyLevel": {
-    "grade_interval": "(1){1st grade};(2){2nd grade};",
-    "grade_plural": "{{count}}th grade",
+    "grade1": "1st grade",
+    "grade2": "2nd grade",
+    "grade3": "3rd grade",
+    "grade_with_count": "{{count}}th grade",
     "preschool": "5-6 aged",
-    "secondary": "secondary level students",
+    "secondary": "Secondary level students",
     "age02": "0-2 aged",
     "age34": "3-4 aged",
     "other": "Other group"

--- a/public/locales/fi/enrolment.json
+++ b/public/locales/fi/enrolment.json
@@ -85,8 +85,10 @@
     "title": "Valitut tapahtuma-ajat"
   },
   "studyLevel": {
-    "grade": "{{count}}. luokka",
-    "grade_plural": "{{count}}. luokka",
+    "grade1": "1. luokka",
+    "grade2": "2. luokka",
+    "grade3": "3. luokka",
+    "grade_with_count": "{{count}}. luokka",
     "preschool": "5-6 -vuotiaat",
     "secondary": "Toisen asteen opiskelijat",
     "age02": "0-2 -vuotiaat",

--- a/public/locales/sv/enrolment.json
+++ b/public/locales/sv/enrolment.json
@@ -86,8 +86,10 @@
   },
   "pageTitle": "Anmäl dig till evenemanget",
   "studyLevel": {
-    "grade": "{{count}}: Åk",
-    "grade_plural": "{{count}}: Åk",
+    "grade1": "1:a klass",
+    "grade2": "2:a klass",
+    "grade3": "3:e klass",
+    "grade_with_count": "{{count}}:e klass",
     "preschool": "5-6 åringar",
     "secondary": "Gymnasie- och yrkesutbildning",
     "age02": "0-2 åringar",

--- a/src/domain/studyLevel/useStudyLevels.ts
+++ b/src/domain/studyLevel/useStudyLevels.ts
@@ -28,13 +28,21 @@ export default function useStudyLevels(): StudyLevelsState {
       if (!level) {
         return { label: '', value: '' };
       }
+      if (level.startsWith('GRADE_')) {
+        // TECHNICAL DEBT: The ordinal number translations could be done using i18next
+        // but that would require at least v21.0.0 of i18next which is a major breaking
+        // release.
+        const count = Number(level.split('_')[1]);
+        if (count > 3) {
+          return {
+            label: t('enrolment:studyLevel.grade_with_count', { count: count }),
+            value: level,
+          };
+        }
+      }
+
       return {
-        label: level.startsWith('GRADE')
-          ? t('enrolment:studyLevel.grade_interval', {
-              postProcess: 'interval',
-              count: Number(level.split('_')[1]),
-            })
-          : translateValue('enrolment:studyLevel.', level, t),
+        label: translateValue('enrolment:studyLevel.', level, t),
         value: level,
       };
     }) ?? [];


### PR DESCRIPTION
## Description :sparkles:

### fix: fix study level grade translations, e.g. "3rd class"

NOTE: There is TECHNICAL DEBT:
 - The ordinal number translations could be done using i18next but that would require at least v21.0.0 of i18next which is a major breaking release.
 - Without upgrading to at least v21.0.0 i18next just using a hardcoded support for translating ordinal study level grades with keys:
   - grade1 for study level grade 1
   - grade2 for study level grade 2
   - grade3   for study level grade 3
   - grade_with_count for study level grades > 3

refs PT-1573

## Issues :bug:

### Closes :no_good_woman:

**[PT-1573](https://helsinkisolutionoffice.atlassian.net/browse/PT-1573)**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

### Study level grade translations (Finnish/English/Swedish):
- ![fi](https://user-images.githubusercontent.com/77663720/221417970-e0a0b1ac-a221-44c4-850b-13d628be54fc.png)
- ![en](https://user-images.githubusercontent.com/77663720/221417972-36cf704a-fc9b-4032-9074-ace19ed5e233.png)
- ![sv](https://user-images.githubusercontent.com/77663720/221417974-198609ab-fdd8-49ad-b49c-fbfad3b1bfe3.png)

## Additional notes :spiral_notepad:

[PT-1573]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ