### PR TITLE
fix: group size field validation when no limits are set

### DIFF
--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -47,7 +47,7 @@ const EnrolmentForm: React.FC<Props> = ({
   submitting,
   onCloseForm,
   minGroupSize,
-  maxGroupSize = 20,
+  maxGroupSize,
   actionType = 'enrolment',
 }) => {
   const { t } = useTranslation();

--- a/src/domain/enrolment/enrolmentForm/ValidationSchema.tsx
+++ b/src/domain/enrolment/enrolmentForm/ValidationSchema.tsx
@@ -3,8 +3,8 @@ import * as Yup from 'yup';
 import { VALIDATION_MESSAGE_KEYS } from '../../app/forms/constants';
 
 type EnrolmentFormValidationSchemaProps = {
-  minGroupSize: number;
-  maxGroupSize: number;
+  minGroupSize?: number;
+  maxGroupSize?: number;
   isQueueEnrolment: boolean;
 };
 
@@ -55,10 +55,12 @@ export default function getValidationSchema({
           // The used validation error message will be the same for both the fields.
           // This is also preventing negative param.max to occur in validation.
           if (
-            !sizePair ||
-            sizePair < 0 ||
-            sizePair < minGroupSize ||
-            sizePair > maxGroupSize
+            minGroupSize &&
+            maxGroupSize &&
+            (!sizePair ||
+              sizePair < 0 ||
+              sizePair < minGroupSize ||
+              sizePair > maxGroupSize)
           ) {
             return (
               schema
@@ -78,13 +80,17 @@ export default function getValidationSchema({
             );
           }
 
-          // After the field pair is given, count how many seats are left
-          // and use that as max limit.
-          // The used validation error message will be unique for both the fields.
-          return schema.max(maxGroupSize - sizePair, (param) => ({
-            max: param.max,
-            key: fieldMaxLimitValidationMessage,
-          }));
+          if (maxGroupSize && sizePair) {
+            // After the field pair is given, count how many seats are left
+            // and use that as max limit.
+            // The used validation error message will be unique for both the fields.
+            return schema.max(maxGroupSize - sizePair, (param) => ({
+              max: param.max,
+              key: fieldMaxLimitValidationMessage,
+            }));
+          }
+
+          return schema;
         };
 
         return schema.shape(

--- a/src/domain/enrolment/enrolmentForm/__tests__/EnrolmentForm.test.tsx
+++ b/src/domain/enrolment/enrolmentForm/__tests__/EnrolmentForm.test.tsx
@@ -215,8 +215,8 @@ test('render and focuses error notification correctly', async () => {
 
 describe('max group size validation of the Children and Adults -fields', () => {
   const createEnrolmentForm = async (
-    childrenCount: string,
-    adultsCount: string,
+    childrenCount: string | undefined,
+    adultsCount: string | undefined,
     minGroupSize: number | undefined = 10,
     maxGroupSize: number | undefined = 20
   ) => {
@@ -328,6 +328,13 @@ describe('max group size validation of the Children and Adults -fields', () => {
           /Lasten ja aikuisten yhteislukumäärän tulee olla vähintään 1/i
         )
       ).toHaveLength(2);
+    });
+  });
+
+  test('The field is still required when the limits are unset', async () => {
+    await createEnrolmentForm(undefined, undefined, undefined, undefined);
+    await waitFor(() => {
+      expect(screen.getAllByText(/Tämä kenttä on pakollinen/i)).toHaveLength(2);
     });
   });
 });


### PR DESCRIPTION
PT-1772.

The group sizes can be left empty, especially when 1 group is set to fill the event. In those cases, the group size children and adult inputs should not validate themselves against the unset limits. The fields should only be required when the limits are not set.
<img width="884" alt="image" src="https://github.com/user-attachments/assets/38df0521-bb60-4399-86a0-c7debc2a2c84">
