### PR TITLE
PT-1614 | Fix "Share Event" translation

### DIFF
--- a/public/locales/en/event.json
+++ b/public/locales/en/event.json
@@ -65,7 +65,7 @@
     "labelLanguages": "Event languages"
   },
   "shareLinks": {
-    "title": "Jaa tapahtuma"
+    "title": "Share Event"
   },
   "info": {
     "textCalendarLinkDescription": "{{description}} Read more: {{link}}"

--- a/public/locales/fi/event.json
+++ b/public/locales/fi/event.json
@@ -65,7 +65,7 @@
     "labelLanguages": "Tapahtuman kielet"
   },
   "shareLinks": {
-    "title": "Share Event"
+    "title": "Jaa tapahtuma"
   },
   "info": {
     "textCalendarLinkDescription": "{{description}} Lue lisää: {{link}}"


### PR DESCRIPTION
## Description :sparkles:

### fix: fix "Share Event" translation (en & fi translations were swapped)

refs PT-1614

## Issues :bug:

### Closes :no_good_woman:

[PT-1614](https://helsinkisolutionoffice.atlassian.net/browse/PT-1614)

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[PT-1614]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ