### PR TITLE
PT-1694 | feat: update extra needs field's helper text

### DIFF
--- a/public/locales/en/enrolment.json
+++ b/public/locales/en/enrolment.json
@@ -28,7 +28,7 @@
         "labelName": "Name",
         "labelPhoneNumber": "Phone number"
       },
-      "helperExtraNeeds": "Add here if you want to tell the organizer something else relevant to your group",
+      "helperExtraNeeds": "Please add here if you wish to provide any other essential information about your group (e.g., information relevant to language skills or accessibility that may be necessary for the organizer). Please refrain from sharing information that violates privacy, thank you.",
       "helperGroupName": "Unique name of the group, for example: 4a",
       "labelAmountOfAdult": "Adults",
       "labelExtraNeedsOptional": "Additional information (optional)",

--- a/public/locales/fi/enrolment.json
+++ b/public/locales/fi/enrolment.json
@@ -28,7 +28,7 @@
         "labelName": "Nimi",
         "labelPhoneNumber": "Puhelinnumero"
       },
-      "helperExtraNeeds": "Lisää tähän, jos haluat kertoa järjestäjälle jotain muuta olennaista ryhmästänne",
+      "helperExtraNeeds": "Lisää tähän, jos haluat kertoa jotain muuta olennaista ryhmästänne (esim. kielitaitoon tai esteettömyyteen liittyviä järjestäjälle tarpeellisia tietoja). Ethän ilmoita sellaisia tietoja, jotka loukkaavat yksityisyyden suojaa, kiitos.",
       "helperGroupName": "Ryhmän yksilöivä nimi, esimerkiksi: 4a",
       "labelAmountOfAdult": "Aikuisia",
       "labelExtraNeedsOptional": "Lisätiedot (valinnainen)",

--- a/public/locales/sv/enrolment.json
+++ b/public/locales/sv/enrolment.json
@@ -28,7 +28,7 @@
         "labelName": "Namn",
         "labelPhoneNumber": "Telefonnummer"
       },
-      "helperExtraNeeds": "Ytterligare relevant info till arrangören om din grupp",
+      "helperExtraNeeds": "Vill du berätta något annat viktigt om din grupp (t.ex. nödvändig information för arrangören relaterad till språkkunskaper eller tillgänglighet)? Vänligen lämna inte information som bryter mot integritetsskyddet, tack.",
       "helperGroupName": "Gruppens unika namn, t.ex. 4a",
       "labelAmountOfAdult": "Vuxna",
       "labelExtraNeedsOptional": "Ytterligare information (valfri)",


### PR DESCRIPTION
## Description :sparkles:

### feat: update extra needs field's helper text

closes PT-1694

## Issues :bug:

### Closes :no_good_woman:

[PT-1694](https://helsinkisolutionoffice.atlassian.net/browse/PT-1694)

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[PT-1694]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ