### PR TITLE
Fix notification query client usage

### DIFF
--- a/src/domain/app/header/HeaderNotification.tsx
+++ b/src/domain/app/header/HeaderNotification.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../generated/graphql-cms';
 import useLocale from '../../../hooks/useLocale';
 import hash from '../../../utils/hash';
+import { useCMSApolloClient } from '../../headless-cms/apollo/apolloClient';
 
 export const NOTIFICATION_STORAGE_KEY = 'header-notification';
 
@@ -41,8 +42,10 @@ const HeaderNotification: React.FC = () => {
       closedNotificationHash: null,
     });
   const { isVisible, closedNotificationHash } = notificationState ?? {};
+  const cmsApolloClient = useCMSApolloClient();
 
   const { data } = useNotificationQuery({
+    client: cmsApolloClient,
     variables: {
       language: locale ?? 'fi',
     },

--- a/src/domain/app/layout/__tests__/PageLayout.test.tsx
+++ b/src/domain/app/layout/__tests__/PageLayout.test.tsx
@@ -1,7 +1,6 @@
-import { MockedResponse } from '@apollo/client/testing';
 import React from 'react';
 
-import { NotificationDocument } from '../../../../generated/graphql-cms';
+import * as GraphQLCms from '../../../../generated/graphql-cms';
 import { emptyMenuQueryMocks } from '../../../../tests/apollo-mocks/menuMocks';
 import { fakeNotification } from '../../../../utils/cmsMockDataUtils';
 import {
@@ -13,54 +12,53 @@ import {
 } from '../../../../utils/testUtils';
 import PageLayout from '../PageLayout';
 
+jest.mock('../../../../generated/graphql-cms', () => ({
+  esModule: true,
+  ...jest.requireActual<Record<string, unknown>>(
+    '../../../../generated/graphql-cms'
+  ),
+  useNotificationQuery: jest.fn(),
+}));
+
 const notificationContent = 'Notification content';
 const notificationTitle = 'Notification title';
 
-const createMocks = (
-  notificationTitle: string,
-  notificationContent: string
-): MockedResponse[] => [
-  ...emptyMenuQueryMocks,
-  {
-    request: {
-      query: NotificationDocument,
-      variables: {
-        language: 'fi',
-      },
-    },
-    result: {
-      data: {
-        notification: fakeNotification({
-          title: notificationTitle,
-          content: notificationContent,
-        }),
-      },
-    },
-  },
-];
-
-const mocksWithNonEmptyNotification = createMocks(
-  notificationTitle,
-  `<p>${notificationContent}</p>`
-);
-const mocksWithEmptyNotification = createMocks('', '');
-
 it('PageLayout matches snapshot', () => {
+  const notificationMock = {
+    notification: fakeNotification({
+      title: '',
+      content: '',
+    }),
+  };
+  jest.spyOn(GraphQLCms, 'useNotificationQuery').mockReturnValue({
+    data: { ...notificationMock },
+    loading: false,
+  } as any);
   const { container } = render(
     <PageLayout>
       <div>Page layout children</div>
     </PageLayout>,
-    { mocks: mocksWithNonEmptyNotification }
+    { mocks: [...emptyMenuQueryMocks] }
   );
   expect(container.firstChild).toMatchSnapshot();
 });
 
 it('renders notification and it can be closed', async () => {
+  const notificationMock = {
+    notification: fakeNotification({
+      title: notificationTitle,
+      content: `<p>${notificationContent}</p>`,
+    }),
+  };
+  jest.spyOn(GraphQLCms, 'useNotificationQuery').mockReturnValue({
+    data: { ...notificationMock },
+    loading: false,
+  } as any);
   render(
     <PageLayout>
       <div>Page layout children</div>
     </PageLayout>,
-    { mocks: mocksWithNonEmptyNotification }
+    { mocks: [...emptyMenuQueryMocks] }
   );
 
   const notification = await screen.findByRole('region', {
@@ -85,11 +83,21 @@ it('renders notification and it can be closed', async () => {
 });
 
 it("doesn't render notification when there are none", async () => {
+  const notificationMock = {
+    notification: fakeNotification({
+      title: '',
+      content: '',
+    }),
+  };
+  jest.spyOn(GraphQLCms, 'useNotificationQuery').mockReturnValue({
+    data: { ...notificationMock },
+    loading: false,
+  } as any);
   render(
     <PageLayout>
       <div>Page layout children</div>
     </PageLayout>,
-    { mocks: mocksWithEmptyNotification }
+    { mocks: [...emptyMenuQueryMocks] }
   );
 
   await waitFor(() => {

--- a/src/tests/msw/server-handlers.ts
+++ b/src/tests/msw/server-handlers.ts
@@ -28,15 +28,16 @@ const handlers: Parameters<typeof setupServer> = [
     );
   }),
   graphql.query('Notification', (req, res, ctx) => {
+    const notification: Notification = {
+      __typename: 'Notification',
+      title: 'MSW mock for notification',
+      content: 'Content of MSW notification mock',
+      level: 'info',
+      linkUrl: '#',
+    };
     return res(
       ctx.data({
-        notification: {
-          __typename: 'Notification',
-          title: 'moi',
-          content: 'm0i',
-          level: 'info',
-          linkUrl: '#',
-        } as Notification,
+        notification,
       })
     );
   }),


### PR DESCRIPTION
PT-1795.

There was an issue in CMS notification query, because it was using a
wrong Apollo Client. It was using the one meant not for Headless CMS but
for Kultus API.