### PR TITLE
build(docker): enable hot reload with watchpack for dev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,8 @@ FROM appbase AS development
 # Set NODE_ENV to development in the development container
 ARG NODE_ENV=development
 ENV NODE_ENV $NODE_ENV
+# enable hot reload
+ENV WATCHPACK_POLLING=true
 
 # copy in our source code last, as it changes the most
 COPY --chown=default:root . .


### PR DESCRIPTION
PT-1792.

Ref. https://github.com/vercel/next.js/issues/36774
