### PR TITLE
PT-1864 | Remove inexistent kuva-frontend team from dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,5 @@ updates:
     # Disable version updates and only allow security updates
     open-pull-requests-limit: 0
     reviewers:
-      - "City-of-Helsinki/kuva-frontend"
       - "City-of-Helsinki/kuva-developers"
       - "City-of-Helsinki/ratkaisutoimiston-frontend"


### PR DESCRIPTION
## Description :sparkles:

Remove inexistent kuva-frontend team from dependabot reviewers

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[PT-1864](https://helsinkisolutionoffice.atlassian.net/browse/PT-1864)

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

https://github.com/orgs/City-of-Helsinki/teams/kuva-frontend does not exist,
https://github.com/orgs/City-of-Helsinki/teams/kuva-front does exist but is not up to date

[PT-1864]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ