### PR TITLE
PT-1792 | Fix hot reload in docker development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,15 @@ FROM appbase AS development
 ARG NODE_ENV=development
 ENV NODE_ENV $NODE_ENV
 
+# Enable hot reload by default by polling for file changes.
+#
+# NOTE: Can be disabled by setting WATCHPACK_POLLING=false in file `.env`
+#       if hot reload works on your system without polling to save CPU time.
+ARG WATCHPACK_POLLING=true
+ENV WATCHPACK_POLLING=${WATCHPACK_POLLING}
+
+WORKDIR /app
+
 # copy in our source code last, as it changes the most
 COPY --chown=default:root . .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: .
       target: ${DOCKER_TARGET:-development}
+    environment:
+      - WATCHPACK_POLLING=${WATCHPACK_POLLING:-true}
     volumes:
       # Share local directory to enable development with hot reloading
       - .:/app

--- a/next.config.js
+++ b/next.config.js
@@ -92,6 +92,13 @@ module.exports = {
       };
     }
 
+    // https://webpack.js.org/configuration/watch/#watchoptions
+    config.watchOptions = {
+      poll: 1000, // Check for changes every second
+      aggregateTimeout: 300, // Delay 0.3s before rebuilding to group changes
+      ignored: ['**/node_modules'],
+    };
+
     config.resolve.alias = {
       ...config.resolve.alias,
       '~hds-core': path.resolve(__dirname, './node_modules/hds-core'),


### PR DESCRIPTION
## Description :sparkles:

### fix: hot reload in docker development by using polling & correct workdir

WATCHPACK_POLLING is enabled by default to use file change polling so
hot reload works more easily out-of-the-box

Tested and hot reload worked on Windows 11 + Docker Desktop + WSL2
using "docker compose up --build" and keeping the source code on the
host's NTFS file system, not inside the Linux file system in WSL2.

refs PT-1792

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

- [PT-1792](https://helsinkisolutionoffice.atlassian.net/browse/PT-1792)
- PR #341 

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[PT-1792]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ