### PR TITLE
Move enrol to queue button below the occurrences table and hide it when queue should not be possible

### DIFF
--- a/public/locales/en/enrolment.json
+++ b/public/locales/en/enrolment.json
@@ -97,8 +97,11 @@
   },
   "title": "Enrol for the event",
   "titleEnquiry": "Enquiry for the event",
+  "enrolment": {
+    "title": "Enrolment"
+  },
   "queue": {
-    "title": "Enrolment",
+    "title": "Queue enrolment",
     "enrol": "Enrol to queue",
     "enrolText": "Is the event fully booked? Enroll to queue if you are interested in cancellations.",
     "submit": "Submit your enrolment to queue",

--- a/public/locales/fi/enrolment.json
+++ b/public/locales/fi/enrolment.json
@@ -97,8 +97,11 @@
   },
   "title": "Ilmoittaudu tapahtumaan",
   "titleEnquiry": "Varaustiedustelu tapahtumaan",
+  "enrolment": {
+    "title": "Ilmoittautuminen"
+  },
   "queue": {
-    "title": "Ilmoittautuminen",
+    "title": "Jonoon ilmoittautuminen",
     "enrol": "Ilmoittaudu jonoon",
     "enrolText": "Ovatko haluamasi ajat täynnä? Ilmoittaudu jonoon, jos haluat tietoa peruutuspaikoista.",
     "submit": "Lähetä ilmoittautuminen jonoon",

--- a/public/locales/sv/enrolment.json
+++ b/public/locales/sv/enrolment.json
@@ -98,8 +98,11 @@
   },
   "title": "Anmäl dig till evenemanget",
   "titleEnquiry": "Bokningsförfrågan till evenemanget",
+  "enrolment": {
+    "title": "Anmälning"
+  },
   "queue": {
-    "title": "Anmälning",
+    "title": "Köanmälning",
     "enrol": "Anmäl dig i kö",
     "enrolText": "Är de önskade tiderna fullbokade? Ställ dig i kö om du vill få information om avbokningar.",
     "submit": "Skicka anmälan för att köa",

--- a/src/domain/event/EventPage.tsx
+++ b/src/domain/event/EventPage.tsx
@@ -156,9 +156,7 @@ const EventPage = (): ReactElement => {
                 />
               )}
               <EventBasicInfo event={eventData.event} />
-              <h2 className={styles.enrolmentHeader}>
-                {t('enrolment:enrolment.title')}
-              </h2>
+
               {occurrences && (
                 <div
                   className={styles.occurrencesContainer}

--- a/src/domain/event/EventPage.tsx
+++ b/src/domain/event/EventPage.tsx
@@ -153,12 +153,9 @@ const EventPage = (): ReactElement => {
                 />
               )}
               <EventBasicInfo event={eventData.event} />
-              <QueueFormContainer
-                event={eventData.event}
-                handleOnQueue={handleOnQueue}
-                setShowQueueForm={setShowQueueForm}
-                showQueueForm={showQueueForm}
-              />
+              <h2 className={styles.enrolmentHeader}>
+                {t('enrolment:enrolment.title')}
+              </h2>
               {occurrences && (
                 <div
                   className={styles.occurrencesContainer}
@@ -194,6 +191,12 @@ const EventPage = (): ReactElement => {
                   showEnrolmentForm={showEnrolmentButton}
                 />
               )}
+              <QueueFormContainer
+                event={eventData.event}
+                handleOnQueue={handleOnQueue}
+                setShowQueueForm={setShowQueueForm}
+                showQueueForm={showQueueForm}
+              />
               <div className={styles.sharePart}>
                 <div></div>
                 <div>

--- a/src/domain/event/EventPage.tsx
+++ b/src/domain/event/EventPage.tsx
@@ -14,7 +14,7 @@ import EventPageMeta from './eventPageMeta/EventPageMeta';
 import EnrolmentFormSection from './occurrences/EnrolmentFormSection';
 import Occurrences from './occurrences/OccurrencesTable';
 import QueueFormSection from './occurrences/QueueFormSection';
-import { getEventFields } from './utils';
+import { getEventFields, shouldEventSupportQueueEnrolments } from './utils';
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
 import ShareLinks from '../../common/components/shareLinks/ShareLinks';
 import {
@@ -115,6 +115,9 @@ const EventPage = (): ReactElement => {
     neededOccurrences > 1 &&
     isEnrolmentStarted(event);
 
+  // Show the queue controls only when the enrolments has started and they are handled internally
+  const isQueueEnrolmentAvailable = shouldEventSupportQueueEnrolments(event);
+
   return (
     <PageWrapper title={eventName || t('event:pageTitle')}>
       <LoadingSpinner isLoading={loading}>
@@ -191,12 +194,14 @@ const EventPage = (): ReactElement => {
                   showEnrolmentForm={showEnrolmentButton}
                 />
               )}
-              <QueueFormContainer
-                event={eventData.event}
-                handleOnQueue={handleOnQueue}
-                setShowQueueForm={setShowQueueForm}
-                showQueueForm={showQueueForm}
-              />
+              {isQueueEnrolmentAvailable && (
+                <QueueFormContainer
+                  event={eventData.event}
+                  handleOnQueue={handleOnQueue}
+                  setShowQueueForm={setShowQueueForm}
+                  showQueueForm={showQueueForm}
+                />
+              )}
               <div className={styles.sharePart}>
                 <div></div>
                 <div>

--- a/src/domain/event/eventPage.module.scss
+++ b/src/domain/event/eventPage.module.scss
@@ -29,7 +29,8 @@
 }
 
 h2.enrolmentHeader {
-  font-size: var(--fontsize-heading-l);
+  padding-top: var(--spacing-m);
+  font-size: var(--fontsize-heading-m);
 }
 
 .enrolmentText {

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -21,6 +21,7 @@ import {
 import { Language } from '../../types';
 import getLocalisedString from '../../utils/getLocalisedString';
 import { formatIntoTime, formatLocalizedDate } from '../../utils/time/format';
+import { isEnrolmentStarted } from '../occurrence/utils';
 
 export const getEventPlaceholderImage = (id: string): string => {
   const numbers = id.match(/\d+/g);
@@ -168,4 +169,20 @@ export const getEnrolmentType = (
     return EnrolmentType.Internal;
   }
   return EnrolmentType.Unenrollable;
+};
+
+/**
+ * Does the event support enrolling in the queue?
+ * 1. Are the enrolments handled internally in the Kultus
+ * 2. Has the enrolment started already
+ */
+export const shouldEventSupportQueueEnrolments = (
+  event?: EventFieldsFragment | null
+) => {
+  if (!event?.pEvent) return false;
+  const hasInternalEnrolments =
+    getEnrolmentType(event.pEvent) === EnrolmentType.Internal;
+  const hasEnrolmentStarted = isEnrolmentStarted(event);
+  // Show the queue controls only when the enrolments has started and they are handled internally
+  return hasInternalEnrolments && hasEnrolmentStarted;
 };

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -173,9 +173,9 @@ export const getEnrolmentType = (
 
 /**
  * Does the event support enrolling in the queue?
- * 1. Are the enrolments handled internally in the Kultus
- * 2. Has the enrolment started already
- * 3. Are there any occurrences for the event
+ * @return True if enrolments are handled internally in Kultus,
+ * the enrolment has started and there is at least one occurrence
+ * for the event, otherwise False.
  */
 export const shouldEventSupportQueueEnrolments = (
   event?: EventFieldsFragment | null

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -175,6 +175,7 @@ export const getEnrolmentType = (
  * Does the event support enrolling in the queue?
  * 1. Are the enrolments handled internally in the Kultus
  * 2. Has the enrolment started already
+ * 3. Are there any occurrences for the event
  */
 export const shouldEventSupportQueueEnrolments = (
   event?: EventFieldsFragment | null
@@ -183,6 +184,6 @@ export const shouldEventSupportQueueEnrolments = (
   const hasInternalEnrolments =
     getEnrolmentType(event.pEvent) === EnrolmentType.Internal;
   const hasEnrolmentStarted = isEnrolmentStarted(event);
-  // Show the queue controls only when the enrolments has started and they are handled internally
-  return hasInternalEnrolments && hasEnrolmentStarted;
+  const hasOccurrences = event.pEvent.occurrences?.edges?.length;
+  return hasInternalEnrolments && hasEnrolmentStarted && hasOccurrences;
 };


### PR DESCRIPTION
PT-1686
Move enrol to queue button below the occurrences table. Change the style and the text of the heading.

PT-1678
The event queue form should be hidden when there are no occurrences

PT-1677
The event queue form should be available only for the events with internal enrolment when the enrolment period has already started.

Second try for #287 .

----

### The event queue section is below the occurrences table when a single internal enrolment is required

<img width="1024" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin-ui/assets/389204/136e2498-db9a-48fe-92c9-085772418b7e">

The form can be opened and used

<img width="465" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin-ui/assets/389204/a1e26d3f-a1f2-4823-b47f-795b5ec1d718">

### The event queue section is below the occurrences table when multiple internal enrolments are required

<img width="1048" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin-ui/assets/389204/821830a1-b93e-4e62-8382-4a131258d2a5">


### The queue enrolment controls are hidden when the event has external enrolments:

<img width="1031" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin-ui/assets/389204/c274c18b-9edd-4610-bf0d-7cb2b4100fae">


### The event queue section is hidden when the event has no enrolments

<img width="1054" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin-ui/assets/389204/ffb928be-3e30-4c7a-9daa-5be2d921ada7">

### The event queue section is hidden when the event has no occurrences

<img width="1058" alt="image" src="https://github.com/City-of-Helsinki/palvelutarjotin-ui/assets/389204/49cce403-0238-4901-a06b-5580aafee22b">
