### PR TITLE
PT-1752 | Fix resolving internal URLs to known non-CMS pages e.g. /newsletter/

### DIFF
--- a/src/domain/app/footer/Footer.tsx
+++ b/src/domain/app/footer/Footer.tsx
@@ -7,11 +7,9 @@ import { useMenuQuery } from 'react-helsinki-headless-cms/apollo';
 import styles from './footer.module.scss';
 import { resetFocusId } from '../../../common/components/resetFocus/ResetFocus';
 import { DEFAULT_FOOTER_MENU_NAME } from '../../../constants';
+import { getRoutedInternalHrefForLocale } from '../../../headless-cms/utils';
 import useLocale from '../../../hooks/useLocale';
-import {
-  getIsHrefExternal,
-  getRoutedInternalHrefForLocale,
-} from '../../../pages/_app';
+import { getIsHrefExternal } from '../../../pages/_app';
 
 const FooterSection = (): React.ReactElement => {
   const { t } = useTranslation();

--- a/src/headless-cms/__tests__/utils.test.ts
+++ b/src/headless-cms/__tests__/utils.test.ts
@@ -19,6 +19,8 @@ import {
   removeTrailingSlash,
   slugsToUriSegments,
   uriToBreadcrumbs,
+  isInternalHrefCmsPage,
+  getRoutedInternalHrefForLocale,
 } from '../utils';
 
 describe('getUriID', () => {
@@ -220,5 +222,97 @@ describe('getAllMenuPages', () => {
     const pages = await getAllMenuPages();
     expect(pages).toHaveLength(allMockedMenuPages.length);
     expect(pages).toStrictEqual(allMockedMenuPages);
+  });
+});
+
+describe('getRoutedInternalHrefForLocale', () => {
+  test.each<{ locale: Language; link?: string | null; expected: string }>([
+    // English locale with CMS page
+    { locale: 'en', link: '/slug1', expected: '/en/cms-page/slug1' },
+    { locale: 'en', link: '/slug1/', expected: '/en/cms-page/slug1' },
+    { locale: 'en', link: '/en/slug1', expected: '/en/cms-page/slug1' },
+    { locale: 'en', link: '/fi/slug1', expected: '/en/cms-page/slug1' },
+    { locale: 'en', link: '/sv/slug1', expected: '/en/cms-page/slug1' },
+    { locale: 'en', link: '/en/slug1/', expected: '/en/cms-page/slug1' },
+    { locale: 'en', link: '/fi/slug1/', expected: '/en/cms-page/slug1' },
+    { locale: 'en', link: '/sv/slug1/', expected: '/en/cms-page/slug1' },
+    // Swedish locale with CMS page
+    { locale: 'sv', link: '/slug1', expected: '/sv/cms-page/slug1' },
+    { locale: 'sv', link: '/slug1/', expected: '/sv/cms-page/slug1' },
+    { locale: 'sv', link: '/en/slug1', expected: '/sv/cms-page/slug1' },
+    { locale: 'sv', link: '/fi/slug1', expected: '/sv/cms-page/slug1' },
+    { locale: 'sv', link: '/sv/slug1', expected: '/sv/cms-page/slug1' },
+    { locale: 'sv', link: '/en/slug1/', expected: '/sv/cms-page/slug1' },
+    { locale: 'sv', link: '/fi/slug1/', expected: '/sv/cms-page/slug1' },
+    { locale: 'sv', link: '/sv/slug1/', expected: '/sv/cms-page/slug1' },
+    // Finnish locale (special case) with CMS page
+    { locale: 'fi', link: '/slug1', expected: '/cms-page/slug1' },
+    { locale: 'fi', link: '/slug1/', expected: '/cms-page/slug1' },
+    { locale: 'fi', link: '/en/slug1', expected: '/cms-page/slug1' },
+    { locale: 'fi', link: '/fi/slug1', expected: '/cms-page/slug1' },
+    { locale: 'fi', link: '/sv/slug1', expected: '/cms-page/slug1' },
+    { locale: 'fi', link: '/en/slug1/', expected: '/cms-page/slug1' },
+    { locale: 'fi', link: '/fi/slug1/', expected: '/cms-page/slug1' },
+    { locale: 'fi', link: '/sv/slug1/', expected: '/cms-page/slug1' },
+    // English locale with known non-CMS pages
+    { locale: 'en', link: '/newsletter', expected: '/en/newsletter' },
+    { locale: 'en', link: '/newsletter/', expected: '/en/newsletter' },
+    { locale: 'en', link: '', expected: '/en' },
+    { locale: 'en', link: '/', expected: '/en' },
+    { locale: 'en', link: '/search', expected: '/en/search' },
+    { locale: 'en', link: '/search/', expected: '/en/search' },
+    // Swedish locale with known non-CMS pages
+    { locale: 'sv', link: '/newsletter', expected: '/sv/newsletter' },
+    { locale: 'sv', link: '/newsletter/', expected: '/sv/newsletter' },
+    { locale: 'sv', link: '', expected: '/sv' },
+    { locale: 'sv', link: '/', expected: '/sv' },
+    { locale: 'sv', link: '/search', expected: '/sv/search' },
+    { locale: 'sv', link: '/en/search/', expected: '/sv/search' },
+    // Finnish locale (special case) with known non-CMS pages
+    { locale: 'fi', link: '/en/newsletter/', expected: '/newsletter' },
+    { locale: 'fi', link: '/en/newsletter/', expected: '/newsletter' },
+    { locale: 'fi', link: '', expected: '/' },
+    { locale: 'fi', link: '/', expected: '/' },
+    { locale: 'fi', link: '/en/search', expected: '/search' },
+    { locale: 'fi', link: '/search/', expected: '/search' },
+  ])(
+    'getRoutedInternalHrefForLocale($locale, $link) returns $expected',
+    ({ locale, link, expected }) => {
+      expect(getRoutedInternalHrefForLocale(locale, link)).toBe(expected);
+    }
+  );
+});
+
+describe('isInternalHrefCmsPage', () => {
+  test.each<{ link?: string | null; expected: boolean }>([
+    { link: '/slug1', expected: true },
+    { link: '/slug1/', expected: true },
+    { link: '/en/slug1', expected: true },
+    { link: '/fi/slug1', expected: true },
+    { link: '/sv/slug1', expected: true },
+    { link: '/sv/slug1/', expected: true },
+    // /newsletter/ is not a CMS page
+    { link: '/newsletter', expected: false },
+    { link: '/newsletter/', expected: false },
+    { link: '/en/newsletter', expected: false },
+    { link: '/en/newsletter/', expected: false },
+    { link: '/fi/newsletter', expected: false },
+    { link: '/fi/newsletter/', expected: false },
+    { link: '/sv/newsletter', expected: false },
+    { link: '/sv/newsletter/', expected: false },
+    // /search/ is not a CMS page
+    { link: '/search', expected: false },
+    { link: '/search/', expected: false },
+    { link: '/en/search', expected: false },
+    { link: '/en/search/', expected: false },
+    { link: '/fi/search', expected: false },
+    { link: '/fi/search/', expected: false },
+    { link: '/sv/search', expected: false },
+    { link: '/sv/search/', expected: false },
+    // root is not a CMS page
+    { link: '', expected: false },
+    { link: '/', expected: false },
+  ])('isInternalHrefCmsPage($link) returns $expected', ({ link, expected }) => {
+    expect(isInternalHrefCmsPage(link)).toBe(expected);
   });
 });

--- a/src/headless-cms/utils.ts
+++ b/src/headless-cms/utils.ts
@@ -200,3 +200,28 @@ export function rewriteInternalURLs(
   }
   return JSON.parse(jsonText);
 }
+
+/** Known non-CMS pages without trailing slash. */
+const KNOWN_NON_CMS_PAGES = [
+  '', // root without slash
+  '/search',
+  '/newsletter',
+];
+
+export const isInternalHrefCmsPage = (link?: string | null) => {
+  const linkWithoutLocale = removeTrailingSlash(stripLocaleFromUri(link ?? ''));
+  return !KNOWN_NON_CMS_PAGES.includes(linkWithoutLocale);
+};
+
+export const getRoutedInternalHrefForLocale = (
+  locale: Language,
+  link?: string | null
+) => {
+  // menu nav items, not breadcrumb
+  const localePath = locale !== 'fi' ? `/${locale}` : '';
+  const linkWithoutLocale = stripLocaleFromUri(link ?? '');
+  const resolvedLink = isInternalHrefCmsPage(link)
+    ? getCmsPagePath(linkWithoutLocale)
+    : linkWithoutLocale;
+  return removeTrailingSlash(`${localePath}${resolvedLink}`).replace(/^$/, '/'); // "" -> "/"
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -28,9 +28,8 @@ import FocusToTop from '../FocusToTop';
 import { useCmsApollo } from '../headless-cms/cmsApolloClient';
 import CMSApolloProvider from '../headless-cms/cmsApolloContext';
 import AppConfig from '../headless-cms/config';
-import { stripLocaleFromUri } from '../headless-cms/utils';
+import { getRoutedInternalHrefForLocale } from '../headless-cms/utils';
 import useLocale from '../hooks/useLocale';
-import { Language } from '../types';
 import getLanguageCode from '../utils/getCurrentLanguageCode';
 import '../styles/globals.scss';
 
@@ -48,17 +47,6 @@ const internalHrefOrigins = [APP_DOMAIN, CMS_API_DOMAIN];
 export const getIsHrefExternal = (href: string) => {
   if (href?.startsWith('/')) return false;
   return !internalHrefOrigins.some((origin) => href?.includes(origin));
-};
-
-export const getRoutedInternalHrefForLocale = (
-  locale: Language,
-  link?: string | null
-) => {
-  // menu nav items, not breadcrumb
-  const localePath = locale !== 'fi' ? `/${locale}` : '';
-  return `${localePath}${getCmsPagePath(
-    stripLocaleFromUri(link ?? '')
-  )}`.replace(/\/$/, '');
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description :sparkles:

### fix: resolving internal URLs to known non-CMS pages e.g. /newsletter/

refs PT-1752

## Issues :bug:

### Closes :no_good_woman:

[PT-1752](https://helsinkisolutionoffice.atlassian.net/browse/PT-1752)

### Related :handshake:

## Testing :alembic:

Manually tested all footer links in PR's review environment using Finnish, Swedish and English.
All links worked except "Give feedback" but that's a CMS configuration issue, meaning
that the page pointed to by the URL given in the CMS doesn't exist anymore and should
be updated in the CMS.

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

![image](https://github.com/user-attachments/assets/9558ea43-49d6-4004-978a-66051cc9089a)

## Additional notes :spiral_notepad:


[PT-1752]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ