### PR TITLE
fix: use only the values of a persisted form state when initializing …

### DIFF
--- a/src/common/components/formikPersist/FormikPersist.tsx
+++ b/src/common/components/formikPersist/FormikPersist.tsx
@@ -55,7 +55,7 @@ const FormikPersist = ({
 
   const saveForm = React.useCallback(
     (data: FormikProps<Record<string, unknown>>) => {
-      debouncedSaveForm(data);
+      debouncedSaveForm({ ...data, errors: {} });
     },
     [debouncedSaveForm]
   );
@@ -67,9 +67,6 @@ const FormikPersist = ({
   }, [formik, saveForm]);
 
   React.useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let timeout: any;
-
     const storedFormikState = isSessionStorage
       ? window.sessionStorage.getItem(name)
       : window.localStorage.getItem(name);
@@ -81,14 +78,8 @@ const FormikPersist = ({
       storedFormikStateObject &&
       objectStructureMatches(initialValues, storedFormikStateObject.values)
     ) {
-      formik.setFormikState(JSON.parse(storedFormikState));
-
-      // Validate form after setting state
-      timeout = setTimeout(() => {
-        formik.validateForm();
-      });
+      formik.setValues(storedFormikStateObject.values, true);
     }
-    return () => clearTimeout(timeout);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 


### PR DESCRIPTION
…a form with FormikPersist

PT-1721.

The FormikPersist persists the whole Formik state to the local storage, so it included all the errors and dirtiness checks. When user opened the form again, if there were any errors in the persisted form state, the form also had all the validation errors visible. The validation errors replaces the helper texts. Instead of initializing the full form state with the persisted state, use only the persisted form values.

<img width="883" alt="image" src="https://github.com/user-attachments/assets/3354f044-7cd5-42d9-a8c5-9d62216af552">
