### PR TITLE
PT-1792 | Fix development stage of Dockerfile & add volume mappings for docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ ENV NODE_ENV $NODE_ENV
 # copy in our source code last, as it changes the most
 COPY --chown=default:root . .
 
+RUN yarn install --immutable --inline-builds
+
 # Bake package.json start command into the image
 CMD ["yarn", "dev"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,15 @@
-version: '3.7'
-
 services:
   app:
     container_name: palvelutarjotin-ui
     build:
       context: .
       target: ${DOCKER_TARGET:-development}
+    volumes:
+      # Share local directory to enable development with hot reloading
+      - .:/app
+      # Prevent sharing the following directories between host and container
+      # to avoid ownership and/or platform issues:
+      - /app/node_modules
+      - /app/.next
     ports:
       - '${PORT}:${PORT}'


### PR DESCRIPTION
## Description :sparkles:

### fix: development stage of Dockerfile, add volume mappings for compose

now "docker compose up --build" spins up a development build locally,
hot reloading on Windows 11 + Docker Desktop didn't work, but that
may be Windows + WSL2 specific setup problem, see the following:
- https://github.com/vercel/next.js/issues/36774
- https://github.com/microsoft/WSL/issues/4739

also:
 - remove deprecated version number from docker-compose.yml

refs PT-1792

## Issues :bug:

### Closes :no_good_woman:

[PT-1792](https://helsinkisolutionoffice.atlassian.net/browse/PT-1792)

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[PT-1792]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ