### PR TITLE
feat: use keywordOrSet-filter in events list query for keywords

### DIFF
--- a/src/domain/events/EventsSearchPage.tsx
+++ b/src/domain/events/EventsSearchPage.tsx
@@ -126,7 +126,9 @@ export const useEventsSearch = () => {
     end,
     inLanguage,
     start,
-    keywordAnd,
+    keywordOrSet1,
+    keywordOrSet2,
+    keywordOrSet3,
     location,
     isFree,
   } = variables;
@@ -135,7 +137,9 @@ export const useEventsSearch = () => {
     !!text?.length ||
     !!division?.length ||
     !!inLanguage?.length ||
-    !!keywordAnd?.length ||
+    !!keywordOrSet1?.length ||
+    !!keywordOrSet2?.length ||
+    !!keywordOrSet3?.length ||
     !!location ||
     !!end ||
     !!isFree ||

--- a/src/domain/events/__tests__/EventsSearchPage.test.tsx
+++ b/src/domain/events/__tests__/EventsSearchPage.test.tsx
@@ -96,7 +96,6 @@ const mocks: MockedResponse[] = [
       query: EventsDocument,
       variables: {
         include: ['keywords', 'location', 'audience', 'in_language'],
-        keywordAnd: [],
         text: '',
         inLanguage: '',
         location: '',
@@ -285,7 +284,7 @@ test('search form is in advanced state if advanced search parameters are used', 
           variables: {
             ...mocks[0].request.variables,
             text: searchText,
-            keywordAnd: ['categories=kultus%3A13'],
+            keywordOrSet1: ['categories=kultus%3A13'],
           },
         },
       },
@@ -335,7 +334,7 @@ test('renders filter tag when category not found in pre defined list', async () 
           variables: {
             include: ['keywords', 'location', 'audience', 'in_language'],
             text: '',
-            keywordAnd: [categoryId],
+            keywordOrSet1: [categoryId],
             inLanguage: '',
             location: '',
             start: 'now',

--- a/src/domain/events/query.ts
+++ b/src/domain/events/query.ts
@@ -74,6 +74,9 @@ export const QUERY_EVENTS = gql`
     $isFree: Boolean
     $keyword: [String]
     $keywordAnd: [String]
+    $keywordOrSet1: [String]
+    $keywordOrSet2: [String]
+    $keywordOrSet3: [String]
     $keywordNot: [String]
     $language: String
     $location: String
@@ -97,6 +100,9 @@ export const QUERY_EVENTS = gql`
       isFree: $isFree
       keyword: $keyword
       keywordAnd: $keywordAnd
+      keywordOrSet1: $keywordOrSet1
+      keywordOrSet2: $keywordOrSet2
+      keywordOrSet3: $keywordOrSet3
       keywordNot: $keywordNot
       language: $language
       location: $location

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -63,34 +63,20 @@ type KeywordOrSetSearchVariablesType = {
   keywordOrSet3?: string[];
 };
 
+const toArray = (
+  value: string | string[] | null | undefined
+): string[] | undefined =>
+  Array.isArray(value) ? value : value ? [value] : undefined;
+
 const getKeywordsToQuery = (keywords: {
   [KEYWORD_QUERY_PARAMS.CATEGORIES]?: string | string[];
   [KEYWORD_QUERY_PARAMS.TARGET_GROUPS]?: string | string[];
   [KEYWORD_QUERY_PARAMS.ADDITIONAL_CRITERIA]?: string | string[];
-}): KeywordOrSetSearchVariablesType => {
-  return [
-    keywords[KEYWORD_QUERY_PARAMS.CATEGORIES],
-    keywords[KEYWORD_QUERY_PARAMS.TARGET_GROUPS],
-    keywords[KEYWORD_QUERY_PARAMS.ADDITIONAL_CRITERIA],
-  ].reduce<KeywordOrSetSearchVariablesType>(
-    (result, groupKeywords, currentIndex) => {
-      if (Array.isArray(groupKeywords)) {
-        return {
-          ...result,
-          [`keywordOrSet${currentIndex + 1}`]: groupKeywords,
-        };
-      }
-      if (groupKeywords) {
-        return {
-          ...result,
-          [`keywordOrSet${currentIndex + 1}`]: [groupKeywords],
-        };
-      }
-      return result;
-    },
-    {}
-  );
-};
+}): KeywordOrSetSearchVariablesType => ({
+  keywordOrSet1: toArray(keywords[KEYWORD_QUERY_PARAMS.CATEGORIES]),
+  keywordOrSet2: toArray(keywords[KEYWORD_QUERY_PARAMS.TARGET_GROUPS]),
+  keywordOrSet3: toArray(keywords[KEYWORD_QUERY_PARAMS.ADDITIONAL_CRITERIA]),
+});
 
 const getDateString = (date?: string | string[]): string | null => {
   return typeof date === 'string' && isValidDate(new Date(date))

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -46,35 +46,50 @@ export const getEventFilterVariables = (
     include: ['keywords', 'location', 'audience', 'in_language'],
     text: search ?? '',
     inLanguage: getTextFromDict(query, 'inLanguage', undefined),
-    keywordAnd: getKeywordsToQuery(query),
     start: getDateString(query.date) || 'now',
     end: getDateString(query.endDate),
     location: getTextFromDict(query, 'places', undefined),
     organisationId: getTextFromDict(query, 'organisation', undefined),
     division: getTextFromDict(query, 'divisions', undefined),
     isFree: query.isFree === 'true' ? true : undefined,
+    ...getKeywordsToQuery(query),
     ...options,
   };
+};
+
+type KeywordOrSetSearchVariablesType = {
+  keywordOrSet1?: string[];
+  keywordOrSet2?: string[];
+  keywordOrSet3?: string[];
 };
 
 const getKeywordsToQuery = (keywords: {
   [KEYWORD_QUERY_PARAMS.CATEGORIES]?: string | string[];
   [KEYWORD_QUERY_PARAMS.TARGET_GROUPS]?: string | string[];
   [KEYWORD_QUERY_PARAMS.ADDITIONAL_CRITERIA]?: string | string[];
-}): string[] => {
+}): KeywordOrSetSearchVariablesType => {
   return [
     keywords[KEYWORD_QUERY_PARAMS.CATEGORIES],
     keywords[KEYWORD_QUERY_PARAMS.TARGET_GROUPS],
     keywords[KEYWORD_QUERY_PARAMS.ADDITIONAL_CRITERIA],
-  ].reduce<string[]>((prev, next) => {
-    if (Array.isArray(next)) {
-      return [...prev, ...next];
-    }
-    if (next) {
-      return [...prev, next];
-    }
-    return prev;
-  }, []);
+  ].reduce<KeywordOrSetSearchVariablesType>(
+    (result, groupKeywords, currentIndex) => {
+      if (Array.isArray(groupKeywords)) {
+        return {
+          ...result,
+          [`keywordOrSet${currentIndex + 1}`]: groupKeywords,
+        };
+      }
+      if (groupKeywords) {
+        return {
+          ...result,
+          [`keywordOrSet${currentIndex + 1}`]: [groupKeywords],
+        };
+      }
+      return result;
+    },
+    {}
+  );
 };
 
 const getDateString = (date?: string | string[]): string | null => {

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -2181,6 +2181,9 @@ export type EventsQueryVariables = Exact<{
   isFree?: InputMaybe<Scalars['Boolean']['input']>;
   keyword?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
   keywordAnd?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
+  keywordOrSet1?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
+  keywordOrSet2?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
+  keywordOrSet3?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
   keywordNot?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
   language?: InputMaybe<Scalars['String']['input']>;
   location?: InputMaybe<Scalars['String']['input']>;
@@ -2818,7 +2821,7 @@ export type EnrolEventQueueMutationHookResult = ReturnType<typeof useEnrolEventQ
 export type EnrolEventQueueMutationResult = Apollo.MutationResult<EnrolEventQueueMutation>;
 export type EnrolEventQueueMutationOptions = Apollo.BaseMutationOptions<EnrolEventQueueMutation, EnrolEventQueueMutationVariables>;
 export const EventsDocument = gql`
-    query Events($division: [String], $allOngoingAnd: [String], $end: String, $include: [String], $inLanguage: String, $isFree: Boolean, $keyword: [String], $keywordAnd: [String], $keywordNot: [String], $language: String, $location: String, $page: Int, $pageSize: Int, $publisher: ID, $sort: String, $start: String, $superEvent: ID, $superEventType: [String], $text: String, $translation: String, $organisationId: String) {
+    query Events($division: [String], $allOngoingAnd: [String], $end: String, $include: [String], $inLanguage: String, $isFree: Boolean, $keyword: [String], $keywordAnd: [String], $keywordOrSet1: [String], $keywordOrSet2: [String], $keywordOrSet3: [String], $keywordNot: [String], $language: String, $location: String, $page: Int, $pageSize: Int, $publisher: ID, $sort: String, $start: String, $superEvent: ID, $superEventType: [String], $text: String, $translation: String, $organisationId: String) {
   events(
     division: $division
     allOngoingAnd: $allOngoingAnd
@@ -2828,6 +2831,9 @@ export const EventsDocument = gql`
     isFree: $isFree
     keyword: $keyword
     keywordAnd: $keywordAnd
+    keywordOrSet1: $keywordOrSet1
+    keywordOrSet2: $keywordOrSet2
+    keywordOrSet3: $keywordOrSet3
     keywordNot: $keywordNot
     language: $language
     location: $location
@@ -2873,6 +2879,9 @@ ${EventsFieldsFragmentDoc}`;
  *      isFree: // value for 'isFree'
  *      keyword: // value for 'keyword'
  *      keywordAnd: // value for 'keywordAnd'
+ *      keywordOrSet1: // value for 'keywordOrSet1'
+ *      keywordOrSet2: // value for 'keywordOrSet2'
+ *      keywordOrSet3: // value for 'keywordOrSet3'
  *      keywordNot: // value for 'keywordNot'
  *      language: // value for 'language'
  *      location: // value for 'location'


### PR DESCRIPTION
PT-1591.
Update the GraphQL schemas: Add KeywordOrSet filters to events list query.
The keyword-filter is now replaced with 3 new KeywordOrSet filters:
keywordOrSet1, keywordOrSet2 and keywordOrSet3, because there
are 3 different keyword set types in Kultus search -- target groups,
categories and activities / additional criterias.

----

This PR needs the new filters from the API: https://github.com/City-of-Helsinki/palvelutarjotin/pull/341

NOTE: This can also act as an alternative for https://github.com/City-of-Helsinki/palvelutarjotin-ui/pull/306