### PR TITLE
PT-1695 | fix(toast): automatically close toast error messages after 10s

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -63,3 +63,5 @@ export const DEFAULT_FOOTER_MENU_NAME: Record<Language, string> = {
     process.env.NEXT_PUBLIC_CMS_FOOTER_MENU_NAME_SV ??
     'Palvelutarjotin-UI Footer (SV)',
 };
+
+export const TOAST_AUTO_CLOSE_DURATION_MS = 10_000;

--- a/src/domain/event/occurrences/EnrolmentFormSection.tsx
+++ b/src/domain/event/occurrences/EnrolmentFormSection.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'next-i18next';
 import React from 'react';
 import { toast } from 'react-toastify';
 
+import { TOAST_AUTO_CLOSE_DURATION_MS } from '../../../constants';
 import {
   OccurrenceFieldsFragment,
   EventFieldsFragment,
@@ -84,6 +85,7 @@ const EnrolmentFormSection: React.FC<{
           : t('enrolment:errors.createFailed'),
         {
           type: toast.TYPE.ERROR,
+          autoClose: TOAST_AUTO_CLOSE_DURATION_MS,
         }
       );
     }

--- a/src/domain/event/occurrences/QueueFormSection.tsx
+++ b/src/domain/event/occurrences/QueueFormSection.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'next-i18next';
 import React from 'react';
 import { toast } from 'react-toastify';
 
+import { TOAST_AUTO_CLOSE_DURATION_MS } from '../../../constants';
 import {
   EventFieldsFragment,
   useEnrolEventQueueMutation,
@@ -61,6 +62,7 @@ const QueueFormSection: React.FC<{
     } catch (e) {
       toast(t('enrolment:queue.error'), {
         type: toast.TYPE.ERROR,
+        autoClose: TOAST_AUTO_CLOSE_DURATION_MS,
       });
     }
   };


### PR DESCRIPTION
## Description :sparkles:

### fix(toast): automatically close toast error messages after 10s

default autoclose for toast error messages is 5s, this doubles that to
give users more time to read the message

refs PT-1695

## Issues :bug:

### Closes :no_good_woman:

[PT-1695](https://helsinkisolutionoffice.atlassian.net/browse/PT-1695)

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[PT-1695]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ