### PR TITLE
test: add an option to run Testcafe test with chromium

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:staged": "cross-env SASS_PATH=./src/assets/styles jest --findRelatedTests",
     "ci": "jest --verbose --coverage --runInBand",
     "browser-test": "testcafe \"chrome --window-size='1920,1080'\" testcafe/e2e/ --live --dev",
-    "browser-test:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" --screenshots takeOnFails=true,path=report,fullPage=true --video report testcafe/e2e/"
+    "browser-test:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" --screenshots takeOnFails=true,path=report,fullPage=true --video report testcafe/e2e/",
+    "browser-test:ci:chromium": "testcafe \"chromium:headless --disable-gpu --window-size='1920,1080'\" --screenshots takeOnFails=true,path=report,fullPage=true --video report testcafe/e2e/"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
Requirement: https://dev.azure.com/City-of-Helsinki/kultus/_git/kultus-pipelines/pullrequest/9959.

Add an option to run Testcafe browser tests with Chromium instead of Chrome. There have been some issues with the Chrome that prevents using it in CI environment:

- https://github.com/DevExpress/testcafe/issues/8286
- https://github.com/DevExpress/testcafe/issues/8300
- https://github.com/DevExpress/testcafe/issues/8304
- https://github.com/DevExpress/testcafe/issues/8307
