### PR TITLE
fix: rehydration issue in event cards keywords and enrolment statuses

### DIFF
--- a/src/common/components/keyword/EnrolmentStatusKeyword.tsx
+++ b/src/common/components/keyword/EnrolmentStatusKeyword.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from 'next-i18next';
 
 import Keyword, { KeywordProps } from './Keyword';
 

--- a/src/common/components/keyword/KeywordsList.tsx
+++ b/src/common/components/keyword/KeywordsList.tsx
@@ -23,12 +23,14 @@ type KeywordsListProps = {
   keywords: KeywordFieldsFragment[];
   itemType?: 'button' | 'link';
   enrolmentStatus?: EnrolmentStatusKeywordPropsType['enrolmentStatus'];
+  identifier: string;
 };
 
 const KeywordsList: React.FC<KeywordsListProps> = ({
   keywords,
   itemType = 'link',
   enrolmentStatus,
+  identifier,
 }) => {
   const locale = useLocale();
   const { t } = useTranslation();
@@ -36,12 +38,14 @@ const KeywordsList: React.FC<KeywordsListProps> = ({
   const keywordsPropArr = getKeywordsProps(keywords, keywordOptions, locale);
 
   return (
-    <ul className={styles.keywordsList}>
+    <ul className={styles.keywordsList} key={`keywordlist-${identifier}`}>
       {enrolmentStatus && (
-        <EnrolmentStatusKeyword enrolmentStatus={enrolmentStatus} />
+        <li key={`enrolmentStatusKeyword-${identifier}`}>
+          <EnrolmentStatusKeyword enrolmentStatus={enrolmentStatus} />
+        </li>
       )}
       {keywordsPropArr.map((k, i) => (
-        <li key={`${i}-${k.id}`}>
+        <li key={`keyword-${identifier}${i}-${k.id}`}>
           <Keyword
             href={{ pathname: ROUTES.EVENTS_SEARCH, query: k.query }}
             keyword={k.label}

--- a/src/common/components/keyword/__tests__/KeywordsList.test.tsx
+++ b/src/common/components/keyword/__tests__/KeywordsList.test.tsx
@@ -106,6 +106,7 @@ const mocks: MockedResponse[] = [
 it('renders list of keywords as links with correct hrefs', async () => {
   const { container } = render(
     <KeywordsList
+      identifier="test-identifier"
       keywords={[
         ...categoryKeywords,
         ...targetGroupKeywords,

--- a/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
+++ b/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
@@ -71,7 +71,7 @@ const EventBasicInfo: React.FC<EventBasicInfoProps> = ({ event }) => {
           text={description}
           className={styles.description}
         />
-        {keywords && <KeywordsList keywords={keywords} />}
+        {keywords && <KeywordsList identifier={event.id} keywords={keywords} />}
         <EventCategorisation event={event} />
       </div>
       <div className={styles.infoRight}>

--- a/src/domain/event/eventCard/EventCard.tsx
+++ b/src/domain/event/eventCard/EventCard.tsx
@@ -66,6 +66,7 @@ const EventCard: React.FC<Props> = ({ event, link }) => {
             keywords={keywords}
             itemType="button"
             enrolmentStatus={enrolmentStatus}
+            identifier={event.id}
           />
         </div>
       </a>


### PR DESCRIPTION
PT-1844.

The actual rehydration issue came from the useTranslation hook, which was not imported from the next-i18next, but from the react-i18next. Because of that, the result some how differed between the renders (from SSR and client).

The EnrolmentStatusKeyword was also rendered without LI-element, even then when it was rendered inside an UL-element. That is invalid against HTML standard.

Also, some key-attributes are now added with some uniqueID prefixes, because otherwise React struggled to identify the unique keyword items. This could have been an issue during rerenders. It was warned in the console.
