### PR TITLE
fix: cms rewriting rule

### DIFF
--- a/src/headless-cms/config.ts
+++ b/src/headless-cms/config.ts
@@ -42,13 +42,13 @@ class AppConfig {
    * - https://kultus.content.api.hel.fi/fi/something/
    *
    * Examples that are invalid:
-   * - https://kultus.content.api.hel.fi/fi/app/images
-   * - https://kultus.content.api.hel.fi/sv/app/pictures
-   * - https://kultus.content.api.hel.fi/en/app/files
+   * - https://kultus.content.api.hel.fi/app/images
+   * - https://kultus.content.api.hel.fi/app/pictures
+   * - https://kultus.content.api.hel.fi/app/files
    */
   static get URLRewriteMapping() {
     return {
-      [`${AppConfig.cmsOrigin}[/fi|/en|/sv]*${AppConfig.cmsPagesContextPath}((?!app)[^/])*$`]:
+      [`${AppConfig.cmsOrigin}[/fi|/en|/sv]*${AppConfig.cmsPagesContextPath}(?!app/)`]:
         '/cms-page/',
     };
   }


### PR DESCRIPTION
PT-1840.

The images were fixed with last commit related to this, but then the sublinks, etc inside the page are not working. The rule was too strict, when it was first too loose -- Now it should be fixed.
