### PR TITLE
feat: skip build static generation with env-variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 PORT=3000
+SKIP_BUILD_STATIC_GENERATION=1
 NEXT_PUBLIC_CAPTCHA_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 NEXT_PUBLIC_API_BASE_URL=https://kultus.api.test.hel.ninja/graphql
 NEXT_PUBLIC_UNIFIED_SEARCH_BASE_URL=https://kuva-unified-search.api.test.hel.ninja/search

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ FROM appbase AS staticbuilder
 # ===================================
 # Set environmental variables (when building image on GitLab CI) 
 # specified in gitlab-ci.yml file  
+ARG SKIP_BUILD_STATIC_GENERATION
 ARG NEXT_PUBLIC_APP_ORIGIN
 ARG NEXT_PUBLIC_API_BASE_URL
 ARG NEXT_PUBLIC_UNIFIED_SEARCH_BASE_URL

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "cross-env SASS_PATH=./src/assets/styles jest --watch",
     "test:changed": "jest -o",
     "test:coverage": "jest --watchAll=false --coverage",
-    "test:staged": "cross-env SASS_PATH=./src/assets/styles jest --findRelatedTests",
+    "test:staged": "cross-env SASS_PATH=./src/assets/styles jest --findRelatedTests --passWithNoTests",
     "ci": "jest --verbose --coverage --runInBand",
     "browser-test": "testcafe \"chrome --window-size='1920,1080'\" testcafe/e2e/ --live --dev",
     "browser-test:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" --screenshots takeOnFails=true,path=report,fullPage=true --video report testcafe/e2e/",

--- a/src/pages/cms-page/[...slug].tsx
+++ b/src/pages/cms-page/[...slug].tsx
@@ -51,6 +51,13 @@ const NextCmsPage: NextPage<{
 }> = (props) => <DynamicCmsPageWithNoSSR {...props} />;
 
 export async function getStaticPaths() {
+  if (process.env.SKIP_BUILD_STATIC_GENERATION) {
+    return {
+      paths: [],
+      fallback: 'blocking',
+    };
+  }
+
   const pages = await getAllMenuPages();
 
   if (isFeatureEnabled('HEADLESS_CMS') && pages?.length) {


### PR DESCRIPTION
PT-1837.

Use `SKIP_BUILD_STATIC_GENERATION=1` to skip static page generation.
