### PR TITLE
fix(style): white-space wrapping in enrolment form and event details

### DIFF
--- a/src/domain/enrolment/enrolmentForm/enrolmentForm.module.scss
+++ b/src/domain/enrolment/enrolmentForm/enrolmentForm.module.scss
@@ -2,7 +2,8 @@
 
 .enrolmentForm {
   padding: var(--spacing-layout-s) var(--spacing-layout-xs);
-
+  white-space: normal;
+  
   .rowWith2Columns {
     display: grid;
 

--- a/src/domain/event/occurrences/occurrences.module.scss
+++ b/src/domain/event/occurrences/occurrences.module.scss
@@ -5,6 +5,7 @@
   --date-filter-width: 160px;
   --inactive-date-filter-color: lightgrey;
 
+  white-space: normal;
   margin-top: var(--spacing-m);
 
   .occurrencesTitle {
@@ -99,6 +100,7 @@
   .infoSection {
     display: grid;
     grid-template-columns: auto 1fr;
+    white-space: normal;
 
     p {
       margin: 0;


### PR DESCRIPTION
PT-1840

Fixes the place description and enrolment form heading lining

<img width="909" alt="image" src="https://github.com/user-attachments/assets/89a501ab-f43e-494f-b4b2-047349975650" />

<img width="796" alt="image" src="https://github.com/user-attachments/assets/8b7d979b-81d7-4cb8-bea5-aa0c3a3dda53" />
