### PR TITLE
PT-1695 | feat: add specific toast error message for event full when enrolling

### DIFF
--- a/public/locales/en/enrolment.json
+++ b/public/locales/en/enrolment.json
@@ -56,6 +56,7 @@
   },
   "errors": {
     "createFailed": "Failed to create enrolment",
+    "createFailedBecauseNotEnoughCapacity": "Unfortunately, the event is already full. You can try to enrol for another event.",
     "label": {
       "enrolmentClosedError": "Registration ended",
       "enrolmentNotStartedError": "Registration has not opened",

--- a/public/locales/fi/enrolment.json
+++ b/public/locales/fi/enrolment.json
@@ -56,6 +56,7 @@
   },
   "errors": {
     "createFailed": "Ilmoittautumisen luominen epäonnistui",
+    "createFailedBecauseNotEnoughCapacity": "Valitettavasti tapahtuma on ehtinyt jo täyttyä. Voit koittaa ilmoittautua toiseen tapahtumaan.",
     "label": {
       "enrolmentClosedError": "Ilmoittautuminen päättynyt",
       "enrolmentNotStartedError": "Ilmoitautuminen ei ole avautunut",

--- a/public/locales/sv/enrolment.json
+++ b/public/locales/sv/enrolment.json
@@ -56,6 +56,7 @@
   },
   "errors": {
     "createFailed": "Misslyckades med att skapa registrering",
+    "createFailedBecauseNotEnoughCapacity": "Tyvärr är evenemanget redan fullbokat. Du kan försöka anmäla dig till ett annat evenemang.",
     "label": {
       "enrolmentClosedError": "Registreringen avslutades",
       "enrolmentNotStartedError": "Registreringen har inte öppnats",

--- a/src/domain/event/occurrences/EnrolmentFormSection.tsx
+++ b/src/domain/event/occurrences/EnrolmentFormSection.tsx
@@ -1,3 +1,4 @@
+import { isApolloError } from '@apollo/client';
 import { omit } from 'lodash';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
@@ -14,7 +15,10 @@ import useLocale from '../../../hooks/useLocale';
 import { saveDataForRecommendedEventsQuery } from '../../../utils/recommendedEventsUtils';
 import { assertUnreachable } from '../../../utils/typescript.utils';
 import { ROUTES } from '../../app/routes/constants';
-import { ENROLMENT_URL_PARAMS } from '../../enrolment/constants';
+import {
+  ENROLMENT_ERRORS,
+  ENROLMENT_URL_PARAMS,
+} from '../../enrolment/constants';
 import {
   EnrolmentFormFields,
   defaultEnrolmentInitialValues,
@@ -68,9 +72,20 @@ const EnrolmentFormSection: React.FC<{
       });
       onEnrol?.();
     } catch (e) {
-      toast(t('enrolment:errors.createFailed'), {
-        type: toast.TYPE.ERROR,
-      });
+      const isNotEnoughCapacityError =
+        e instanceof Error &&
+        isApolloError(e) &&
+        e.graphQLErrors[0]?.extensions?.code ===
+          ENROLMENT_ERRORS.NOT_ENOUGH_CAPACITY_ERROR;
+
+      toast(
+        isNotEnoughCapacityError
+          ? t('enrolment:errors.createFailedBecauseNotEnoughCapacity')
+          : t('enrolment:errors.createFailed'),
+        {
+          type: toast.TYPE.ERROR,
+        }
+      );
     }
   };
 


### PR DESCRIPTION
## Description :sparkles:

### feat: add specific toast error message for event full when enrolling

refs PT-1695

## Issues :bug:

### Closes :no_good_woman:

[PT-1695](https://helsinkisolutionoffice.atlassian.net/browse/PT-1695)

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

Tested locally:
### Finnish
![event-full-fi](https://github.com/City-of-Helsinki/palvelutarjotin-ui/assets/77663720/c3f0fdc5-7284-4196-ba19-bf54aa47a1d2)

### Swedish
![event-full-sv](https://github.com/City-of-Helsinki/palvelutarjotin-ui/assets/77663720/68b55248-e337-4440-b80c-1edaee33c22a)

### English
![event-full-en](https://github.com/City-of-Helsinki/palvelutarjotin-ui/assets/77663720/8160874e-d15b-4b16-8e37-cff2377fd411)

## Additional notes :spiral_notepad:


[PT-1695]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ