### PR TITLE
PT-1723 | fix: getAllMenuPages, footer CMS page links, remove obsolete menus

### DIFF
--- a/src/domain/app/footer/Footer.tsx
+++ b/src/domain/app/footer/Footer.tsx
@@ -8,6 +8,10 @@ import styles from './footer.module.scss';
 import { resetFocusId } from '../../../common/components/resetFocus/ResetFocus';
 import { DEFAULT_FOOTER_MENU_NAME } from '../../../constants';
 import useLocale from '../../../hooks/useLocale';
+import {
+  getIsHrefExternal,
+  getRoutedInternalHrefForLocale,
+} from '../../../pages/_app';
 
 const FooterSection = (): React.ReactElement => {
   const { t } = useTranslation();
@@ -41,17 +45,16 @@ const FooterSection = (): React.ReactElement => {
       >
         {!loading &&
           data?.menu?.menuItems?.nodes?.map((navigationItem) => {
-            const href =
-              navigationItem?.connectedNode?.node &&
-              'link' in navigationItem.connectedNode.node
-                ? `/${locale}${navigationItem?.connectedNode.node.link}`
-                : navigationItem?.path;
+            const path = navigationItem?.path ?? '';
+            const href = getIsHrefExternal(path)
+              ? path
+              : getRoutedInternalHrefForLocale(locale, path);
             return (
               <Footer.Link
                 className={styles.footerLink}
                 key={navigationItem?.id}
                 as={Link}
-                href={href || ''}
+                href={href}
                 label={navigationItem?.label || undefined}
               />
             );

--- a/src/domain/app/footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/domain/app/footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -100,7 +100,7 @@ exports[`Footer matches snapshot 1`] = `
             </span>
             <a
               class="LinkBase-module_link__djxNm LinkBase_hds-link__4Kjdj LinkBase-module_linkM__Hz4Zc LinkBase_hds-link--medium__bHZ5t LinkBase-module_disableVisitedStyles__S6UjE LinkBase_hds-link--disable-visited-styles__cQcea Link-module_link__ysKHd FooterLink-module_item__3Ig3B FooterLink-module_base__bzKoj footerLink"
-              href="/saavutettavuusseloste"
+              href="/cms-page/saavutettavuusseloste"
             >
               <span
                 class="LinkBase-module_content__Y4oQw"
@@ -118,7 +118,7 @@ exports[`Footer matches snapshot 1`] = `
             </span>
             <a
               class="LinkBase-module_link__djxNm LinkBase_hds-link__4Kjdj LinkBase-module_linkM__Hz4Zc LinkBase_hds-link--medium__bHZ5t LinkBase-module_disableVisitedStyles__S6UjE LinkBase_hds-link--disable-visited-styles__cQcea Link-module_link__ysKHd FooterLink-module_item__3Ig3B FooterLink-module_base__bzKoj footerLink"
-              href="/kayttoehdot"
+              href="/cms-page/kayttoehdot"
             >
               <span
                 class="LinkBase-module_content__Y4oQw"
@@ -136,7 +136,7 @@ exports[`Footer matches snapshot 1`] = `
             </span>
             <a
               class="LinkBase-module_link__djxNm LinkBase_hds-link__4Kjdj LinkBase-module_linkM__Hz4Zc LinkBase_hds-link--medium__bHZ5t LinkBase-module_disableVisitedStyles__S6UjE LinkBase_hds-link--disable-visited-styles__cQcea Link-module_link__ysKHd FooterLink-module_item__3Ig3B FooterLink-module_base__bzKoj footerLink"
-              href="/palaute"
+              href="/cms-page/palaute"
             >
               <span
                 class="LinkBase-module_content__Y4oQw"

--- a/src/headless-cms/cmsApolloClient.ts
+++ b/src/headless-cms/cmsApolloClient.ts
@@ -11,6 +11,7 @@ import fetch from 'cross-fetch';
 import merge from 'lodash/merge';
 import { useMemo } from 'react';
 
+import AppConfig from './config';
 import { rewriteInternalURLs } from './utils';
 
 let cmsApolloClient: ApolloClient<NormalizedCacheObject>;
@@ -56,9 +57,7 @@ export const createCmsApolloClient =
     });
 
     const httpLink = new HttpLink({
-      uri:
-        process.env.NEXT_PUBLIC_CMS_BASE_URL ??
-        'https://kultus.content.api.hel.fi/graphql',
+      uri: AppConfig.cmsGraphqlEndpoint,
       fetch,
     });
 

--- a/src/headless-cms/config.ts
+++ b/src/headless-cms/config.ts
@@ -9,7 +9,7 @@ class AppConfig {
   static get cmsGraphqlEndpoint() {
     return getEnvOrError(
       process.env.NEXT_PUBLIC_CMS_BASE_URL,
-      'NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT'
+      'NEXT_PUBLIC_CMS_BASE_URL'
     );
   }
   static get cmsOrigin() {

--- a/src/headless-cms/constants.ts
+++ b/src/headless-cms/constants.ts
@@ -1,11 +1,4 @@
-//TODO: still used for the breadcrumb but contradicts with the current Navigation logic with localized menus?
-
 import { Language, LanguageCodeEnum } from 'react-helsinki-headless-cms';
-
-export enum MENU_NAME {
-  Header = 'Palvelutarjotin-UI Header',
-  Footer = 'Palvelutarjotin-UI Footer',
-}
 
 /**
  * This is just a mock of list of Languages.

--- a/src/tests/apollo-mocks/menuMocks.ts
+++ b/src/tests/apollo-mocks/menuMocks.ts
@@ -1,0 +1,135 @@
+import {
+  DEFAULT_FOOTER_MENU_NAME,
+  DEFAULT_HEADER_MENU_NAME,
+} from '../../constants';
+import { PageInfo } from '../../headless-cms/utils';
+import enHeaderMenu from '../fixtures/menus/Palvelutarjotin all UIs Header (EN)';
+import fiHeaderMenu from '../fixtures/menus/Palvelutarjotin all UIs Header (FI)';
+import svHeaderMenu from '../fixtures/menus/Palvelutarjotin all UIs Header (SV)';
+import enFooterMenu from '../fixtures/menus/Palvelutarjotin-UI Footer (EN)';
+import fiFooterMenu from '../fixtures/menus/Palvelutarjotin-UI Footer (FI)';
+import svFooterMenu from '../fixtures/menus/Palvelutarjotin-UI Footer (SV)';
+
+const menuIdToMenuData = {
+  [DEFAULT_HEADER_MENU_NAME['en']]: enHeaderMenu,
+  [DEFAULT_HEADER_MENU_NAME['fi']]: fiHeaderMenu,
+  [DEFAULT_HEADER_MENU_NAME['sv']]: svHeaderMenu,
+  [DEFAULT_FOOTER_MENU_NAME['en']]: enFooterMenu,
+  [DEFAULT_FOOTER_MENU_NAME['fi']]: fiFooterMenu,
+  [DEFAULT_FOOTER_MENU_NAME['sv']]: svFooterMenu,
+} as const;
+
+/** Menu query mocks for English, Finnish and Swedish. */
+export const menuQueryMocks = Object.entries(menuIdToMenuData).map(
+  ([id, menu]) => ({
+    variables: { id, menuIdentifiersOnly: false },
+    response: menu,
+  })
+);
+
+/** All menu pages when querying the mocked menu queries. */
+export const allMockedMenuPages: PageInfo[] = [
+  {
+    uri: '/en/accessibility-statement/',
+    slug: 'accessibility-statement',
+    locale: 'en',
+  },
+  { uri: '/oppimateriaalit/alakoulu/', slug: 'alakoulu', locale: 'fi' },
+  {
+    uri: '/sv/anvandarvillkor/',
+    slug: 'anvandarvillkor',
+    locale: 'sv',
+  },
+  {
+    uri: '/sv/kulturpedagogik/centrala-begrepp-2/',
+    slug: 'centrala-begrepp-2',
+    locale: 'sv',
+  },
+  {
+    uri: '/en/cultural-education/',
+    slug: 'cultural-education',
+    locale: 'en',
+  },
+  {
+    uri: '/en/cultural-education/cultural-routes/',
+    slug: 'cultural-routes',
+    locale: 'en',
+  },
+  {
+    uri: '/kayttoehdot/',
+    slug: 'kayttoehdot',
+    locale: 'fi',
+  },
+  {
+    uri: '/en/cultural-education/key-concepts/',
+    slug: 'key-concepts',
+    locale: 'en',
+  },
+  {
+    uri: '/kulttuurikasvatus/kulttuurikasvatuksen-kasitteita/',
+    slug: 'kulttuurikasvatuksen-kasitteita',
+    locale: 'fi',
+  },
+  {
+    uri: '/kulttuurikasvatus/',
+    slug: 'kulttuurikasvatus',
+    locale: 'fi',
+  },
+  {
+    uri: '/kulttuurikasvatus/kulttuuripolulla-kulttuuria-kaikille/',
+    slug: 'kulttuuripolulla-kulttuuria-kaikille',
+    locale: 'fi',
+  },
+  { uri: '/sv/kulturpedagogik/', slug: 'kulturpedagogik', locale: 'sv' },
+  {
+    uri: '/mika-kultus/',
+    slug: 'mika-kultus',
+    locale: 'fi',
+  },
+  { uri: '/oppimateriaalit/', slug: 'oppimateriaalit', locale: 'fi' },
+  {
+    uri: '/saavutettavuusseloste/',
+    slug: 'saavutettavuusseloste',
+    locale: 'fi',
+  },
+  {
+    uri: '/en/terms-of-service/',
+    slug: 'terms-of-service',
+    locale: 'en',
+  },
+  {
+    uri: '/sv/tillganglighetsutlatande/',
+    slug: 'tillganglighetsutlatande',
+    locale: 'sv',
+  },
+  {
+    uri: '/sv/vad-ar-kultus/',
+    slug: 'vad-ar-kultus',
+    locale: 'sv',
+  },
+  {
+    uri: '/oppimateriaalit/varhaiskasvatus/',
+    slug: 'varhaiskasvatus',
+    locale: 'fi',
+  },
+  {
+    uri: '/en/what-is-kultus/',
+    slug: 'what-is-kultus',
+    locale: 'en',
+  },
+  {
+    uri: '/kulttuurikasvatus/yhteistyo/',
+    slug: 'yhteistyo',
+    locale: 'fi',
+  },
+  {
+    uri: '/mika-kultus/yhteystiedot/',
+    slug: 'yhteystiedot',
+    locale: 'fi',
+  },
+  {
+    uri: '/oppimateriaalit/ylakoulu-ja-toinen-aste/',
+    slug: 'ylakoulu-ja-toinen-aste',
+    locale: 'fi',
+  },
+];

--- a/src/tests/fixtures/menus/Palvelutarjotin all UIs Header (EN).ts
+++ b/src/tests/fixtures/menus/Palvelutarjotin all UIs Header (EN).ts
@@ -1,0 +1,341 @@
+import { LanguageCodeEnum } from './types';
+import type { MenuQuery } from './types';
+
+const menu: MenuQuery = {
+  menu: {
+    __typename: 'Menu',
+    id: 'dGVybTozMzY=',
+    menuItems: {
+      __typename: 'MenuToMenuItemConnection',
+      nodes: [
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzMy',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDo2MA==',
+                  slug: 'mika-kultus',
+                  uri: '/mika-kultus/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Fi,
+                    id: 'TGFuZ3VhZ2U6Zmk=',
+                    slug: 'fi',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/what-is-kultus/',
+                      slug: 'what-is-kultus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/vad-ar-kultus/',
+                      slug: 'vad-ar-kultus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDo3MQ==',
+                  slug: 'vad-ar-kultus',
+                  uri: '/sv/vad-ar-kultus/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/what-is-kultus/',
+                      slug: 'what-is-kultus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/mika-kultus/',
+                      slug: 'mika-kultus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDo2OQ==',
+              slug: 'what-is-kultus',
+              uri: '/en/what-is-kultus/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.En,
+                id: 'TGFuZ3VhZ2U6ZW4=',
+                slug: 'en',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzMz',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDo2Mg==',
+                  slug: 'kulttuurikasvatus',
+                  uri: '/kulttuurikasvatus/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Fi,
+                    id: 'TGFuZ3VhZ2U6Zmk=',
+                    slug: 'fi',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/cultural-education/',
+                      slug: 'cultural-education',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/kulturpedagogik/',
+                      slug: 'kulturpedagogik',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoxNzMw',
+                  slug: 'kulturpedagogik',
+                  uri: '/sv/kulturpedagogik/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/cultural-education/',
+                      slug: 'cultural-education',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/kulttuurikasvatus/',
+                      slug: 'kulttuurikasvatus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDo3Nw==',
+              slug: 'cultural-education',
+              uri: '/en/cultural-education/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.En,
+                id: 'TGFuZ3VhZ2U6ZW4=',
+                slug: 'en',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzU3',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyNDE5',
+                  slug: 'centrala-begrepp-2',
+                  uri: '/sv/kulturpedagogik/centrala-begrepp-2/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/kulttuurikasvatus/kulttuurikasvatuksen-kasitteita/',
+                      slug: 'kulttuurikasvatuksen-kasitteita',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/en/cultural-education/key-concepts/',
+                      slug: 'key-concepts',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDo2NDE=',
+                  slug: 'kulttuurikasvatuksen-kasitteita',
+                  uri: '/kulttuurikasvatus/kulttuurikasvatuksen-kasitteita/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Fi,
+                    id: 'TGFuZ3VhZ2U6Zmk=',
+                    slug: 'fi',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/kulturpedagogik/centrala-begrepp-2/',
+                      slug: 'centrala-begrepp-2',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/en/cultural-education/key-concepts/',
+                      slug: 'key-concepts',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoyNDI3',
+              slug: 'key-concepts',
+              uri: '/en/cultural-education/key-concepts/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.En,
+                id: 'TGFuZ3VhZ2U6ZW4=',
+                slug: 'en',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzU4',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyNDg=',
+                  slug: 'kulttuuripolulla-kulttuuria-kaikille',
+                  uri: '/kulttuurikasvatus/kulttuuripolulla-kulttuuria-kaikille/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Fi,
+                    id: 'TGFuZ3VhZ2U6Zmk=',
+                    slug: 'fi',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/cultural-education/cultural-routes/',
+                      slug: 'cultural-routes',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoyNDMx',
+              slug: 'cultural-routes',
+              uri: '/en/cultural-education/cultural-routes/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.En,
+                id: 'TGFuZ3VhZ2U6ZW4=',
+                slug: 'en',
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+export default menu;

--- a/src/tests/fixtures/menus/Palvelutarjotin all UIs Header (FI).ts
+++ b/src/tests/fixtures/menus/Palvelutarjotin all UIs Header (FI).ts
@@ -1,0 +1,680 @@
+import { LanguageCodeEnum } from './types';
+import type { MenuQuery } from './types';
+
+const menu: MenuQuery = {
+  menu: {
+    __typename: 'Menu',
+    id: 'dGVybTozMzc=',
+    menuItems: {
+      __typename: 'MenuToMenuItemConnection',
+      nodes: [
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzE5',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDo2OQ==',
+                  slug: 'what-is-kultus',
+                  uri: '/en/what-is-kultus/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/mika-kultus/',
+                      slug: 'mika-kultus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/vad-ar-kultus/',
+                      slug: 'vad-ar-kultus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDo3MQ==',
+                  slug: 'vad-ar-kultus',
+                  uri: '/sv/vad-ar-kultus/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/what-is-kultus/',
+                      slug: 'what-is-kultus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/mika-kultus/',
+                      slug: 'mika-kultus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDo2MA==',
+              slug: 'mika-kultus',
+              uri: '/mika-kultus/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Fi,
+                id: 'TGFuZ3VhZ2U6Zmk=',
+                slug: 'fi',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzIx',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [],
+              id: 'cG9zdDo2MzY=',
+              slug: 'yhteystiedot',
+              uri: '/mika-kultus/yhteystiedot/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Fi,
+                id: 'TGFuZ3VhZ2U6Zmk=',
+                slug: 'fi',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzIy',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDo3Nw==',
+                  slug: 'cultural-education',
+                  uri: '/en/cultural-education/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/kulttuurikasvatus/',
+                      slug: 'kulttuurikasvatus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/kulturpedagogik/',
+                      slug: 'kulturpedagogik',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoxNzMw',
+                  slug: 'kulturpedagogik',
+                  uri: '/sv/kulturpedagogik/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/cultural-education/',
+                      slug: 'cultural-education',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/kulttuurikasvatus/',
+                      slug: 'kulttuurikasvatus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDo2Mg==',
+              slug: 'kulttuurikasvatus',
+              uri: '/kulttuurikasvatus/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Fi,
+                id: 'TGFuZ3VhZ2U6Zmk=',
+                slug: 'fi',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzI0',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyNDE5',
+                  slug: 'centrala-begrepp-2',
+                  uri: '/sv/kulturpedagogik/centrala-begrepp-2/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/kulttuurikasvatus/kulttuurikasvatuksen-kasitteita/',
+                      slug: 'kulttuurikasvatuksen-kasitteita',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/en/cultural-education/key-concepts/',
+                      slug: 'key-concepts',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyNDI3',
+                  slug: 'key-concepts',
+                  uri: '/en/cultural-education/key-concepts/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/kulturpedagogik/centrala-begrepp-2/',
+                      slug: 'centrala-begrepp-2',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/kulttuurikasvatus/kulttuurikasvatuksen-kasitteita/',
+                      slug: 'kulttuurikasvatuksen-kasitteita',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDo2NDE=',
+              slug: 'kulttuurikasvatuksen-kasitteita',
+              uri: '/kulttuurikasvatus/kulttuurikasvatuksen-kasitteita/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Fi,
+                id: 'TGFuZ3VhZ2U6Zmk=',
+                slug: 'fi',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzI1',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [],
+              id: 'cG9zdDoyNjE=',
+              slug: 'yhteistyo',
+              uri: '/kulttuurikasvatus/yhteistyo/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Fi,
+                id: 'TGFuZ3VhZ2U6Zmk=',
+                slug: 'fi',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzI2',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyNDMx',
+                  slug: 'cultural-routes',
+                  uri: '/en/cultural-education/cultural-routes/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/kulttuurikasvatus/kulttuuripolulla-kulttuuria-kaikille/',
+                      slug: 'kulttuuripolulla-kulttuuria-kaikille',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoyNDg=',
+              slug: 'kulttuuripolulla-kulttuuria-kaikille',
+              uri: '/kulttuurikasvatus/kulttuuripolulla-kulttuuria-kaikille/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Fi,
+                id: 'TGFuZ3VhZ2U6Zmk=',
+                slug: 'fi',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzI3',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [],
+              id: 'cG9zdDo2Nw==',
+              slug: 'oppimateriaalit',
+              uri: '/oppimateriaalit/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Fi,
+                id: 'TGFuZ3VhZ2U6Zmk=',
+                slug: 'fi',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzI5',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoxNTQ=',
+                  slug: 'high-school',
+                  uri: '/en/learning-materials/high-school/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/oppimateriaalit/ylakoulu-ja-toinen-aste/',
+                      slug: 'ylakoulu-ja-toinen-aste',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/laromedel/gymnasium/',
+                      slug: 'gymnasium',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoxNTY=',
+                  slug: 'gymnasium',
+                  uri: '/sv/laromedel/gymnasium/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/learning-materials/high-school/',
+                      slug: 'high-school',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/oppimateriaalit/ylakoulu-ja-toinen-aste/',
+                      slug: 'ylakoulu-ja-toinen-aste',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoxNDM=',
+              slug: 'ylakoulu-ja-toinen-aste',
+              uri: '/oppimateriaalit/ylakoulu-ja-toinen-aste/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Fi,
+                id: 'TGFuZ3VhZ2U6Zmk=',
+                slug: 'fi',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzMw',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoxNDY=',
+                  slug: 'elementary-school',
+                  uri: '/en/learning-materials/elementary-school/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/oppimateriaalit/alakoulu/',
+                      slug: 'alakoulu',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/laromedel/grundskola/',
+                      slug: 'grundskola',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoxNDg=',
+                  slug: 'grundskola',
+                  uri: '/sv/laromedel/grundskola/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/learning-materials/elementary-school/',
+                      slug: 'elementary-school',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/oppimateriaalit/alakoulu/',
+                      slug: 'alakoulu',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoxNDA=',
+              slug: 'alakoulu',
+              uri: '/oppimateriaalit/alakoulu/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Fi,
+                id: 'TGFuZ3VhZ2U6Zmk=',
+                slug: 'fi',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzMx',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoxNTA=',
+                  slug: 'early-childhood-education',
+                  uri: '/en/learning-materials/early-childhood-education/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/oppimateriaalit/varhaiskasvatus/',
+                      slug: 'varhaiskasvatus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/laromedel/tidig-barndom/',
+                      slug: 'tidig-barndom',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoxNTI=',
+                  slug: 'tidig-barndom',
+                  uri: '/sv/laromedel/tidig-barndom/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/learning-materials/early-childhood-education/',
+                      slug: 'early-childhood-education',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/oppimateriaalit/varhaiskasvatus/',
+                      slug: 'varhaiskasvatus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoxMzc=',
+              slug: 'varhaiskasvatus',
+              uri: '/oppimateriaalit/varhaiskasvatus/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Fi,
+                id: 'TGFuZ3VhZ2U6Zmk=',
+                slug: 'fi',
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+export default menu;

--- a/src/tests/fixtures/menus/Palvelutarjotin all UIs Header (SV).ts
+++ b/src/tests/fixtures/menus/Palvelutarjotin all UIs Header (SV).ts
@@ -1,0 +1,295 @@
+import { LanguageCodeEnum } from './types';
+import type { MenuQuery } from './types';
+
+const menu: MenuQuery = {
+  menu: {
+    __typename: 'Menu',
+    id: 'dGVybTozMzg=',
+    menuItems: {
+      __typename: 'MenuToMenuItemConnection',
+      nodes: [
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzM0',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDo2OQ==',
+                  slug: 'what-is-kultus',
+                  uri: '/en/what-is-kultus/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/mika-kultus/',
+                      slug: 'mika-kultus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/vad-ar-kultus/',
+                      slug: 'vad-ar-kultus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDo2MA==',
+                  slug: 'mika-kultus',
+                  uri: '/mika-kultus/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Fi,
+                    id: 'TGFuZ3VhZ2U6Zmk=',
+                    slug: 'fi',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/what-is-kultus/',
+                      slug: 'what-is-kultus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/vad-ar-kultus/',
+                      slug: 'vad-ar-kultus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDo3MQ==',
+              slug: 'vad-ar-kultus',
+              uri: '/sv/vad-ar-kultus/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Sv,
+                id: 'TGFuZ3VhZ2U6c3Y=',
+                slug: 'sv',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzM1',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDo3Nw==',
+                  slug: 'cultural-education',
+                  uri: '/en/cultural-education/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/kulttuurikasvatus/',
+                      slug: 'kulttuurikasvatus',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/kulturpedagogik/',
+                      slug: 'kulturpedagogik',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDo2Mg==',
+                  slug: 'kulttuurikasvatus',
+                  uri: '/kulttuurikasvatus/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Fi,
+                    id: 'TGFuZ3VhZ2U6Zmk=',
+                    slug: 'fi',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/cultural-education/',
+                      slug: 'cultural-education',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/kulturpedagogik/',
+                      slug: 'kulturpedagogik',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoxNzMw',
+              slug: 'kulturpedagogik',
+              uri: '/sv/kulturpedagogik/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Sv,
+                id: 'TGFuZ3VhZ2U6c3Y=',
+                slug: 'sv',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyNzU5',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDo2NDE=',
+                  slug: 'kulttuurikasvatuksen-kasitteita',
+                  uri: '/kulttuurikasvatus/kulttuurikasvatuksen-kasitteita/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Fi,
+                    id: 'TGFuZ3VhZ2U6Zmk=',
+                    slug: 'fi',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/kulturpedagogik/centrala-begrepp-2/',
+                      slug: 'centrala-begrepp-2',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/en/cultural-education/key-concepts/',
+                      slug: 'key-concepts',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyNDI3',
+                  slug: 'key-concepts',
+                  uri: '/en/cultural-education/key-concepts/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/kulturpedagogik/centrala-begrepp-2/',
+                      slug: 'centrala-begrepp-2',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/kulttuurikasvatus/kulttuurikasvatuksen-kasitteita/',
+                      slug: 'kulttuurikasvatuksen-kasitteita',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoyNDE5',
+              slug: 'centrala-begrepp-2',
+              uri: '/sv/kulturpedagogik/centrala-begrepp-2/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Sv,
+                id: 'TGFuZ3VhZ2U6c3Y=',
+                slug: 'sv',
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+export default menu;

--- a/src/tests/fixtures/menus/Palvelutarjotin-UI Footer (EN).ts
+++ b/src/tests/fixtures/menus/Palvelutarjotin-UI Footer (EN).ts
@@ -1,0 +1,222 @@
+import { LanguageCodeEnum } from './types';
+import type { MenuQuery } from './types';
+
+const menu: MenuQuery = {
+  menu: {
+    __typename: 'Menu',
+    id: 'dGVybToyNzQ=',
+    menuItems: {
+      __typename: 'MenuToMenuItemConnection',
+      nodes: [
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDUw',
+          connectedNode: null,
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDUx',
+          connectedNode: null,
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDUy',
+          connectedNode: null,
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDUz',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyMDMx',
+                  slug: 'saavutettavuusseloste',
+                  uri: '/saavutettavuusseloste/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Fi,
+                    id: 'TGFuZ3VhZ2U6Zmk=',
+                    slug: 'fi',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/accessibility-statement/',
+                      slug: 'accessibility-statement',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/tillganglighetsutlatande/',
+                      slug: 'tillganglighetsutlatande',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyMDM1',
+                  slug: 'tillganglighetsutlatande',
+                  uri: '/sv/tillganglighetsutlatande/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/accessibility-statement/',
+                      slug: 'accessibility-statement',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/saavutettavuusseloste/',
+                      slug: 'saavutettavuusseloste',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoyMDMz',
+              slug: 'accessibility-statement',
+              uri: '/en/accessibility-statement/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.En,
+                id: 'TGFuZ3VhZ2U6ZW4=',
+                slug: 'en',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDU0',
+          connectedNode: null,
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMTQw',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyMDI1',
+                  slug: 'kayttoehdot',
+                  uri: '/kayttoehdot/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Fi,
+                    id: 'TGFuZ3VhZ2U6Zmk=',
+                    slug: 'fi',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/terms-of-service/',
+                      slug: 'terms-of-service',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/anvandarvillkor/',
+                      slug: 'anvandarvillkor',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyMDI5',
+                  slug: 'anvandarvillkor',
+                  uri: '/sv/anvandarvillkor/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/terms-of-service/',
+                      slug: 'terms-of-service',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/kayttoehdot/',
+                      slug: 'kayttoehdot',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoyMDI3',
+              slug: 'terms-of-service',
+              uri: '/en/terms-of-service/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.En,
+                id: 'TGFuZ3VhZ2U6ZW4=',
+                slug: 'en',
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+export default menu;

--- a/src/tests/fixtures/menus/Palvelutarjotin-UI Footer (FI).ts
+++ b/src/tests/fixtures/menus/Palvelutarjotin-UI Footer (FI).ts
@@ -1,0 +1,222 @@
+import { LanguageCodeEnum } from './types';
+import type { MenuQuery } from './types';
+
+const menu: MenuQuery = {
+  menu: {
+    __typename: 'Menu',
+    id: 'dGVybToyMg==',
+    menuItems: {
+      __typename: 'MenuToMenuItemConnection',
+      nodes: [
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDM4',
+          connectedNode: null,
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDM5',
+          connectedNode: null,
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDQw',
+          connectedNode: null,
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDQx',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyMDMz',
+                  slug: 'accessibility-statement',
+                  uri: '/en/accessibility-statement/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/saavutettavuusseloste/',
+                      slug: 'saavutettavuusseloste',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/tillganglighetsutlatande/',
+                      slug: 'tillganglighetsutlatande',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyMDM1',
+                  slug: 'tillganglighetsutlatande',
+                  uri: '/sv/tillganglighetsutlatande/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/accessibility-statement/',
+                      slug: 'accessibility-statement',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/saavutettavuusseloste/',
+                      slug: 'saavutettavuusseloste',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoyMDMx',
+              slug: 'saavutettavuusseloste',
+              uri: '/saavutettavuusseloste/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Fi,
+                id: 'TGFuZ3VhZ2U6Zmk=',
+                slug: 'fi',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDQy',
+          connectedNode: null,
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMTE2',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyMDI3',
+                  slug: 'terms-of-service',
+                  uri: '/en/terms-of-service/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/kayttoehdot/',
+                      slug: 'kayttoehdot',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/anvandarvillkor/',
+                      slug: 'anvandarvillkor',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyMDI5',
+                  slug: 'anvandarvillkor',
+                  uri: '/sv/anvandarvillkor/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Sv,
+                    id: 'TGFuZ3VhZ2U6c3Y=',
+                    slug: 'sv',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/terms-of-service/',
+                      slug: 'terms-of-service',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/kayttoehdot/',
+                      slug: 'kayttoehdot',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoyMDI1',
+              slug: 'kayttoehdot',
+              uri: '/kayttoehdot/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Fi,
+                id: 'TGFuZ3VhZ2U6Zmk=',
+                slug: 'fi',
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+export default menu;

--- a/src/tests/fixtures/menus/Palvelutarjotin-UI Footer (SV).ts
+++ b/src/tests/fixtures/menus/Palvelutarjotin-UI Footer (SV).ts
@@ -1,0 +1,222 @@
+import { LanguageCodeEnum } from './types';
+import type { MenuQuery } from './types';
+
+const menu: MenuQuery = {
+  menu: {
+    __typename: 'Menu',
+    id: 'dGVybToyNzM=',
+    menuItems: {
+      __typename: 'MenuToMenuItemConnection',
+      nodes: [
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDY5',
+          connectedNode: null,
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDcw',
+          connectedNode: null,
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDcx',
+          connectedNode: null,
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDcy',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyMDMz',
+                  slug: 'accessibility-statement',
+                  uri: '/en/accessibility-statement/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/saavutettavuusseloste/',
+                      slug: 'saavutettavuusseloste',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/tillganglighetsutlatande/',
+                      slug: 'tillganglighetsutlatande',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyMDMx',
+                  slug: 'saavutettavuusseloste',
+                  uri: '/saavutettavuusseloste/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Fi,
+                    id: 'TGFuZ3VhZ2U6Zmk=',
+                    slug: 'fi',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/accessibility-statement/',
+                      slug: 'accessibility-statement',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/tillganglighetsutlatande/',
+                      slug: 'tillganglighetsutlatande',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoyMDM1',
+              slug: 'tillganglighetsutlatande',
+              uri: '/sv/tillganglighetsutlatande/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Sv,
+                id: 'TGFuZ3VhZ2U6c3Y=',
+                slug: 'sv',
+              },
+            },
+          },
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMDcz',
+          connectedNode: null,
+        },
+        {
+          __typename: 'MenuItem',
+          id: 'cG9zdDoyMTM3',
+          connectedNode: {
+            __typename: 'MenuItemToMenuItemLinkableConnectionEdge',
+            node: {
+              __typename: 'Page',
+              translations: [
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyMDI3',
+                  slug: 'terms-of-service',
+                  uri: '/en/terms-of-service/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.En,
+                    id: 'TGFuZ3VhZ2U6ZW4=',
+                    slug: 'en',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/kayttoehdot/',
+                      slug: 'kayttoehdot',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Fi,
+                        id: 'TGFuZ3VhZ2U6Zmk=',
+                        slug: 'fi',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/anvandarvillkor/',
+                      slug: 'anvandarvillkor',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+                {
+                  __typename: 'Page',
+                  id: 'cG9zdDoyMDI1',
+                  slug: 'kayttoehdot',
+                  uri: '/kayttoehdot/',
+                  language: {
+                    __typename: 'Language',
+                    code: LanguageCodeEnum.Fi,
+                    id: 'TGFuZ3VhZ2U6Zmk=',
+                    slug: 'fi',
+                  },
+                  translations: [
+                    {
+                      __typename: 'Page',
+                      uri: '/en/terms-of-service/',
+                      slug: 'terms-of-service',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.En,
+                        id: 'TGFuZ3VhZ2U6ZW4=',
+                        slug: 'en',
+                      },
+                    },
+                    {
+                      __typename: 'Page',
+                      uri: '/sv/anvandarvillkor/',
+                      slug: 'anvandarvillkor',
+                      language: {
+                        __typename: 'Language',
+                        code: LanguageCodeEnum.Sv,
+                        id: 'TGFuZ3VhZ2U6c3Y=',
+                        slug: 'sv',
+                      },
+                    },
+                  ],
+                },
+              ],
+              id: 'cG9zdDoyMDI5',
+              slug: 'anvandarvillkor',
+              uri: '/sv/anvandarvillkor/',
+              language: {
+                __typename: 'Language',
+                code: LanguageCodeEnum.Sv,
+                id: 'TGFuZ3VhZ2U6c3Y=',
+                slug: 'sv',
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+export default menu;

--- a/src/tests/fixtures/menus/README.md
+++ b/src/tests/fixtures/menus/README.md
@@ -1,0 +1,41 @@
+# Menu fixtures for testing
+
+Menus were read from production headless CMS with `menuIdentifiersOnly: false`,
+written to JSON files using field name filtering to reduce the amount of data,
+and wrapped with:
+```typescript
+import { LanguageCodeEnum } from './types';
+import type { MenuQuery } from './types';
+
+const menu: MenuQuery = {
+  <JSON data>
+};
+
+export default menu;
+```
+
+Also converted the enum values to make type checking pass:
+ - `code: "FI"` → `code: LanguageCodeEnum.Fi`
+ - `code: "EN"` → `code: LanguageCodeEnum.En`
+ - `code: "SV"` → `code: LanguageCodeEnum.Sv`
+
+## Field filtering
+
+The fields needed for testing were:
+ - "" (whole object)
+ - "0", "1", "2", ... (array indices as strings)
+ - "__typename"
+ - "code"
+ - "connectedNode"
+ - "id"
+ - "language"
+ - "menu"
+ - "menuItems"
+ - "node"
+ - "nodes"
+ - "slug"
+ - "translations"
+ - "uri"
+
+This can be easily used in a `replacer` function given to `JSON.stringify`
+so it only accepts these fields.

--- a/src/tests/fixtures/menus/types.ts
+++ b/src/tests/fixtures/menus/types.ts
@@ -1,0 +1,5 @@
+import { LanguageCodeEnum } from 'react-helsinki-headless-cms';
+import { MenuQuery } from 'react-helsinki-headless-cms/apollo';
+
+export { LanguageCodeEnum };
+export type { MenuQuery };


### PR DESCRIPTION
## Description :sparkles:

**NOTE**:
 - This will **only** fetch **CMS pages** that are in a **menu** in some language or that are a translation of a page that is in a menu

### fix: getAllMenuPages, footer CMS page links, remove obsolete menus

fixes:
 - getAllMenuPages was using an obsolete menu, changed it to use the
   new menus after HDS 3 upgrade in PR #304 i.e.
   commit c64b314d5b4bc2f4a95251c5cb158032b2f85dad in master branch
 - footer CMS page links were broken, fixed them to use the /cms-page/
 - getAllMenuPages wasn't fetching footer CMS pages at all, added them

also:
 - use AppConfig.cmsGraphqlEndpoint where applicable
 - fix name passed to getEnvOrError in AppConfig.cmsGraphqlEndpoint

refs PT-1723

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[PT-1723](https://helsinkisolutionoffice.atlassian.net/browse/PT-1723)

## Testing :alembic:

Footer is empty in review environment, probably a configuration issue.
You can try locally running the application to see the footer in action:
 - checkout the PR's branch
 - set `NEXT_PUBLIC_CMS_BASE_URL=https://kultus.content.api.hel.fi/graphql` in `.env.local` to use production CMS
 - yarn
 - `yarn dev` or try building it `yarn build` as that'll use the `getAllMenuPages`

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

### Saavutettavuusseloste -link in Footer
![image](https://github.com/City-of-Helsinki/palvelutarjotin-ui/assets/77663720/e2f9b7fe-361d-410f-859f-4abfd794ec8c)

### Käyttöehdot -link in Footer
![image](https://github.com/City-of-Helsinki/palvelutarjotin-ui/assets/77663720/4a8ab633-ece4-4182-93a3-29a3c2c838c6)

## Additional notes :spiral_notepad:

[PT-1723]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ