### PR TITLE
PT-1720 | Refactoring & cleaning up

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -90,6 +90,19 @@ module.exports = {
       };
     }
 
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '~hds-core': path.resolve(__dirname, './node_modules/hds-core'),
+      '~hds-design-tokens': path.resolve(
+        __dirname,
+        './node_modules/hds-design-tokens'
+      ),
+      '~react-toastify': path.resolve(
+        __dirname,
+        './node_modules/react-toastify'
+      ),
+    };
+
     // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/tree-shaking/
     config.plugins.push(
       new webpack.DefinePlugin({

--- a/src/assets/styles/layout.scss
+++ b/src/assets/styles/layout.scss
@@ -1,21 +1,24 @@
+@import '~hds-design-tokens/lib/breakpoint/all';
+
 //
 //  MEDIA QUERIES
 //––––––––––––––––––––––––––––––––––––––––––––––––––
 
 // A map of breakpoints.
 $breakpoints: (
-  xs: 576px,
-  sm: 768px,
-  md: 992px,
-  lg: 1248px,
-  xlg: 1600px,
+  xs: $breakpoint-xs,
+  s: $breakpoint-s,
+  m: $breakpoint-m,
+  l: $breakpoint-l,
+  xl: $breakpoint-xl,
+  xxl: 1600px, // Custom breakpoint, not in HDS
 );
 
 //
 //  RESPOND ABOVE
 //––––––––––––––––––––––––––––––––––––––––––––––––––
 
-// @include respond-above(sm) {}
+// @include respond-above(m) {}
 @mixin respond-above($breakpoint) {
   // If the breakpoint exists in the map.
   @if map-has-key($breakpoints, $breakpoint) {
@@ -38,7 +41,7 @@ $breakpoints: (
 //  RESPOND BELOW
 //––––––––––––––––––––––––––––––––––––––––––––––––––
 
-// @include respond-below(sm) {}
+// @include respond-below(m) {}
 @mixin respond-below($breakpoint) {
   // If the breakpoint exists in the map.
   @if map-has-key($breakpoints, $breakpoint) {
@@ -61,7 +64,7 @@ $breakpoints: (
 //  RESPOND BETWEEN
 //––––––––––––––––––––––––––––––––––––––––––––––––––
 
-// @include respond-between(sm, md) {}
+// @include respond-between(m, l) {}
 @mixin respond-between($lower, $upper) {
   // If both the lower and upper breakpoints exist in the map.
   @if map-has-key($breakpoints, $lower) and map-has-key($breakpoints, $upper) {

--- a/src/common/components/multiSelectDropdown/dropdownMenu.module.scss
+++ b/src/common/components/multiSelectDropdown/dropdownMenu.module.scss
@@ -7,7 +7,7 @@
   z-index: 1;
   position: relative;
 
-  @include respond_above(sm) {
+  @include respond_above(m) {
     position: absolute;
     top: 100%;
     left: 0;
@@ -16,7 +16,7 @@
   }
 
   .dropdownMenuWrapper {
-    @include respond_above(sm) {
+    @include respond_above(m) {
       max-height: 18.35rem;
       overflow: auto;
     }

--- a/src/common/components/table/table.module.scss
+++ b/src/common/components/table/table.module.scss
@@ -30,7 +30,7 @@
         padding: var(--spacing-cell);
         border-bottom: 1px solid var(--border-color-cell);
 
-        @include respond-above(md) {
+        @include respond-above(l) {
           &:nth-child(2) {
             padding-left: 0;
           }
@@ -62,7 +62,7 @@
         text-align: left;
         padding: var(--spacing-cell);
 
-        @include respond-above(md) {
+        @include respond-above(l) {
           &:nth-child(2) {
             padding-left: 0;
           }
@@ -91,7 +91,7 @@
         background-color: var(--background-color-active-row);
         border-bottom: 1px solid var(--border-color-cell);
 
-        @include respond-above(md) {
+        @include respond-above(l) {
           padding: var(--spacing-m) var(--spacing-2-xl) !important;
         }
       }

--- a/src/domain/app/header/Header.tsx
+++ b/src/domain/app/header/Header.tsx
@@ -10,7 +10,6 @@ import {
 } from 'react-helsinki-headless-cms';
 import { useMenuQuery } from 'react-helsinki-headless-cms/apollo';
 
-import styles from './header.module.scss';
 import HeaderNotification from './HeaderNotification';
 import { DEFAULT_HEADER_MENU_NAME } from '../../../constants';
 import { PageIdType, usePageQuery } from '../../../generated/graphql-cms';
@@ -108,7 +107,6 @@ const Header: React.FC = () => {
     <div>
       <Navigation
         languages={HARDCODED_LANGUAGES}
-        className={styles.header}
         menu={menu}
         onTitleClick={goToPage(ROUTES.HOME)}
         getIsItemActive={getIsItemActive}

--- a/src/domain/app/header/__tests__/__snapshots__/Header.test.tsx.snap
+++ b/src/domain/app/header/__tests__/__snapshots__/Header.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Header matches snapshot 1`] = `
 <div>
   <header
-    class="hds-header Header-module_header__291GF header"
+    class="hds-header Header-module_header__291GF"
     style="--header-max-width: var(--breakpoint-xl);"
   >
     <div

--- a/src/domain/app/header/header.module.scss
+++ b/src/domain/app/header/header.module.scss
@@ -1,5 +1,0 @@
-.header {
-  button {
-    margin: 0 0 0 var(--spacing-s) !important;
-  }
-}

--- a/src/domain/app/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/domain/app/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PageLayout matches snapshot 1`] = `
 >
   <div>
     <header
-      class="hds-header Header-module_header__291GF header"
+      class="hds-header Header-module_header__291GF"
       style="--header-max-width: var(--breakpoint-xl);"
     >
       <div

--- a/src/domain/app/layout/container.module.scss
+++ b/src/domain/app/layout/container.module.scss
@@ -7,11 +7,11 @@
   place-content: flex-start;
   grid-template-columns: var(--spacing-s) 1fr var(--spacing-s);
 
-  @include respond-between(sm, xlg) {
+  @include respond-between(m, xxl) {
     grid-template-columns: 1fr 10fr 1fr;
   }
 
-  @include respond-above(xlg) {
+  @include respond-above(xxl) {
     grid-template-columns: 1fr minmax(auto, $containerMaxWidth) 1fr;
   }
 
@@ -20,13 +20,13 @@
   }
 
   &.xsmall {
-    @include respond-above(sm) {
+    @include respond-above(m) {
       grid-template-columns: 1fr minmax(auto, $containerXSmallMaxWidth) 1fr;
     }
   }
 
   &.small {
-    @include respond-above(sm) {
+    @include respond-above(m) {
       grid-template-columns: 1fr minmax(auto, $containerSmallMaxWidth) 1fr;
     }
   }

--- a/src/domain/app/layout/pageLayout.module.scss
+++ b/src/domain/app/layout/pageLayout.module.scss
@@ -17,7 +17,7 @@
   padding: var(--padding-body);
   flex: 1;
 
-  @include respond-below(sm) {
+  @include respond-below(m) {
     opacity: 1;
     transition: visibility 0.2s, opacity 0.2s;
 

--- a/src/domain/enrolment/enrolmentForm/enrolmentForm.module.scss
+++ b/src/domain/enrolment/enrolmentForm/enrolmentForm.module.scss
@@ -6,7 +6,7 @@
   .rowWith2Columns {
     display: grid;
 
-    @include respond_above(sm) {
+    @include respond_above(m) {
       grid-template-columns: 1fr 1fr;
       grid-gap: var(--spacing-layout-s);
     }
@@ -16,7 +16,7 @@
     display: grid;
     grid-gap: var(--spacing-layout-s);
 
-    @include respond_above(sm) {
+    @include respond_above(m) {
       grid-template-columns: 1fr 1fr 1fr;
     }
   }

--- a/src/domain/errorPage/errorPage.module.scss
+++ b/src/domain/errorPage/errorPage.module.scss
@@ -32,7 +32,7 @@
     width: var(--width-button);
     margin-top: var(--content-spacing);
 
-    @include respond_above(sm) {
+    @include respond_above(m) {
       margin-top: 4rem;
     }
   }

--- a/src/domain/event/eventBasicInfo/eventBasicInfo.module.scss
+++ b/src/domain/event/eventBasicInfo/eventBasicInfo.module.scss
@@ -38,7 +38,7 @@
       margin-top: 0;
     }
 
-    @include respond_above(sm) {
+    @include respond_above(m) {
       grid-template-columns: 1fr 1fr;
     }
   }

--- a/src/domain/event/eventCard/eventCard.module.scss
+++ b/src/domain/event/eventCard/eventCard.module.scss
@@ -24,7 +24,7 @@
   text-decoration: none;
   color: black;
 
-  @include respond_above(sm) {
+  @include respond_above(m) {
     grid-template-columns: var(--width-image) 1fr;
   }
 
@@ -34,7 +34,7 @@
     background-size: cover;
     background-repeat: no-repeat;
 
-    @include respond_above(sm) {
+    @include respond_above(m) {
       height: var(--height-image);
     }
   }
@@ -64,7 +64,7 @@
     grid-gap: var(--spacing-m);
     margin-top: var(--spacing-m);
 
-    @include respond_above(sm) {
+    @include respond_above(m) {
       grid-template-columns: 1fr 1fr;
     }
   }

--- a/src/domain/event/eventPage.module.scss
+++ b/src/domain/event/eventPage.module.scss
@@ -7,7 +7,7 @@
   display: block;
   z-index: 1;
 
-  @include respond-above(sm) {
+  @include respond-above(m) {
     box-shadow: rgb(0 0 0 / 24%) 0 3px 8px;
     padding: 1rem var(--spacing-2-xl);
     background-color: var(--color-white);
@@ -43,7 +43,7 @@ h2.enrolmentHeader {
   border-top: 1px solid var(--color-black-10);
   margin-top: -1px;
 
-  @include respond-above(sm) {
+  @include respond-above(m) {
     margin: 0 calc(-1 * var(--spacing-2-xl));
     margin-top: -1px;
   }
@@ -56,7 +56,7 @@ h2.enrolmentHeader {
   height: var(--hero-height);
   position: relative;
 
-  @include respond-above(sm) {
+  @include respond-above(m) {
     margin-bottom: calc((-1 * var(--hero-height)) / 2);
   }
 
@@ -81,7 +81,7 @@ h2.enrolmentHeader {
 }
 
 .occurrencesContainer {
-  @include respond-above(sm) {
+  @include respond-above(m) {
     margin: 0 calc(-1 * var(--spacing-2-xl));
   }
 }

--- a/src/domain/event/occurrences/occurrences.module.scss
+++ b/src/domain/event/occurrences/occurrences.module.scss
@@ -17,7 +17,7 @@
     grid-template-columns: auto 1fr;
     align-items: center;
 
-    @include respond-above(sm) {
+    @include respond-above(m) {
       margin: 0 var(--spacing-2-xl);
     }
   }
@@ -30,7 +30,7 @@
   }
 
   .enrolmentNotification {
-    @include respond-above(sm) {
+    @include respond-above(m) {
       margin: 0 var(--spacing-2-xl);
       width: auto;
     }
@@ -49,7 +49,7 @@
     display: grid;
     grid-template-columns: 3fr 2fr;
 
-    @include respond-above(md) {
+    @include respond-above(l) {
       grid-template-columns: 4fr 2fr;
     }
   }

--- a/src/domain/events/eventList/eventList.module.scss
+++ b/src/domain/events/eventList/eventList.module.scss
@@ -22,7 +22,7 @@
   grid-gap: var(--spacing-s);
   margin-bottom: var(--spacing-s);
 
-  @include respond_above(sm) {
+  @include respond_above(m) {
     grid-template-columns: 1fr auto;
     grid-gap: var(--spacing-l);
   }

--- a/src/domain/events/eventSearchForm/eventSearchForm.module.scss
+++ b/src/domain/events/eventSearchForm/eventSearchForm.module.scss
@@ -21,7 +21,7 @@
   display: grid;
   grid-gap: var(--grid-gap-mobile);
 
-  @include respond_above(md) {
+  @include respond_above(l) {
     grid-template-columns: 1fr 1fr 1fr;
   }
 }
@@ -30,7 +30,7 @@
   display: grid;
   grid-gap: var(--grid-gap-mobile);
 
-  @include respond_above(md) {
+  @include respond_above(l) {
     grid-template-columns: 1fr 1fr 1fr 1fr;
   }
 }
@@ -106,7 +106,7 @@
   grid-gap: 1rem;
   color: var(--color-white);
 
-  @include respond_above(md) {
+  @include respond_above(l) {
     grid-template-columns: auto 1fr auto;
   }
 
@@ -127,7 +127,7 @@
     //   }
     // }
 
-    @include respond_above(md) {
+    @include respond_above(l) {
       text-align: right;
       margin-left: var(--spacing-s);
     }

--- a/src/domain/events/eventsPage.module.scss
+++ b/src/domain/events/eventsPage.module.scss
@@ -5,7 +5,7 @@
   padding: var(--spacing-layout-xs);
   margin-bottom: var(--spacing-layout-s) !important;
 
-  @include respond_above(md) {
+  @include respond_above(l) {
     padding: var(--spacing-layout-l);
   }
 }

--- a/src/domain/newsletter/newsletterSubscribeForm/newsletterSubscribeForm.module.scss
+++ b/src/domain/newsletter/newsletterSubscribeForm/newsletterSubscribeForm.module.scss
@@ -7,7 +7,7 @@
     display: grid;
     grid-gap: var(--spacing-layout-s);
 
-    @include respond_above(sm) {
+    @include respond_above(m) {
       grid-template-columns: 1fr 1fr;
     }
   }

--- a/src/utils/stringifyUrlObject.ts
+++ b/src/utils/stringifyUrlObject.ts
@@ -9,24 +9,14 @@ const queryToString = (
   query: Record<string, unknown> | string | undefined,
   usedQueryParts: string[]
 ) => {
-  if (!query) {
-    return;
-  }
-
-  if (typeof query === 'string') {
+  if (!query || typeof query === 'string') {
     return query;
   }
 
-  const queryWithoutUsed = Object.entries(query).reduce((acc, [key, value]) => {
-    if (usedQueryParts.includes(key)) {
-      return acc;
-    }
-
-    return {
-      ...acc,
-      [key]: value,
-    };
-  }, {});
+  const usedQueryPartsSet = new Set(Object.keys(usedQueryParts));
+  const queryWithoutUsed = Object.fromEntries(
+    Object.entries(query).filter(([key]) => !usedQueryPartsSet.has(key))
+  );
 
   const queryAsString = queryString.stringify(queryWithoutUsed);
 


### PR DESCRIPTION
## Description :sparkles:

### refactor: use HDS v3.7's breakpoints directly if possible

old breakpoint name (old breakpoint width) / new name (new width):
 - sm (768px) -> m (768px) = $breakpoint-m in HDS v3.7
 - md (992px) -> l (992px) = $breakpoint-l in HDS v3.7
 - xlg (1600px) -> xxl (1600px), a custom breakpoint, not in HDS v3.7

refs PT-1720 (cleaning up / refactoring after the fact)

### refactor: make queryToString function faster, conciser & more readable

refs PT-1720 (cleaning up / refactoring)

### refactor: remove header stylings as unnecessary (no need with HDS v3.7)

refs PT-1720 (cleanup / refactoring after the fact)

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[PT-1720](https://helsinkisolutionoffice.atlassian.net/browse/PT-1720)
https://github.com/City-of-Helsinki/palvelutarjotin-ui/pull/304

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[PT-1720]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ