### PR TITLE
fix: set CMS page search size to better fit on grid implementation

### DIFF
--- a/src/headless-cms/components/CmsPageSearch/CmsPageSearch.tsx
+++ b/src/headless-cms/components/CmsPageSearch/CmsPageSearch.tsx
@@ -25,7 +25,7 @@ import {
 import useDebounce from '../../../hooks/useDebounce';
 import { useCMSClient } from '../../cmsApolloContext';
 
-const BLOCK_SIZE = 10;
+const BLOCK_SIZE = 9;
 const SEARCH_DEBOUNCE_TIME = 500;
 
 const CmsPageSearch: React.FC<{


### PR DESCRIPTION
PT-1771.

Instead of fetching 10 items to a grid that has 3 columns, fetch 9 items, so they are equally balanced in the grid.

<img width="1180" alt="image" src="https://github.com/user-attachments/assets/7f856a13-6b31-43ae-9e53-cef4629efe79">

