### PR TITLE
feat: use keywordAnd-filter in events list query for keywords

### DIFF
--- a/src/common/components/keyword/KeywordsList.tsx
+++ b/src/common/components/keyword/KeywordsList.tsx
@@ -32,8 +32,8 @@ const KeywordsList: React.FC<KeywordsListProps> = ({
 
   return (
     <ul className={styles.keywordsList}>
-      {keywordsPropArr.map((k) => (
-        <li key={k.id}>
+      {keywordsPropArr.map((k, i) => (
+        <li key={`${i}-${k.id}`}>
           <Keyword
             href={{ pathname: ROUTES.EVENTS_SEARCH, query: k.query }}
             keyword={k.label}

--- a/src/domain/events/EventsSearchPage.tsx
+++ b/src/domain/events/EventsSearchPage.tsx
@@ -120,14 +120,22 @@ export const useEventsSearch = () => {
     [router.query]
   );
 
-  const { text, division, end, inLanguage, start, keyword, location, isFree } =
-    variables;
+  const {
+    text,
+    division,
+    end,
+    inLanguage,
+    start,
+    keywordAnd,
+    location,
+    isFree,
+  } = variables;
 
   const filterActive =
     !!text?.length ||
     !!division?.length ||
     !!inLanguage?.length ||
-    !!keyword?.length ||
+    !!keywordAnd?.length ||
     !!location ||
     !!end ||
     !!isFree ||

--- a/src/domain/events/__tests__/EventsSearchPage.test.tsx
+++ b/src/domain/events/__tests__/EventsSearchPage.test.tsx
@@ -96,7 +96,7 @@ const mocks: MockedResponse[] = [
       query: EventsDocument,
       variables: {
         include: ['keywords', 'location', 'audience', 'in_language'],
-        keyword: [],
+        keywordAnd: [],
         text: '',
         inLanguage: '',
         location: '',
@@ -222,7 +222,19 @@ test('renders search form and events list with correct information', async () =>
 test('search form is compact state when only text parameter is used', async () => {
   advanceTo(testDate);
   const searchText = 'hakusana';
-  render(<EventsSearchPage />, { mocks, query: { text: searchText } });
+  render(<EventsSearchPage />, {
+    mocks: [
+      {
+        ...mocks[0],
+        request: {
+          ...mocks[0].request,
+          variables: { ...mocks[0].request.variables, text: searchText },
+        },
+      },
+      ...mocks.slice(1),
+    ],
+    query: { text: searchText },
+  });
 
   const textInput = await screen.findByRole('textbox', {
     name: /hae tapahtumia/i,
@@ -235,7 +247,19 @@ test('search form is compact state when only text parameter is used', async () =
 test('search form expands when text input is focused', async () => {
   advanceTo(testDate);
   const searchText = 'hakusana';
-  render(<EventsSearchPage />, { mocks, query: { text: searchText } });
+  render(<EventsSearchPage />, {
+    mocks: [
+      {
+        ...mocks[0],
+        request: {
+          ...mocks[0].request,
+          variables: { ...mocks[0].request.variables, text: searchText },
+        },
+      },
+      ...mocks.slice(1),
+    ],
+    query: { text: searchText },
+  });
 
   const textInput = await screen.findByRole('textbox', {
     name: /hae tapahtumia/i,
@@ -253,7 +277,33 @@ test('search form is in advanced state if advanced search parameters are used', 
   advanceTo(testDate);
   const searchText = 'hakusana';
   render(<EventsSearchPage />, {
-    mocks,
+    mocks: [
+      {
+        ...mocks[0],
+        request: {
+          ...mocks[0].request,
+          variables: {
+            ...mocks[0].request.variables,
+            text: searchText,
+            keywordAnd: ['categories=kultus%3A13'],
+          },
+        },
+      },
+      {
+        request: {
+          query: KeywordDocument,
+          variables: {
+            id: 'categories=kultus%3A13',
+          },
+        },
+        result: {
+          data: {
+            keyword: null,
+          },
+        },
+      },
+      ...mocks.slice(1),
+    ],
     query: { text: searchText, categories: 'categories=kultus%3A13' },
   });
 
@@ -279,6 +329,29 @@ test('renders filter tag when category not found in pre defined list', async () 
   render(<EventsSearchPage />, {
     mocks: [
       ...mocks,
+      {
+        request: {
+          query: EventsDocument,
+          variables: {
+            include: ['keywords', 'location', 'audience', 'in_language'],
+            text: '',
+            keywordAnd: [categoryId],
+            inLanguage: '',
+            location: '',
+            start: 'now',
+            pageSize: 10,
+            sort: 'start_time',
+            end: null,
+            organisationId: '',
+            division: '',
+          },
+        },
+        result: {
+          data: {
+            events: fakeEvents(4, eventMocks),
+          },
+        },
+      },
       {
         request: {
           query: KeywordSetDocument,
@@ -328,7 +401,21 @@ test('renders filter tag when category not found in pre defined list', async () 
 
 test('saves sort state to local storage', async () => {
   advanceTo(testDate);
-  render(<EventsSearchPage />, { mocks });
+  render(<EventsSearchPage />, {
+    mocks: [
+      {
+        ...mocks[0],
+        request: {
+          ...mocks[0].request,
+          variables: {
+            ...mocks[0].request.variables,
+            sort: '-last_modified_time',
+          },
+        },
+      },
+      ...mocks,
+    ],
+  });
   await waitFor(() => {
     expect(screen.getByText(/järjestys/i)).toBeInTheDocument();
   });

--- a/src/domain/events/query.ts
+++ b/src/domain/events/query.ts
@@ -73,6 +73,7 @@ export const QUERY_EVENTS = gql`
     $inLanguage: String
     $isFree: Boolean
     $keyword: [String]
+    $keywordAnd: [String]
     $keywordNot: [String]
     $language: String
     $location: String
@@ -95,6 +96,7 @@ export const QUERY_EVENTS = gql`
       inLanguage: $inLanguage
       isFree: $isFree
       keyword: $keyword
+      keywordAnd: $keywordAnd
       keywordNot: $keywordNot
       language: $language
       location: $location

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -46,7 +46,7 @@ export const getEventFilterVariables = (
     include: ['keywords', 'location', 'audience', 'in_language'],
     text: search ?? '',
     inLanguage: getTextFromDict(query, 'inLanguage', undefined),
-    keyword: getKeywordsToQuery(query),
+    keywordAnd: getKeywordsToQuery(query),
     start: getDateString(query.date) || 'now',
     end: getDateString(query.endDate),
     location: getTextFromDict(query, 'places', undefined),

--- a/src/generated/graphql-cms.tsx
+++ b/src/generated/graphql-cms.tsx
@@ -56,18 +56,27 @@ export enum AvatarRatingEnum {
   X = 'X'
 }
 
-/** Card field */
+/** Breadcumb field */
+export type Breadcrumb = {
+  __typename?: 'Breadcrumb';
+  /** The title of the page */
+  title?: Maybe<Scalars['String']['output']>;
+  /** The link of the page. */
+  uri?: Maybe<Scalars['String']['output']>;
+};
+
+/** Kortin kenttä */
 export type Card = {
   __typename?: 'Card';
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Description */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
-  /** Icon */
+  /** Ikoni */
   icon?: Maybe<Scalars['String']['output']>;
-  /** Link */
+  /** Linkki */
   link?: Maybe<Link>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -481,7 +490,7 @@ export type CategoryToTaxonomyConnectionEdge = Edge & OneToOneConnection & Taxon
 /** The collection type */
 export type Collection = ContentNode & DatabaseIdentifier & Node & NodeWithRevisions & NodeWithTemplate & NodeWithTitle & Previewable & UniformResourceIdentifiable & {
   __typename?: 'Collection';
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
   /**
    * The id field matches the WP_Post-&gt;ID field.
@@ -498,7 +507,7 @@ export type Collection = ContentNode & DatabaseIdentifier & Node & NodeWithRevis
   date?: Maybe<Scalars['String']['output']>;
   /** The publishing date set in GMT. */
   dateGmt?: Maybe<Scalars['String']['output']>;
-  /** Description */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
   /** The desired slug of the post */
   desiredSlug?: Maybe<Scalars['String']['output']>;
@@ -516,7 +525,7 @@ export type Collection = ContentNode & DatabaseIdentifier & Node & NodeWithRevis
   guid?: Maybe<Scalars['String']['output']>;
   /** The globally unique identifier of the collection-cpt object. */
   id: Scalars['ID']['output'];
-  /** Image */
+  /** Kuva */
   image?: Maybe<Scalars['String']['output']>;
   /** Whether the node is a Content Node */
   isContentNode: Scalars['Boolean']['output'];
@@ -538,7 +547,7 @@ export type Collection = ContentNode & DatabaseIdentifier & Node & NodeWithRevis
   modified?: Maybe<Scalars['String']['output']>;
   /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
   modifiedGmt?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /** Connection between the Collection type and the collection type */
   preview?: Maybe<CollectionToPreviewConnectionEdge>;
@@ -552,7 +561,7 @@ export type Collection = ContentNode & DatabaseIdentifier & Node & NodeWithRevis
   revisions?: Maybe<CollectionToRevisionConnection>;
   /** The SEO Framework data of the collection */
   seo?: Maybe<Seo>;
-  /** Show on front page */
+  /** Näytä etusivulla */
   showOnFrontPage?: Maybe<Scalars['Boolean']['output']>;
   /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
   slug?: Maybe<Scalars['String']['output']>;
@@ -1100,7 +1109,7 @@ export type Contact = ContentNode & DatabaseIdentifier & Node & NodeWithFeatured
   date?: Maybe<Scalars['String']['output']>;
   /** The publishing date set in GMT. */
   dateGmt?: Maybe<Scalars['String']['output']>;
-  /** Description */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
   /** The desired slug of the post */
   desiredSlug?: Maybe<Scalars['String']['output']>;
@@ -1118,7 +1127,7 @@ export type Contact = ContentNode & DatabaseIdentifier & Node & NodeWithFeatured
   featuredImageDatabaseId?: Maybe<Scalars['Int']['output']>;
   /** Globally unique ID of the featured image assigned to the node */
   featuredImageId?: Maybe<Scalars['ID']['output']>;
-  /** First name */
+  /** Etunimi */
   firstName?: Maybe<Scalars['String']['output']>;
   /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
   guid?: Maybe<Scalars['String']['output']>;
@@ -1140,7 +1149,7 @@ export type Contact = ContentNode & DatabaseIdentifier & Node & NodeWithFeatured
   language?: Maybe<Language>;
   /** The user that most recently edited the node */
   lastEditedBy?: Maybe<ContentNodeToEditLastConnectionEdge>;
-  /** Last name */
+  /** Sukunimi */
   lastName?: Maybe<Scalars['String']['output']>;
   /** The permalink of the post */
   link?: Maybe<Scalars['String']['output']>;
@@ -2178,7 +2187,7 @@ export type DateQueryInput = {
   year?: InputMaybe<Scalars['Int']['input']>;
 };
 
-/** Default images of different post types. Returns url of image of queried post type. Values come from Sivuston Asetukset -&gt; Oletuskuvat. */
+/** Oletuskuva */
 export type DefaultImages = {
   __typename?: 'DefaultImages';
   /** Attachment URL for article image */
@@ -2570,14 +2579,14 @@ export type EnqueuedStylesheetConnectionEdge = {
   node: EnqueuedStylesheet;
 };
 
-/** Collection Module: EventSearch */
+/** Kokoelmamoduuli: EventSearch */
 export type EventSearch = {
   __typename?: 'EventSearch';
-  /** Amount of events listed before &quot;show more -button&quot; */
+  /** Listattujen tapahtumien määrä “Näytä lisää” -painiketta */
   initAmountOfEvents?: Maybe<Scalars['Int']['output']>;
-  /** Module type */
+  /** Moduulin tyyppi */
   module?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /**
    * Show all -link, final link is combination of Tapahtuma- ja kurssikarusellin
@@ -2586,26 +2595,26 @@ export type EventSearch = {
    *
    */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Show all -link */
+  /** Näytä kaikki -linkki */
   showAllLinkCustom?: Maybe<Scalars['String']['output']>;
-  /** Module title */
+  /** Moduulin otsikko */
   title?: Maybe<Scalars['String']['output']>;
-  /** Search query */
+  /** Hakukysely */
   url?: Maybe<Scalars['String']['output']>;
 };
 
-/** Collection Module: EventSearchCarousel */
+/** Kokoelmamoduuli: EventSearchCarousel */
 export type EventSearchCarousel = {
   __typename?: 'EventSearchCarousel';
-  /** Amount of cards in carousel */
+  /** Korttien määrä karusellissa */
   amountOfCards?: Maybe<Scalars['Int']['output']>;
-  /** Events nearby */
+  /** Tapahtumat lähellä */
   eventsNearby?: Maybe<Scalars['Boolean']['output']>;
-  /** Module type */
+  /** Moduulin tyyppi */
   module?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
-  /** Events order */
+  /** Tapahtumien järjestys */
   orderNewestFirst?: Maybe<Scalars['Boolean']['output']>;
   /**
    * Show all -link, final link is combination of Tapahtuma- ja kurssikarusellin
@@ -2614,49 +2623,70 @@ export type EventSearchCarousel = {
    *
    */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Show all -link */
+  /** Näytä kaikki -linkki */
   showAllLinkCustom?: Maybe<Scalars['String']['output']>;
-  /** Module title */
+  /** Moduulin otsikko */
   title?: Maybe<Scalars['String']['output']>;
-  /** Search query */
+  /** Hakukysely */
   url?: Maybe<Scalars['String']['output']>;
 };
 
-/** Collection Module: EventSelected */
+/** Kokoelmamoduuli: EventSelected */
 export type EventSelected = {
   __typename?: 'EventSelected';
-  /** List of event IDs */
+  /** Lista tapahtumien ID-tiedoista */
   events?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  /** Amount of events listed before &quot;show more -button&quot; */
+  /** Listattujen tapahtumien määrä “Näytä lisää” -painiketta */
   initAmountOfEvents?: Maybe<Scalars['Int']['output']>;
-  /** Module type */
+  /** Moduulin tyyppi */
   module?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
-  /** Show all -link */
+  /** Näytä kaikki -linkki */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Module title */
+  /** Moduulin otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
-/** Collection Module: EventSelectedCarousel */
+/** Kokoelmamoduuli: EventSelectedCarousel */
 export type EventSelectedCarousel = {
   __typename?: 'EventSelectedCarousel';
-  /** Amount of cards in carousel */
+  /** Korttien määrä karusellissa */
   amountOfCards?: Maybe<Scalars['Int']['output']>;
-  /** Amount of cards per row */
+  /** Korttien määrä riviä kohden */
   amountOfCardsPerRow?: Maybe<Scalars['Int']['output']>;
-  /** List of event IDs */
+  /** Lista tapahtumien ID-tiedoista */
   events?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  /** Events nearby */
+  /** Tapahtumat lähellä */
   eventsNearby?: Maybe<Scalars['Boolean']['output']>;
-  /** Module type */
+  /** Moduulin tyyppi */
   module?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
-  /** Show all -link */
+  /** Näytä kaikki -linkki */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Module title */
+  /** Moduulin otsikko */
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type FooterBlocksUnion = LayoutEditor | LayoutImage | LayoutMenu;
+
+/** Galleriakuva */
+export type GalleryImage = {
+  __typename?: 'GalleryImage';
+  /** Kuvan lainaus */
+  caption?: Maybe<Scalars['String']['output']>;
+  /** Kuvaus */
+  description?: Maybe<Scalars['String']['output']>;
+  /** Kuvan (large) URL-osoite */
+  large?: Maybe<Scalars['String']['output']>;
+  /** Kuvan (medium) URL-osoite */
+  medium?: Maybe<Scalars['String']['output']>;
+  /** Kuvan (medium large) URL-osoite */
+  medium_large?: Maybe<Scalars['String']['output']>;
+  /** Kuvan URL-osoite */
+  thumbnail?: Maybe<Scalars['String']['output']>;
+  /** Kuvan otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -2681,20 +2711,22 @@ export type GeneralSettings = {
   url?: Maybe<Scalars['String']['output']>;
 };
 
-/** Hero field */
+export type GlobalSidebarBlocksUnion = LayoutArticleHighlights | LayoutArticles | LayoutEditor;
+
+/** Hero kenttä */
 export type Hero = {
   __typename?: 'Hero';
-  /** The background color of the hero */
+  /** Hero taustaväri */
   background_color?: Maybe<Scalars['String']['output']>;
-  /** The background color of the hero */
+  /** Hero taustaväri */
   background_image_url?: Maybe<Scalars['String']['output']>;
-  /** The desctiption of the hero */
+  /** Hero sisältö */
   description?: Maybe<Scalars['String']['output']>;
-  /** The title of the hero link */
+  /** Hero linkin otsikko */
   link?: Maybe<Link>;
-  /** The title of the hero */
+  /** Hero otsikko */
   title?: Maybe<Scalars['String']['output']>;
-  /** The wave motif of the hero */
+  /** Heron koro */
   wave_motif?: Maybe<Scalars['String']['output']>;
 };
 
@@ -3001,29 +3033,29 @@ export type HierarchicalTermNodeEnqueuedStylesheetsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
-/** Image */
+/** Kuva */
 export type Image = {
   __typename?: 'Image';
-  /** Caption of the image */
+  /** Kuvan lainaus */
   caption?: Maybe<Scalars['String']['output']>;
-  /** Description of the image */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
-  /** The url of the large image */
+  /** Kuvan (large) URL-osoite */
   large?: Maybe<Scalars['String']['output']>;
-  /** The url of the medium image */
+  /** Kuvan (medium) URL-osoite */
   medium?: Maybe<Scalars['String']['output']>;
-  /** The url of the medium large image */
+  /** Kuvan (medium large) URL-osoite */
   medium_large?: Maybe<Scalars['String']['output']>;
-  /** The url of the thumbnail image */
+  /** Kuvan URL-osoite */
   thumbnail?: Maybe<Scalars['String']['output']>;
-  /** Title of the image */
+  /** Kuvan otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** The landingPage type */
 export type LandingPage = ContentNode & DatabaseIdentifier & Node & NodeWithRevisions & NodeWithTemplate & NodeWithTitle & Previewable & UniformResourceIdentifiable & {
   __typename?: 'LandingPage';
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
   /** Box Color */
   boxColor?: Maybe<Scalars['String']['output']>;
@@ -3037,7 +3069,7 @@ export type LandingPage = ContentNode & DatabaseIdentifier & Node & NodeWithRevi
   date?: Maybe<Scalars['String']['output']>;
   /** The publishing date set in GMT. */
   dateGmt?: Maybe<Scalars['String']['output']>;
-  /** Description */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
   /** The desired slug of the post */
   desiredSlug?: Maybe<Scalars['String']['output']>;
@@ -3086,7 +3118,7 @@ export type LandingPage = ContentNode & DatabaseIdentifier & Node & NodeWithRevi
   modified?: Maybe<Scalars['String']['output']>;
   /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
   modifiedGmt?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /** Connection between the LandingPage type and the landingPage type */
   preview?: Maybe<LandingPageToPreviewConnectionEdge>;
@@ -3497,89 +3529,89 @@ export enum LanguageCodeFilterEnum {
 /** Layout: LayoutArticleHighlights */
 export type LayoutArticleHighlights = {
   __typename?: 'LayoutArticleHighlights';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Articles */
+  /** Artikkelit */
   articles?: Maybe<Array<Maybe<Post>>>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Category */
+  /** Kategoria */
   category?: Maybe<Scalars['Int']['output']>;
-  /** Amount of articles to list */
+  /** Valitse montako artikkelia näytetään */
   limit?: Maybe<Scalars['Int']['output']>;
-  /** Show more link */
+  /** Näytä lisää linkki */
   showMore?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  /** Tag */
+  /** Tagi */
   tag?: Maybe<Scalars['Int']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutArticles */
 export type LayoutArticles = {
   __typename?: 'LayoutArticles';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Articles */
+  /** Artikkelit */
   articles?: Maybe<Array<Maybe<Post>>>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Category */
+  /** Kategoria */
   category?: Maybe<Scalars['Int']['output']>;
-  /** Tag */
+  /** Tagi */
   limit?: Maybe<Scalars['Int']['output']>;
-  /** Show all -link */
+  /** Näytä lisää linkki */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Tag */
+  /** Tagi */
   tag?: Maybe<Scalars['Int']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutArticlesCarousel */
 export type LayoutArticlesCarousel = {
   __typename?: 'LayoutArticlesCarousel';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Articles */
+  /** Artikkelit */
   articles?: Maybe<Array<Maybe<Post>>>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Category */
+  /** Kategoria */
   category?: Maybe<Scalars['Int']['output']>;
-  /** Amount of articles to list */
+  /** Valitse montako artikkelia näytetään */
   limit?: Maybe<Scalars['Int']['output']>;
-  /** Show all -link */
+  /** Näytä lisää linkki */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Show more link */
+  /** Näytä lisää linkki */
   showMore?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
-  /** Tag */
+  /** Tagi */
   tag?: Maybe<Scalars['Int']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutCard */
 export type LayoutCard = {
   __typename?: 'LayoutCard';
-  /** Alignment */
+  /** Tasaus */
   alignment?: Maybe<Scalars['String']['output']>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Description */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
-  /** Image */
-  image?: Maybe<Scalars['String']['output']>;
-  /** Link */
+  /** Kuva */
+  image?: Maybe<Image>;
+  /** Linkki */
   link?: Maybe<Link>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutCards */
 export type LayoutCards = {
   __typename?: 'LayoutCards';
-  /** Cards */
+  /** Ikoni kortti */
   cards?: Maybe<Array<Maybe<Card>>>;
 };
 
@@ -3604,117 +3636,153 @@ export type LayoutContact = {
 /** Layout: LayoutContent */
 export type LayoutContent = {
   __typename?: 'LayoutContent';
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   content?: Maybe<Scalars['String']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
+};
+
+/** Layout: LayoutEditor */
+export type LayoutEditor = {
+  __typename?: 'LayoutEditor';
+  /** Editor */
+  editor?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutImage */
 export type LayoutImage = {
   __typename?: 'LayoutImage';
-  /** Border */
+  /** Reunus */
   border?: Maybe<Scalars['Boolean']['output']>;
-  /** Image */
+  /** Kuva */
   image?: Maybe<Image>;
-  /** Photographer name (overwrite) */
+  /** Valokuvaajan nimi (ylikirjoitus) */
   photographer_name?: Maybe<Scalars['String']['output']>;
-  /** Lightbox */
+  /** Näytä lighboxissa */
   show_on_lightbox?: Maybe<Scalars['Boolean']['output']>;
+};
+
+/** Layout: LayoutImageGallery */
+export type LayoutImageGallery = {
+  __typename?: 'LayoutImageGallery';
+  /** Galleria */
+  gallery?: Maybe<Array<Maybe<GalleryImage>>>;
 };
 
 /** Layout: LayoutLinkList */
 export type LayoutLinkList = {
   __typename?: 'LayoutLinkList';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   description?: Maybe<Scalars['String']['output']>;
-  /** Links */
+  /** Linkit */
   links?: Maybe<Array<Maybe<Link>>>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
+};
+
+/** Layout: LayoutMenu */
+export type LayoutMenu = {
+  __typename?: 'LayoutMenu';
+  /** Menu */
+  menu?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutPages */
 export type LayoutPages = {
   __typename?: 'LayoutPages';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Description */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
-  /** Pages */
+  /** Sivut */
   pages?: Maybe<Array<Maybe<Page>>>;
-  /** Show all -link */
+  /** Näytä lisää linkki */
   showAllLink?: Maybe<Scalars['String']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutPagesCarousel */
 export type LayoutPagesCarousel = {
   __typename?: 'LayoutPagesCarousel';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Background Color */
+  /** Taustaväri */
   backgroundColor?: Maybe<Scalars['String']['output']>;
-  /** Description */
+  /** Kuvaus */
   description?: Maybe<Scalars['String']['output']>;
-  /** Pages */
+  /** Sivut */
   pages?: Maybe<Array<Maybe<Page>>>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
 /** Layout: LayoutSocialMediaFeed */
 export type LayoutSocialMediaFeed = {
   __typename?: 'LayoutSocialMediaFeed';
-  /** Anchor */
+  /** Ankkuri */
   anchor?: Maybe<Scalars['String']['output']>;
-  /** Script */
+  /** Scripti */
   script?: Maybe<Scalars['String']['output']>;
-  /** Title */
+  /** Sivuston otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
-/** Link field */
+/** Layout: LayoutSteps */
+export type LayoutSteps = {
+  __typename?: 'LayoutSteps';
+  /** Väri */
+  color?: Maybe<Scalars['String']['output']>;
+  /** Kuvaus */
+  description?: Maybe<Scalars['String']['output']>;
+  /** Vaiheistus */
+  steps?: Maybe<Array<Maybe<Step>>>;
+  /** Sivuston otsikko */
+  title?: Maybe<Scalars['String']['output']>;
+  /** Tyyppi */
+  type?: Maybe<Scalars['String']['output']>;
+};
+
+/** Linkin kenttä */
 export type Link = {
   __typename?: 'Link';
-  /** The target of the link */
+  /** Linkin kohde */
   target?: Maybe<Scalars['String']['output']>;
-  /** The title of the link */
+  /** Linkin otsikko */
   title?: Maybe<Scalars['String']['output']>;
-  /** The url of the link */
+  /** Linkin URL osoite */
   url?: Maybe<Scalars['String']['output']>;
 };
 
-/** Collection Module: LocationsSelected */
+/** Kokoelmamoduuli: LocationsSelected */
 export type LocationsSelected = {
   __typename?: 'LocationsSelected';
   /** List of location IDs */
   locations?: Maybe<Array<Maybe<Scalars['Int']['output']>>>;
   /** Module type */
   module?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /** Module title */
   title?: Maybe<Scalars['String']['output']>;
 };
 
-/** Collection Module: LocationsSelectedCarousel */
+/** Kokoelmamoduuli: LocationsSelectedCarousel */
 export type LocationsSelectedCarousel = {
   __typename?: 'LocationsSelectedCarousel';
   /** List of location IDs */
   locations?: Maybe<Array<Maybe<Scalars['Int']['output']>>>;
   /** Module type */
   module?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduulilistaus */
   modules?: Maybe<Array<Maybe<CollectionModulesUnionType>>>;
   /** Module title */
   title?: Maybe<Scalars['String']['output']>;
@@ -4507,22 +4575,22 @@ export type NodeWithTitleTitleArgs = {
   format?: InputMaybe<PostObjectFieldFormatEnum>;
 };
 
-/** Describe what a CustomType is */
+/** Selitä mikä CustomType on */
 export type Notification = {
   __typename?: 'Notification';
-  /** Notification content */
+  /** Ilmoituksen sisältö */
   content?: Maybe<Scalars['String']['output']>;
-  /** Notification end date */
+  /** Ilmoituksen päättymispäivä */
   endDate?: Maybe<Scalars['String']['output']>;
-  /** Notification level */
+  /** Ilmoituksen tärkeys */
   level?: Maybe<Scalars['String']['output']>;
-  /** Notification link text */
+  /** Ilmoitus linkin teksti */
   linkText?: Maybe<Scalars['String']['output']>;
-  /** Notification link url */
+  /** Ilmoitus linkin url */
   linkUrl?: Maybe<Scalars['String']['output']>;
-  /** Notification start date */
+  /** Ilmoituksen aloituspäivä */
   startDate?: Maybe<Scalars['String']['output']>;
-  /** Notification title */
+  /** Ilmoituksen otsikko */
   title?: Maybe<Scalars['String']['output']>;
 };
 
@@ -4553,6 +4621,8 @@ export type Page = ContentNode & DatabaseIdentifier & HierarchicalContentNode & 
   authorDatabaseId?: Maybe<Scalars['Int']['output']>;
   /** The globally unique identifier of the author of the node */
   authorId?: Maybe<Scalars['ID']['output']>;
+  /** Breadcrumb fields */
+  breadcrumbs?: Maybe<Array<Maybe<Breadcrumb>>>;
   /** Connection between the HierarchicalContentNode type and the ContentNode type */
   children?: Maybe<HierarchicalContentNodeToContentNodeChildrenConnection>;
   /** The content of the post. */
@@ -4587,7 +4657,7 @@ export type Page = ContentNode & DatabaseIdentifier & HierarchicalContentNode & 
   featuredImageId?: Maybe<Scalars['ID']['output']>;
   /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
   guid?: Maybe<Scalars['String']['output']>;
-  /** Hero fields */
+  /** Hero kentät */
   hero?: Maybe<Hero>;
   /** The globally unique identifier of the page object. */
   id: Scalars['ID']['output'];
@@ -4621,7 +4691,7 @@ export type Page = ContentNode & DatabaseIdentifier & HierarchicalContentNode & 
   modified?: Maybe<Scalars['String']['output']>;
   /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
   modifiedGmt?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduuli listaus */
   modules?: Maybe<Array<Maybe<PageModulesUnionType>>>;
   /**
    * The id field matches the WP_Post-&gt;ID field.
@@ -4648,7 +4718,7 @@ export type Page = ContentNode & DatabaseIdentifier & HierarchicalContentNode & 
   seo?: Maybe<Seo>;
   /** Näytä alisivut */
   showChildPages?: Maybe<Scalars['Boolean']['output']>;
-  /** List of modules */
+  /** Moduuli listaus */
   sidebar?: Maybe<Array<Maybe<PageSidebarUnionType>>>;
   /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
   slug?: Maybe<Scalars['String']['output']>;
@@ -4758,7 +4828,7 @@ export enum PageIdType {
   Uri = 'URI'
 }
 
-export type PageModulesUnionType = EventSearch | EventSearchCarousel | EventSelected | EventSelectedCarousel | LayoutArticleHighlights | LayoutArticles | LayoutArticlesCarousel | LayoutCard | LayoutCards | LayoutCollection | LayoutContact | LayoutContent | LayoutImage | LayoutPages | LayoutPagesCarousel | LayoutSocialMediaFeed | LocationsSelected | LocationsSelectedCarousel;
+export type PageModulesUnionType = EventSearch | EventSearchCarousel | EventSelected | EventSelectedCarousel | LayoutArticleHighlights | LayoutArticles | LayoutArticlesCarousel | LayoutCard | LayoutCards | LayoutCollection | LayoutContact | LayoutContent | LayoutImage | LayoutImageGallery | LayoutPages | LayoutPagesCarousel | LayoutSocialMediaFeed | LayoutSteps | LocationsSelected | LocationsSelectedCarousel;
 
 export type PageSidebarUnionType = LayoutArticles | LayoutCards | LayoutLinkList | LayoutPages;
 
@@ -4907,6 +4977,8 @@ export type Post = ContentNode & DatabaseIdentifier & MenuItemLinkable & Node & 
   authorDatabaseId?: Maybe<Scalars['Int']['output']>;
   /** The globally unique identifier of the author of the node */
   authorId?: Maybe<Scalars['ID']['output']>;
+  /** Breadcrumb fields */
+  breadcrumbs?: Maybe<Array<Maybe<Breadcrumb>>>;
   /** Connection between the Post type and the category type */
   categories?: Maybe<PostToCategoryConnection>;
   /** The content of the post. */
@@ -4941,7 +5013,7 @@ export type Post = ContentNode & DatabaseIdentifier & MenuItemLinkable & Node & 
   featuredImageId?: Maybe<Scalars['ID']['output']>;
   /** The global unique identifier for this post. This currently matches the value stored in WP_Post-&gt;guid and the guid column in the &quot;post_objects&quot; database table. */
   guid?: Maybe<Scalars['String']['output']>;
-  /** Hide Published Date */
+  /** Piilota julkaisupäivämäärä */
   hidePublishedDate?: Maybe<Scalars['Boolean']['output']>;
   /** The globally unique identifier of the post object. */
   id: Scalars['ID']['output'];
@@ -4969,7 +5041,7 @@ export type Post = ContentNode & DatabaseIdentifier & MenuItemLinkable & Node & 
   modified?: Maybe<Scalars['String']['output']>;
   /** The GMT modified time for a post. If a post was recently updated the modified field will change to match the corresponding time in GMT. */
   modifiedGmt?: Maybe<Scalars['String']['output']>;
-  /** List of modules */
+  /** Moduuli listaus */
   modules?: Maybe<Array<Maybe<PostModulesUnionType>>>;
   /** Connection between the Post type and the postFormat type */
   postFormats?: Maybe<PostToPostFormatConnection>;
@@ -4990,7 +5062,7 @@ export type Post = ContentNode & DatabaseIdentifier & MenuItemLinkable & Node & 
   revisions?: Maybe<PostToRevisionConnection>;
   /** The SEO Framework data of the post */
   seo?: Maybe<Seo>;
-  /** List of modules */
+  /** Moduuli listaus */
   sidebar?: Maybe<Array<Maybe<PostSidebarUnionType>>>;
   /** The uri slug for the post. This is equivalent to the WP_Post-&gt;post_name field and the post_name column in the database for the &quot;post_objects&quot; table. */
   slug?: Maybe<Scalars['String']['output']>;
@@ -5417,7 +5489,7 @@ export enum PostIdType {
   Uri = 'URI'
 }
 
-export type PostModulesUnionType = EventSearch | EventSearchCarousel | EventSelected | EventSelectedCarousel | LayoutArticleHighlights | LayoutArticles | LayoutArticlesCarousel | LayoutCard | LayoutCards | LayoutCollection | LayoutContact | LayoutContent | LayoutImage | LayoutPages | LayoutPagesCarousel | LocationsSelected | LocationsSelectedCarousel;
+export type PostModulesUnionType = EventSearch | EventSearchCarousel | EventSelected | EventSelectedCarousel | LayoutArticleHighlights | LayoutArticles | LayoutArticlesCarousel | LayoutCard | LayoutCards | LayoutCollection | LayoutContact | LayoutContent | LayoutImage | LayoutImageGallery | LayoutPages | LayoutPagesCarousel | LayoutSocialMediaFeed | LayoutSteps | LocationsSelected | LocationsSelectedCarousel;
 
 /** The format of post field data. */
 export enum PostObjectFieldFormatEnum {
@@ -6678,7 +6750,7 @@ export type RootQuery = {
   categories?: Maybe<RootQueryToCategoryConnection>;
   /** A 0bject */
   category?: Maybe<Category>;
-  /** An object of the collection Type. Collections */
+  /** An object of the collection Type. Kokoelmat */
   collection?: Maybe<Collection>;
   /**
    * A collection object
@@ -6691,7 +6763,7 @@ export type RootQuery = {
   comment?: Maybe<Comment>;
   /** Connection between the RootQuery type and the Comment type */
   comments?: Maybe<RootQueryToCommentConnection>;
-  /** An object of the contact Type. Contacts */
+  /** An object of the contact Type. Yhteystiedot */
   contact?: Maybe<Contact>;
   /**
    * A contact object
@@ -6708,15 +6780,19 @@ export type RootQuery = {
   contentType?: Maybe<ContentType>;
   /** Connection between the RootQuery type and the ContentType type */
   contentTypes?: Maybe<RootQueryToContentTypeConnection>;
-  /** Default Images */
+  /** Oletuskuvat */
   defaultImages?: Maybe<DefaultImages>;
   /** Get language list */
   defaultLanguage?: Maybe<Language>;
   /** Fields of the &#039;DiscussionSettings&#039; settings group */
   discussionSettings?: Maybe<DiscussionSettings>;
+  /** Footer blocks */
+  footerBlocks?: Maybe<Array<Maybe<FooterBlocksUnion>>>;
   /** Fields of the &#039;GeneralSettings&#039; settings group */
   generalSettings?: Maybe<GeneralSettings>;
-  /** An object of the landingPage Type. Landing Pages */
+  /** Global Sidebar blocks */
+  globalSidebarBlocks?: Maybe<Array<Maybe<GlobalSidebarBlocksUnion>>>;
+  /** An object of the landingPage Type. Laskeutumissivut */
   landingPage?: Maybe<LandingPage>;
   /**
    * A landingPage object
@@ -6756,7 +6832,7 @@ export type RootQuery = {
    * @deprecated Deprecated in favor of using the single entry point for this type with ID and IDType fields. For example, instead of postBy( id: &quot;&quot; ), use post(id: &quot;&quot; idType: &quot;&quot;)
    */
   pageBy?: Maybe<Page>;
-  /** Returns ID of page that uses the given template */
+  /** Palauttaa sivun ID:n, joka käyttää annettua sivupohjaa */
   pageByTemplate?: Maybe<Page>;
   /** Connection between the RootQuery type and the page type */
   pages?: Maybe<RootQueryToPageConnection>;
@@ -6783,7 +6859,7 @@ export type RootQuery = {
   registeredScripts?: Maybe<RootQueryToEnqueuedScriptConnection>;
   /** Connection between the RootQuery type and the EnqueuedStylesheet type */
   registeredStylesheets?: Maybe<RootQueryToEnqueuedStylesheetConnection>;
-  /** An object of the release Type. Releases */
+  /** An object of the release Type. Tiedotteet */
   release?: Maybe<Release>;
   /**
    * A release object
@@ -6796,7 +6872,7 @@ export type RootQuery = {
   revisions?: Maybe<RootQueryToRevisionsConnection>;
   /** The SEO Framework settings */
   seoSettings?: Maybe<SeoSettings>;
-  /** Site Settings */
+  /** Sivuston asetukset */
   siteSettings?: Maybe<SiteSettings>;
   /** A 0bject */
   tag?: Maybe<Tag>;
@@ -6816,7 +6892,7 @@ export type RootQuery = {
   themes?: Maybe<RootQueryToThemeConnection>;
   /** Translate string using pll_translate_string() (Polylang) */
   translateString?: Maybe<Scalars['String']['output']>;
-  /** An object of the translation Type. Translations */
+  /** An object of the translation Type. Käännökset */
   translation?: Maybe<Translation>;
   /**
    * A translation object
@@ -6965,6 +7041,18 @@ export type RootQueryContentTypesArgs = {
 
 /** The root entry point into the Graph */
 export type RootQueryDefaultImagesArgs = {
+  language: Scalars['String']['input'];
+};
+
+
+/** The root entry point into the Graph */
+export type RootQueryFooterBlocksArgs = {
+  language: Scalars['String']['input'];
+};
+
+
+/** The root entry point into the Graph */
+export type RootQueryGlobalSidebarBlocksArgs = {
   language: Scalars['String']['input'];
 };
 
@@ -8751,6 +8839,15 @@ export type SiteSettings = {
   siteName?: Maybe<Scalars['String']['output']>;
 };
 
+/** Vaiheen kenttä */
+export type Step = {
+  __typename?: 'Step';
+  /** Vaiheen sisältö */
+  content?: Maybe<Scalars['String']['output']>;
+  /** Vaiheen otsikko */
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 /** The tag type */
 export type Tag = DatabaseIdentifier & MenuItemLinkable & Node & TermNode & UniformResourceIdentifiable & {
   __typename?: 'Tag';
@@ -9142,7 +9239,7 @@ export type TaxonomyToContentTypeConnectionEdge = ContentTypeConnectionEdge & Ed
   node: ContentType;
 };
 
-/** Get page object by template */
+/** Hae sivuobjekti sivupohjan mukaan */
 export enum TemplateEnum {
   FrontPage = 'frontPage',
   PostsPage = 'postsPage'
@@ -9403,7 +9500,7 @@ export type Translation = ContentNode & DatabaseIdentifier & Node & NodeWithRevi
    * @deprecated Deprecated in favor of the databaseId field
    */
   translationId: Scalars['Int']['output'];
-  /** Translations */
+  /** Käännökset */
   translations?: Maybe<Array<Maybe<TranslationResponse>>>;
   /** The unique resource identifier path */
   uri?: Maybe<Scalars['String']['output']>;
@@ -9471,23 +9568,23 @@ export enum TranslationIdType {
   Uri = 'URI'
 }
 
-/** Translation with language/value pairs */
+/** Käännöksen kieli/arvo-parit */
 export type TranslationItems = {
   __typename?: 'TranslationItems';
-  /** Translation string */
+  /** Käännöksen merkkijono */
   en?: Maybe<Scalars['String']['output']>;
-  /** Translation string */
+  /** Käännöksen merkkijono */
   fi?: Maybe<Scalars['String']['output']>;
-  /** Translation string */
+  /** Käännöksen merkkijono */
   sv?: Maybe<Scalars['String']['output']>;
 };
 
-/** Translation response contains translation key and translations */
+/** Käännösvastaus sisältää käännösavaimen ja käännökset */
 export type TranslationResponse = {
   __typename?: 'TranslationResponse';
-  /** Translation key for frontend */
+  /** Käyttöliittymän käännösavain */
   key?: Maybe<Scalars['String']['output']>;
-  /** Translations for frontend */
+  /** Käännökset käyttöliittymälle */
   translations?: Maybe<TranslationItems>;
 };
 
@@ -10797,9 +10894,9 @@ export type MenuQueryVariables = Exact<{
 }>;
 
 
-export type MenuQuery = { __typename?: 'RootQuery', menu?: { __typename?: 'Menu', menuItems?: { __typename?: 'MenuToMenuItemConnection', nodes: Array<{ __typename?: 'MenuItem', connectedNode?: { __typename?: 'MenuItemToMenuItemLinkableConnectionEdge', node: { __typename?: 'Category' } | { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, children?: { __typename?: 'HierarchicalContentNodeToContentNodeChildrenConnection', nodes: Array<{ __typename?: 'Collection' } | { __typename?: 'Contact' } | { __typename?: 'LandingPage' } | { __typename?: 'MediaItem' } | { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | { __typename?: 'Post' } | { __typename?: 'Release' } | { __typename?: 'Translation' }> } | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | { __typename?: 'Post' } | { __typename?: 'Tag' } } | null }> } | null } | null };
+export type MenuQuery = { __typename?: 'RootQuery', menu?: { __typename?: 'Menu', menuItems?: { __typename?: 'MenuToMenuItemConnection', nodes: Array<{ __typename?: 'MenuItem', connectedNode?: { __typename?: 'MenuItemToMenuItemLinkableConnectionEdge', node: { __typename?: 'Category' } | { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, children?: { __typename?: 'HierarchicalContentNodeToContentNodeChildrenConnection', nodes: Array<{ __typename?: 'Collection' } | { __typename?: 'Contact' } | { __typename?: 'LandingPage' } | { __typename?: 'MediaItem' } | { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | { __typename?: 'Post' } | { __typename?: 'Release' } | { __typename?: 'Translation' }> } | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | { __typename?: 'Post' } | { __typename?: 'Tag' } } | null }> } | null } | null };
 
-export type CmsMenuPageFieldsFragment = { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null };
+export type CmsMenuPageFieldsFragment = { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null };
 
 export type PageQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -10807,7 +10904,7 @@ export type PageQueryVariables = Exact<{
 }>;
 
 
-export type PageQuery = { __typename?: 'RootQuery', page?: { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, parent?: { __typename?: 'HierarchicalContentNodeToParentContentNodeConnectionEdge', node: { __typename?: 'Collection' } | { __typename?: 'Contact' } | { __typename?: 'LandingPage' } | { __typename?: 'MediaItem' } | { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | { __typename?: 'Post' } | { __typename?: 'Release' } | { __typename?: 'Translation' } } | null, children?: { __typename?: 'HierarchicalContentNodeToContentNodeChildrenConnection', nodes: Array<{ __typename?: 'Collection' } | { __typename?: 'Contact' } | { __typename?: 'LandingPage' } | { __typename?: 'MediaItem' } | { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | { __typename?: 'Post' } | { __typename?: 'Release' } | { __typename?: 'Translation' }> } | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null };
+export type PageQuery = { __typename?: 'RootQuery', page?: { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, parent?: { __typename?: 'HierarchicalContentNodeToParentContentNodeConnectionEdge', node: { __typename?: 'Collection' } | { __typename?: 'Contact' } | { __typename?: 'LandingPage' } | { __typename?: 'MediaItem' } | { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | { __typename?: 'Post' } | { __typename?: 'Release' } | { __typename?: 'Translation' } } | null, children?: { __typename?: 'HierarchicalContentNodeToContentNodeChildrenConnection', nodes: Array<{ __typename?: 'Collection' } | { __typename?: 'Contact' } | { __typename?: 'LandingPage' } | { __typename?: 'MediaItem' } | { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | { __typename?: 'Post' } | { __typename?: 'Release' } | { __typename?: 'Translation' }> } | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null };
 
 export type CmsLayoutLinkListFieldsFragment = { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null };
 
@@ -10815,14 +10912,14 @@ export type LayoutArticlesFieldsFragment = { __typename?: 'LayoutArticles', titl
 
 export type LayoutPagesFieldsFragment = { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null };
 
-export type PageFieldsFragment = { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null };
+export type PageFieldsFragment = { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null };
 
 export type SeoFieldsFragment = { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null };
 
 export type PagesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type PagesQuery = { __typename?: 'RootQuery', pages?: { __typename?: 'RootQueryToPageConnection', edges: Array<{ __typename?: 'RootQueryToPageConnectionEdge', node: { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } }> } | null };
+export type PagesQuery = { __typename?: 'RootQuery', pages?: { __typename?: 'RootQueryToPageConnection', edges: Array<{ __typename?: 'RootQueryToPageConnectionEdge', node: { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } }> } | null };
 
 export type SubPagesSearchQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -10833,7 +10930,7 @@ export type SubPagesSearchQueryVariables = Exact<{
 }>;
 
 
-export type SubPagesSearchQuery = { __typename?: 'RootQuery', page?: { __typename?: 'Page', id: string, children?: { __typename?: 'HierarchicalContentNodeToContentNodeChildrenConnection', pageInfo?: { __typename?: 'WPPageInfo', endCursor?: string | null, hasNextPage: boolean } | null, edges: Array<{ __typename?: 'HierarchicalContentNodeToContentNodeChildrenConnectionEdge', cursor?: string | null, node: { __typename?: 'Collection' } | { __typename?: 'Contact' } | { __typename?: 'LandingPage' } | { __typename?: 'MediaItem' } | { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | { __typename?: 'Post' } | { __typename?: 'Release' } | { __typename?: 'Translation' } }> } | null } | null };
+export type SubPagesSearchQuery = { __typename?: 'RootQuery', page?: { __typename?: 'Page', id: string, children?: { __typename?: 'HierarchicalContentNodeToContentNodeChildrenConnection', pageInfo?: { __typename?: 'WPPageInfo', endCursor?: string | null, hasNextPage: boolean } | null, edges: Array<{ __typename?: 'HierarchicalContentNodeToContentNodeChildrenConnectionEdge', cursor?: string | null, node: { __typename?: 'Collection' } | { __typename?: 'Contact' } | { __typename?: 'LandingPage' } | { __typename?: 'MediaItem' } | { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | { __typename?: 'Post' } | { __typename?: 'Release' } | { __typename?: 'Translation' } }> } | null } | null };
 
 export type PagesSearchQueryVariables = Exact<{
   search: Scalars['String']['input'];
@@ -10842,7 +10939,7 @@ export type PagesSearchQueryVariables = Exact<{
 }>;
 
 
-export type PagesSearchQuery = { __typename?: 'RootQuery', pages?: { __typename?: 'RootQueryToPageConnection', pageInfo?: { __typename?: 'WPPageInfo', endCursor?: string | null, hasNextPage: boolean } | null, edges: Array<{ __typename?: 'RootQueryToPageConnectionEdge', cursor?: string | null, node: { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } }> } | null };
+export type PagesSearchQuery = { __typename?: 'RootQuery', pages?: { __typename?: 'RootQueryToPageConnection', pageInfo?: { __typename?: 'WPPageInfo', endCursor?: string | null, hasNextPage: boolean } | null, edges: Array<{ __typename?: 'RootQueryToPageConnectionEdge', cursor?: string | null, node: { __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, translations?: Array<{ __typename?: 'Page', id: string, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } | null> | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, slug?: string | null, locale?: string | null, name?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, sidebar?: Array<{ __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutLinkList', anchor?: string | null, title?: string | null, description?: string | null, links?: Array<{ __typename?: 'Link', target?: string | null, title?: string | null, url?: string | null } | null> | null } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | null> | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null } }> } | null };
 
 export type NotificationQueryVariables = Exact<{
   language?: Scalars['String']['input'];
@@ -10856,9 +10953,9 @@ export type ArticleQueryVariables = Exact<{
 }>;
 
 
-export type ArticleQuery = { __typename?: 'RootQuery', post?: { __typename?: 'Post', id: string, date?: string | null, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, categories?: { __typename?: 'PostToCategoryConnection', edges: Array<{ __typename?: 'PostToCategoryConnectionEdge', node: { __typename?: 'Category', id: string, name?: string | null } }> } | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, id: string, locale?: string | null, name?: string | null, slug?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null, translations?: Array<{ __typename?: 'Post', uri?: string | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, id: string, locale?: string | null, name?: string | null, slug?: string | null } | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null } | null> | null } | null };
+export type ArticleQuery = { __typename?: 'RootQuery', post?: { __typename?: 'Post', id: string, date?: string | null, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, categories?: { __typename?: 'PostToCategoryConnection', edges: Array<{ __typename?: 'PostToCategoryConnectionEdge', node: { __typename?: 'Category', id: string, name?: string | null } }> } | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, id: string, locale?: string | null, name?: string | null, slug?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null, translations?: Array<{ __typename?: 'Post', uri?: string | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, id: string, locale?: string | null, name?: string | null, slug?: string | null } | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null } | null> | null } | null };
 
-export type PostFieldsFragment = { __typename?: 'Post', id: string, date?: string | null, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, categories?: { __typename?: 'PostToCategoryConnection', edges: Array<{ __typename?: 'PostToCategoryConnectionEdge', node: { __typename?: 'Category', id: string, name?: string | null } }> } | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, id: string, locale?: string | null, name?: string | null, slug?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null, translations?: Array<{ __typename?: 'Post', uri?: string | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, id: string, locale?: string | null, name?: string | null, slug?: string | null } | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null } | null> | null };
+export type PostFieldsFragment = { __typename?: 'Post', id: string, date?: string | null, content?: string | null, slug?: string | null, title?: string | null, uri?: string | null, link?: string | null, lead?: string | null, categories?: { __typename?: 'PostToCategoryConnection', edges: Array<{ __typename?: 'PostToCategoryConnectionEdge', node: { __typename?: 'Category', id: string, name?: string | null } }> } | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, id: string, locale?: string | null, name?: string | null, slug?: string | null } | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', mediaItemUrl?: string | null, link?: string | null, altText?: string | null, mimeType?: string | null, title?: string | null, uri?: string | null } } | null, modules?: Array<{ __typename?: 'EventSearch' } | { __typename?: 'EventSearchCarousel' } | { __typename?: 'EventSelected' } | { __typename?: 'EventSelectedCarousel' } | { __typename?: 'LayoutArticleHighlights' } | { __typename?: 'LayoutArticles', title?: string | null, articles?: Array<{ __typename?: 'Post', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutArticlesCarousel' } | { __typename?: 'LayoutCard' } | { __typename?: 'LayoutCards' } | { __typename?: 'LayoutCollection' } | { __typename?: 'LayoutContact' } | { __typename?: 'LayoutContent' } | { __typename?: 'LayoutImage' } | { __typename?: 'LayoutImageGallery' } | { __typename?: 'LayoutPages', title?: string | null, pages?: Array<{ __typename?: 'Page', id: string, uri?: string | null, slug?: string | null, link?: string | null, date?: string | null, title?: string | null, lead?: string | null, content?: string | null, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', altText?: string | null, mediaItemUrl?: string | null } } | null } | null> | null } | { __typename?: 'LayoutPagesCarousel' } | { __typename?: 'LayoutSocialMediaFeed' } | { __typename?: 'LayoutSteps' } | { __typename?: 'LocationsSelected' } | { __typename?: 'LocationsSelectedCarousel' } | null> | null, translations?: Array<{ __typename?: 'Post', uri?: string | null, language?: { __typename?: 'Language', code?: LanguageCodeEnum | null, id: string, locale?: string | null, name?: string | null, slug?: string | null } | null, seo?: { __typename?: 'SEO', title?: string | null, description?: string | null, openGraphTitle?: string | null, openGraphDescription?: string | null, openGraphType?: string | null, twitterTitle?: string | null, twitterDescription?: string | null } | null } | null> | null };
 
 export type LanguageFragment = { __typename?: 'Language', code?: LanguageCodeEnum | null, id: string, locale?: string | null, name?: string | null, slug?: string | null };
 

--- a/src/generated/graphql-unified-search.tsx
+++ b/src/generated/graphql-unified-search.tsx
@@ -23,12 +23,51 @@ export type Scalars = {
   link__Import: { input: any; output: any; }
 };
 
-/** TODO: take this from service map / TPREK */
-export type AccessibilityProfile = {
-  __typename?: 'AccessibilityProfile';
-  meta?: Maybe<NodeMeta>;
-  todo?: Maybe<Scalars['String']['output']>;
+export type Accessibility = {
+  __typename?: 'Accessibility';
+  email?: Maybe<Scalars['String']['output']>;
+  phone?: Maybe<Scalars['String']['output']>;
+  sentences: Array<AccessibilitySentence>;
+  shortcomings: Array<AccessibilityShortcoming>;
+  viewpoints: Array<AccessibilityViewpoint>;
+  www?: Maybe<Scalars['String']['output']>;
 };
+
+export enum AccessibilityProfile {
+  HearingAid = 'hearing_aid',
+  ReducedMobility = 'reduced_mobility',
+  Rollator = 'rollator',
+  Stroller = 'stroller',
+  VisuallyImpaired = 'visually_impaired',
+  Wheelchair = 'wheelchair'
+}
+
+export type AccessibilitySentence = {
+  __typename?: 'AccessibilitySentence';
+  sentence?: Maybe<LanguageString>;
+  sentenceGroup?: Maybe<LanguageString>;
+  sentenceGroupName?: Maybe<Scalars['String']['output']>;
+};
+
+export type AccessibilityShortcoming = {
+  __typename?: 'AccessibilityShortcoming';
+  count?: Maybe<Scalars['Int']['output']>;
+  profile: AccessibilityProfile;
+};
+
+export type AccessibilityViewpoint = {
+  __typename?: 'AccessibilityViewpoint';
+  id: Scalars['ID']['output'];
+  name: LanguageString;
+  shortages: Array<LanguageString>;
+  value: AccessibilityViewpointValue;
+};
+
+export enum AccessibilityViewpointValue {
+  Green = 'green',
+  Red = 'red',
+  Unknown = 'unknown'
+}
 
 /** TODO: give real structure */
 export type Address = {
@@ -382,7 +421,7 @@ export enum IdentificationStrength {
 
 /**
  * TODO: merge all free tags, categories, and keywords
- * KEYWORDS ARE GIVEN FROM events-proxy (https://tapahtumat-proxy.test.kuva.hel.ninja/proxy/graphql)
+ * KEYWORDS ARE GIVEN FROM events-proxy (https://events-graphql-proxy.test.hel.ninja/proxy/graphql)
  */
 export type KeywordString = {
   __typename?: 'KeywordString';
@@ -463,7 +502,7 @@ export type LocationDescription = {
   explanation?: Maybe<Scalars['String']['output']>;
   geoLocation?: Maybe<GeoJsonFeature>;
   url?: Maybe<LanguageString>;
-  venue?: Maybe<Venue>;
+  venue?: Maybe<UnifiedSearchVenue>;
 };
 
 export type LocationImage = {
@@ -622,6 +661,20 @@ export type PhoneNumber = {
   restNumber: Scalars['String']['output'];
 };
 
+export enum ProviderType {
+  Association = 'ASSOCIATION',
+  ContractSchool = 'CONTRACT_SCHOOL',
+  Municipality = 'MUNICIPALITY',
+  OtherProductionMethod = 'OTHER_PRODUCTION_METHOD',
+  PaymentCommitment = 'PAYMENT_COMMITMENT',
+  PrivateCompany = 'PRIVATE_COMPANY',
+  PurchasedService = 'PURCHASED_SERVICE',
+  SelfProduced = 'SELF_PRODUCED',
+  SupportedOperations = 'SUPPORTED_OPERATIONS',
+  UnknownProductionMethod = 'UNKNOWN_PRODUCTION_METHOD',
+  VoucherService = 'VOUCHER_SERVICE'
+}
+
 export type Query = {
   __typename?: 'Query';
   _service: _Service;
@@ -650,27 +703,28 @@ export type QueryOntologyWordsArgs = {
 
 
 export type QueryUnifiedSearchArgs = {
-  administrativeDivisionId?: InputMaybe<Scalars['ID']['input']>;
   administrativeDivisionIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
-  index?: InputMaybe<Scalars['String']['input']>;
+  index?: InputMaybe<UnifiedSearchIndex>;
   languages?: Array<UnifiedSearchLanguage>;
-  last?: InputMaybe<Scalars['Int']['input']>;
+  mustHaveReservableResource?: InputMaybe<Scalars['Boolean']['input']>;
   ontology?: InputMaybe<Scalars['String']['input']>;
-  ontologyTreeId?: InputMaybe<Scalars['ID']['input']>;
-  ontologyTreeIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
-  ontologyWordIds?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
+  ontologyTreeIdOrSets?: InputMaybe<Array<Array<Scalars['ID']['input']>>>;
+  ontologyWordIdOrSets?: InputMaybe<Array<Array<Scalars['ID']['input']>>>;
   openAt?: InputMaybe<Scalars['String']['input']>;
+  orderByAccessibilityProfile?: InputMaybe<AccessibilityProfile>;
   orderByDistance?: InputMaybe<OrderByDistance>;
   orderByName?: InputMaybe<OrderByName>;
-  q?: InputMaybe<Scalars['String']['input']>;
+  providerTypes?: InputMaybe<Array<InputMaybe<ProviderType>>>;
+  serviceOwnerTypes?: InputMaybe<Array<InputMaybe<ServiceOwnerType>>>;
+  targetGroups?: InputMaybe<Array<InputMaybe<TargetGroup>>>;
+  text?: InputMaybe<Scalars['String']['input']>;
 };
 
 
 export type QueryUnifiedSearchCompletionSuggestionsArgs = {
-  index?: InputMaybe<Scalars['String']['input']>;
+  index?: InputMaybe<UnifiedSearchIndex>;
   languages?: Array<UnifiedSearchLanguage>;
   prefix?: InputMaybe<Scalars['String']['input']>;
   size?: InputMaybe<Scalars['Int']['input']>;
@@ -681,11 +735,17 @@ export type RawJson = {
   data?: Maybe<Scalars['String']['output']>;
 };
 
+export type Reservation = {
+  __typename?: 'Reservation';
+  externalReservationUrl?: Maybe<LanguageString>;
+  reservable?: Maybe<Scalars['Boolean']['output']>;
+};
+
 export type SearchResultConnection = {
   __typename?: 'SearchResultConnection';
   count?: Maybe<Scalars['Int']['output']>;
   edges: Array<SearchResultEdge>;
-  /**  Elasticsearch raw results  */
+  /** Elasticsearch raw results */
   es_results?: Maybe<Array<Maybe<ElasticSearchResult>>>;
   max_score?: Maybe<Scalars['Float']['output']>;
   pageInfo?: Maybe<SearchResultPageInfo>;
@@ -703,7 +763,7 @@ export type SearchResultNode = {
   event?: Maybe<Event>;
   id: Scalars['ID']['output'];
   searchCategories: Array<UnifiedSearchResultCategory>;
-  venue?: Maybe<Venue>;
+  venue?: Maybe<UnifiedSearchVenue>;
 };
 
 export type SearchResultPageInfo = {
@@ -718,6 +778,31 @@ export type SearchSuggestionConnection = {
   __typename?: 'SearchSuggestionConnection';
   suggestions: Array<Maybe<Suggestion>>;
 };
+
+export type ServiceOwner = {
+  __typename?: 'ServiceOwner';
+  name?: Maybe<LanguageString>;
+  providerType?: Maybe<ProviderType>;
+  type?: Maybe<ServiceOwnerType>;
+};
+
+export enum ServiceOwnerType {
+  MunicipalService = 'MUNICIPAL_SERVICE',
+  NotDisplayed = 'NOT_DISPLAYED',
+  PrivateContractSchool = 'PRIVATE_CONTRACT_SCHOOL',
+  PrivateService = 'PRIVATE_SERVICE',
+  PurchasedService = 'PURCHASED_SERVICE',
+  ServiceByJointMunicipalAuthority = 'SERVICE_BY_JOINT_MUNICIPAL_AUTHORITY',
+  ServiceByMunicipallyOwnedCompany = 'SERVICE_BY_MUNICIPALLY_OWNED_COMPANY',
+  ServiceByMunicipalGroupEntity = 'SERVICE_BY_MUNICIPAL_GROUP_ENTITY',
+  ServiceByOtherMunicipality = 'SERVICE_BY_OTHER_MUNICIPALITY',
+  ServiceByRegionalCooperationOrganization = 'SERVICE_BY_REGIONAL_COOPERATION_ORGANIZATION',
+  ServiceByWellbeingArea = 'SERVICE_BY_WELLBEING_AREA',
+  StateContractSchool = 'STATE_CONTRACT_SCHOOL',
+  StateService = 'STATE_SERVICE',
+  SupportedOperations = 'SUPPORTED_OPERATIONS',
+  VoucherService = 'VOUCHER_SERVICE'
+}
 
 export type Shards = {
   __typename?: 'Shards';
@@ -746,6 +831,17 @@ export type Suggestion = {
   label: Scalars['String']['output'];
 };
 
+export enum TargetGroup {
+  Associations = 'ASSOCIATIONS',
+  ChildrenAndFamilies = 'CHILDREN_AND_FAMILIES',
+  Disabled = 'DISABLED',
+  ElderlyPeople = 'ELDERLY_PEOPLE',
+  Enterprises = 'ENTERPRISES',
+  Immigrants = 'IMMIGRANTS',
+  Individuals = 'INDIVIDUALS',
+  Youth = 'YOUTH'
+}
+
 /** any kind of description answering the question "when". */
 export type TimeDescription = {
   __typename?: 'TimeDescription';
@@ -753,6 +849,15 @@ export type TimeDescription = {
   otherTime?: Maybe<TimeDescription>;
   starting?: Maybe<Scalars['DateTime']['output']>;
 };
+
+export enum UnifiedSearchIndex {
+  AdministrativeDivision = 'administrative_division',
+  Event = 'event',
+  HelsinkiCommonAdministrativeDivision = 'helsinki_common_administrative_division',
+  Location = 'location',
+  OntologyTree = 'ontology_tree',
+  OntologyWord = 'ontology_word'
+}
 
 export enum UnifiedSearchLanguage {
   English = 'ENGLISH',
@@ -780,9 +885,11 @@ export enum UnifiedSearchResultCategory {
  * respa unit or resource, service map unit, beta.kultus venue, linked
  * events place, Kukkuu venue
  */
-export type Venue = {
-  __typename?: 'Venue';
-  accessibilityProfile?: Maybe<AccessibilityProfile>;
+export type UnifiedSearchVenue = {
+  __typename?: 'UnifiedSearchVenue';
+  accessibility?: Maybe<Accessibility>;
+  /** Accessibility shortcoming for a specific accessibility profile. */
+  accessibilityShortcomingFor?: Maybe<AccessibilityShortcoming>;
   additionalInfo?: Maybe<Scalars['String']['output']>;
   arrivalInstructions?: Maybe<Scalars['String']['output']>;
   contactDetails?: Maybe<ContactInfo>;
@@ -796,8 +903,20 @@ export type Venue = {
   name?: Maybe<LanguageString>;
   ontologyWords?: Maybe<Array<Maybe<OntologyWord>>>;
   openingHours?: Maybe<OpeningHours>;
-  partOf?: Maybe<Venue>;
-  reservationPolicy?: Maybe<VenueReservationPolicy>;
+  partOf?: Maybe<UnifiedSearchVenue>;
+  reservation?: Maybe<Reservation>;
+  serviceOwner?: Maybe<ServiceOwner>;
+  targetGroups?: Maybe<Array<Maybe<TargetGroup>>>;
+};
+
+
+/**
+ * A place that forms a unit and can be used for some specific purpose -
+ * respa unit or resource, service map unit, beta.kultus venue, linked
+ * events place, Kukkuu venue
+ */
+export type UnifiedSearchVenueAccessibilityShortcomingForArgs = {
+  profile?: InputMaybe<AccessibilityProfile>;
 };
 
 /** TODO: combine beta.kultus Venue stuff with respa equipment type */
@@ -806,12 +925,6 @@ export type VenueFacility = {
   categories?: Maybe<Array<KeywordString>>;
   meta?: Maybe<NodeMeta>;
   name: Scalars['String']['output'];
-};
-
-/** TODO: this comes from respa resource/unit types */
-export type VenueReservationPolicy = {
-  __typename?: 'VenueReservationPolicy';
-  todo?: Maybe<Scalars['String']['output']>;
 };
 
 export type _Service = {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -89,7 +89,7 @@ export type AddOrganisationMutationInput = {
   clientMutationId?: InputMaybe<Scalars['String']['input']>;
   name: Scalars['String']['input'];
   phoneNumber?: InputMaybe<Scalars['String']['input']>;
-  publisherId?: InputMaybe<Scalars['String']['input']>;
+  publisherId: Scalars['String']['input'];
   type: OrganisationTypeEnum;
 };
 
@@ -880,6 +880,7 @@ export enum NotificationTemplateType {
   OccurrenceEnrolmentSms = 'OCCURRENCE_ENROLMENT_SMS',
   OccurrenceUnenrolment = 'OCCURRENCE_UNENROLMENT',
   OccurrenceUnenrolmentSms = 'OCCURRENCE_UNENROLMENT_SMS',
+  OccurrenceUpcomingSms = 'OCCURRENCE_UPCOMING_SMS',
   PersonMyprofileAccepted = 'PERSON_MYPROFILE_ACCEPTED',
   PersonMyprofileCreation = 'PERSON_MYPROFILE_CREATION'
 }
@@ -1016,7 +1017,7 @@ export type OrganisationNode = Node & {
   /** The ID of the object. */
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
-  persons: PersonNodeConnection;
+  persons?: Maybe<PersonNodeConnection>;
   phoneNumber: Scalars['String']['output'];
   publisherId: Scalars['String']['output'];
   type: OrganisationType;
@@ -2163,6 +2164,7 @@ export type EventsQueryVariables = Exact<{
   inLanguage?: InputMaybe<Scalars['String']['input']>;
   isFree?: InputMaybe<Scalars['Boolean']['input']>;
   keyword?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
+  keywordAnd?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
   keywordNot?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
   language?: InputMaybe<Scalars['String']['input']>;
   location?: InputMaybe<Scalars['String']['input']>;
@@ -2797,7 +2799,7 @@ export type EnrolEventQueueMutationHookResult = ReturnType<typeof useEnrolEventQ
 export type EnrolEventQueueMutationResult = Apollo.MutationResult<EnrolEventQueueMutation>;
 export type EnrolEventQueueMutationOptions = Apollo.BaseMutationOptions<EnrolEventQueueMutation, EnrolEventQueueMutationVariables>;
 export const EventsDocument = gql`
-    query Events($division: [String], $allOngoingAnd: [String], $end: String, $include: [String], $inLanguage: String, $isFree: Boolean, $keyword: [String], $keywordNot: [String], $language: String, $location: String, $page: Int, $pageSize: Int, $publisher: ID, $sort: String, $start: String, $superEvent: ID, $superEventType: [String], $text: String, $translation: String, $organisationId: String) {
+    query Events($division: [String], $allOngoingAnd: [String], $end: String, $include: [String], $inLanguage: String, $isFree: Boolean, $keyword: [String], $keywordAnd: [String], $keywordNot: [String], $language: String, $location: String, $page: Int, $pageSize: Int, $publisher: ID, $sort: String, $start: String, $superEvent: ID, $superEventType: [String], $text: String, $translation: String, $organisationId: String) {
   events(
     division: $division
     allOngoingAnd: $allOngoingAnd
@@ -2806,6 +2808,7 @@ export const EventsDocument = gql`
     inLanguage: $inLanguage
     isFree: $isFree
     keyword: $keyword
+    keywordAnd: $keywordAnd
     keywordNot: $keywordNot
     language: $language
     location: $location
@@ -2850,6 +2853,7 @@ ${EventsFieldsFragmentDoc}`;
  *      inLanguage: // value for 'inLanguage'
  *      isFree: // value for 'isFree'
  *      keyword: // value for 'keyword'
+ *      keywordAnd: // value for 'keywordAnd'
  *      keywordNot: // value for 'keywordNot'
  *      language: // value for 'language'
  *      location: // value for 'location'


### PR DESCRIPTION
PT-1591.
Update the GraphQL schemas: Add KeywordAnd-filter to events list query.
The new keywordAnd filter is now used instead of the keyword-filter,
which means that all the selected keywords narrows down 
the search results list instead of growing it.

There is an alternative or "extension" for this in https://github.com/City-of-Helsinki/palvelutarjotin-ui/pull/307