### PR TITLE
feat(csp): middleware implementation for CSP

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
@@ -11,9 +12,9 @@ const requestType = {
 };
 
 /**
- * Enforce prefix for default locale 'fi'
- * https://github.com/vercel/next.js/discussions/18419
- * @param req
+ * Enforces a prefix for the default locale 'fi'.
+ * Redirects requests with the 'default' locale to the same URL with the default language prefix.
+ * @see {@link https://github.com/vercel/next.js/discussions/18419}
  */
 const prefixDefaultLocale = async (req: NextRequest) => {
   const { pathname, search } = req.nextUrl;
@@ -26,13 +27,95 @@ const prefixDefaultLocale = async (req: NextRequest) => {
   }
 };
 
+/**
+ * Generates a Content Security Policy (CSP) header string with a nonce.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const generateCSPHeader = (nonce: string) => {
+  return `
+    default-src 'self';
+    script-src 'self' ${
+      process.env.NODE_ENV === 'development' ? "'unsafe-eval'" : ''
+    } https://m.youtube.com https://www.youtube.com https://webanalytics.digiaiiris.com *.google.com *.gstatic.com;
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' data: *.hel.fi *.hel.ninja *.ytimg.com *.youtube.com *.vimeo.com *.vimeocdn.com *.blob.core.windows.net *.hkih.hion.dev;
+    font-src 'self' *.hel.fi *.hel.ninja;
+    connect-src 'self' localhost:* 127.0.0.1:* *.hel.fi *.hel.ninja *.hkih.hion.dev *.digiaiiris.com;
+    object-src 'none';
+    media-src 'self' *.hel.fi *.hel.ninja *.hkih.hion.dev;
+    manifest-src 'self';
+    base-uri 'self';
+    form-action 'self';
+    frame-src 'self' *.hel.fi *.hel.ninja *.youtube.com www.youtube-nocookie.com *.vimeo.com *.google.com;
+    frame-ancestors 'none';
+    worker-src    'self';
+    block-all-mixed-content;
+    upgrade-insecure-requests;
+`;
+};
+
+/**
+ * Generates and sets the CSP header and x-nonce header for the request.
+ */
+const getCSPHeader = (request: NextRequest) => {
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+  requestHeaders.set(
+    'Content-Security-Policy',
+    // Replace newline characters and spaces
+    generateCSPHeader(nonce)
+      .replace(/\s{2,}/g, ' ')
+      .trim()
+  );
+  return requestHeaders;
+};
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    {
+      source: '/((?!api|_next/static|_next/image|favicon.ico).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+};
+
+/**
+ * Middleware function to handle requests.
+ */
 export async function middleware(req: NextRequest) {
   if (
     requestType.isStaticFile(req) ||
     requestType.isPagesFolderApi(req) ||
     requestType.isPublicFile(req)
   ) {
-    return;
+    return; // Early return for excluded requests
   }
-  return prefixDefaultLocale(req);
+
+  // Handle default locale redirection.
+  const prefixRedirectResponse = await prefixDefaultLocale(req);
+  if (prefixRedirectResponse) {
+    return prefixRedirectResponse; // Early return if redirection occurs
+  }
+
+  // Apply CSP headers to the request.
+  const requestHeaders = getCSPHeader(req);
+
+  // Pass the modified request to the next handler.
+  return NextResponse.next({
+    headers: requestHeaders,
+    request: {
+      headers: requestHeaders,
+    },
+  });
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -49,18 +49,23 @@ class MyDocument extends NextJsDocument<Props> {
       (hds as any).hdsStyles
     );
 
-    return { ...initialProps, hdsCriticalRules };
+    const nonce = ctx.res?.getHeader('x-nonce');
+
+    return { ...initialProps, hdsCriticalRules, nonce };
   }
   render(): React.ReactElement {
+    const { nonce } = this.props as unknown as { nonce?: string };
     return (
-      <Html lang={documentLang(this.props)}>
-        <Head>
+      <Html lang={documentLang(this.props)} nonce={nonce}>
+        <Head nonce={nonce}>
           <style
             data-used-styles
             dangerouslySetInnerHTML={{ __html: this.props.hdsCriticalRules }}
+            nonce={nonce}
           />
           <script
             src={`https://www.google.com/recaptcha/api.js?render=${process.env.NEXT_PUBLIC_CAPTCHA_KEY}`}
+            nonce={nonce}
           />
         </Head>
         <body>


### PR DESCRIPTION
PT-1874 PT-1893.

To support usage of nonces, a middleware must be used. Reference:
https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy.

However, it seems like the nonces are not usable when using ISR, because the static page generator cannot have a request specific nonce.
