### PR TITLE
Fix event details back button scroll restoration

### DIFF
--- a/src/domain/event/BackButton.tsx
+++ b/src/domain/event/BackButton.tsx
@@ -1,0 +1,21 @@
+import { IconArrowLeft } from 'hds-react';
+import NextLink from 'next/link';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+
+import { createBackButtonHref } from './utils';
+
+// Dedicated Back Button Component
+export const BackButton: React.FC = () => {
+  const { t } = useTranslation();
+  const { asPath } = useRouter();
+  const [, search] = asPath.split('?');
+  const href = createBackButtonHref(search);
+
+  return (
+    <NextLink href={href} aria-label={t('common:buttonBack')}>
+      <IconArrowLeft size="m" />
+    </NextLink>
+  );
+};

--- a/src/domain/event/BackFromEventDetailsButton.tsx
+++ b/src/domain/event/BackFromEventDetailsButton.tsx
@@ -5,18 +5,30 @@ import { useTranslation } from 'next-i18next';
 import React from 'react';
 
 import { createBackButtonHref } from './utils';
+import { SCROLL_RESTORATION_ELEMENT_ID_PREFIX } from '../events/constants';
 
 /**
  * Back to event search from the event details page.
  */
 export default function BackFromEventDetailsButton() {
   const { t } = useTranslation();
-  const { asPath } = useRouter();
-  const [, search] = asPath.split('?');
-  const href = createBackButtonHref(search);
+  const {
+    asPath,
+    query: { eventId },
+  } = useRouter();
+  const [, currentSearch] = asPath.split('?');
+  const { pathname, search } = createBackButtonHref(currentSearch);
+  const hash = `#${SCROLL_RESTORATION_ELEMENT_ID_PREFIX}${eventId}`;
 
+  const href = pathname + (search ? `?${search}` : '') + hash;
+  // Disable back button scroll, because we have our own custom implementation
+  // to fix issues in nextjs: see
+  // 1. https://github.com/vercel/next.js/issues/68746
+  // 2. https://github.com/vercel/next.js/issues/3303
+  // 3. https://github.com/vercel/next.js/discussions/44013
+  const scroll = false;
   return (
-    <NextLink href={href} aria-label={t('common:buttonBack')}>
+    <NextLink href={href} aria-label={t('common:buttonBack')} scroll={scroll}>
       <IconArrowLeft size="m" />
     </NextLink>
   );

--- a/src/domain/event/BackFromEventDetailsButton.tsx
+++ b/src/domain/event/BackFromEventDetailsButton.tsx
@@ -6,8 +6,10 @@ import React from 'react';
 
 import { createBackButtonHref } from './utils';
 
-// Dedicated Back Button Component
-export const BackButton: React.FC = () => {
+/**
+ * Back to event search from the event details page.
+ */
+export default function BackFromEventDetailsButton() {
   const { t } = useTranslation();
   const { asPath } = useRouter();
   const [, search] = asPath.split('?');
@@ -18,4 +20,4 @@ export const BackButton: React.FC = () => {
       <IconArrowLeft size="m" />
     </NextLink>
   );
-};
+}

--- a/src/domain/event/EnrolmentFormContainer.tsx
+++ b/src/domain/event/EnrolmentFormContainer.tsx
@@ -1,0 +1,77 @@
+import classNames from 'classnames';
+import { Notification, Button, IconAngleUp } from 'hds-react';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+
+import styles from './eventPage.module.scss';
+import EnrolmentFormSection from './occurrences/EnrolmentFormSection';
+import {
+  EventFieldsFragment,
+  OccurrenceFieldsFragment,
+} from '../../generated/graphql';
+
+export const EnrolmentFormContainer: React.FC<{
+  neededOccurrences?: number;
+  showEnrolmentForm: boolean;
+  selectedOccurrences: string[];
+  setShowEnrolmentForm: (a: boolean) => void;
+  event: EventFieldsFragment;
+  occurrences?: OccurrenceFieldsFragment[];
+  handleOnEnrol: () => void;
+}> = ({
+  neededOccurrences,
+  showEnrolmentForm,
+  selectedOccurrences,
+  setShowEnrolmentForm,
+  event,
+  occurrences,
+  handleOnEnrol,
+}) => {
+  const { t } = useTranslation();
+  const enrolmentFormRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    enrolmentFormRef.current?.scrollIntoView?.({ behavior: 'smooth' });
+  }, [showEnrolmentForm]);
+
+  return (
+    <div className={styles.enrolmentFormContainer}>
+      {showEnrolmentForm &&
+        selectedOccurrences.length !== neededOccurrences && (
+          <Notification
+            style={{ marginTop: 'var(--spacing-xl)' }}
+            label={t('enrolment:enrolmentForm.labelChooseRequiredOccurrences', {
+              amount: neededOccurrences,
+            })}
+            type="alert"
+          >
+            {t('enrolment:enrolmentForm.descriptionChooseRequiredOccurrences')}
+          </Notification>
+        )}
+      <div
+        className={classNames(styles.enrolmentFormSection, {
+          [styles.hideEnrolmentForm]:
+            selectedOccurrences.length !== neededOccurrences,
+        })}
+        ref={enrolmentFormRef}
+      >
+        <Button
+          className={styles.cancelEnrolmentButton}
+          variant="supplementary"
+          iconRight={<IconAngleUp />}
+          onClick={() => setShowEnrolmentForm(false)}
+        >
+          {t('enrolment:enrolmentForm.buttonCancelAndCloseForm')}
+        </Button>
+        <EnrolmentFormSection
+          event={event}
+          occurrences={
+            occurrences?.filter((o) => selectedOccurrences.includes(o.id)) ?? []
+          }
+          onCloseForm={() => setShowEnrolmentForm(false)}
+          onEnrol={handleOnEnrol}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/domain/event/EventHero.tsx
+++ b/src/domain/event/EventHero.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 
-import { BackButton } from './BackButton';
+import BackFromEventDetailsButton from './BackFromEventDetailsButton';
 import EventImage from './eventImage/EventImage';
 import styles from './eventPage.module.scss';
 import Container from '../app/layout/Container';
@@ -16,7 +16,7 @@ export const EventHero: React.FC<{
   return (
     <div className={styles.eventHero}>
       <Container className={styles.backButtonContainer}>
-        <BackButton />
+        <BackFromEventDetailsButton />
       </Container>
       <EventImage
         imageUrl={imageUrl}

--- a/src/domain/event/EventHero.tsx
+++ b/src/domain/event/EventHero.tsx
@@ -1,0 +1,45 @@
+import { IconArrowLeft } from 'hds-react';
+import NextLink from 'next/link';
+import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+
+import EventImage from './eventImage/EventImage';
+import styles from './eventPage.module.scss';
+import { createBackButtonHref } from './utils';
+import Container from '../app/layout/Container';
+
+// Dedicated Back Button Component
+const BackButton: React.FC = () => {
+  const { t } = useTranslation();
+  const { asPath } = useRouter();
+  const [, search] = asPath.split('?');
+  const href = createBackButtonHref(search);
+
+  return (
+    <NextLink href={href} aria-label={t('common:buttonBack')} scroll={true}>
+      <IconArrowLeft size="m" />
+    </NextLink>
+  );
+};
+
+export const EventHero: React.FC<{
+  imageUrl?: string;
+  imageAltText?: string | null;
+  photographerName?: string | null;
+}> = ({ imageAltText, imageUrl, photographerName }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.eventHero}>
+      <Container className={styles.backButtonContainer}>
+        <BackButton />
+      </Container>
+      <EventImage
+        imageUrl={imageUrl}
+        imageAltText={imageAltText || t('event:eventImageAltText')}
+        photographerName={photographerName}
+      />
+    </div>
+  );
+};

--- a/src/domain/event/EventHero.tsx
+++ b/src/domain/event/EventHero.tsx
@@ -1,27 +1,10 @@
-import { IconArrowLeft } from 'hds-react';
-import NextLink from 'next/link';
-import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
 
+import { BackButton } from './BackButton';
 import EventImage from './eventImage/EventImage';
 import styles from './eventPage.module.scss';
-import { createBackButtonHref } from './utils';
 import Container from '../app/layout/Container';
-
-// Dedicated Back Button Component
-const BackButton: React.FC = () => {
-  const { t } = useTranslation();
-  const { asPath } = useRouter();
-  const [, search] = asPath.split('?');
-  const href = createBackButtonHref(search);
-
-  return (
-    <NextLink href={href} aria-label={t('common:buttonBack')} scroll={true}>
-      <IconArrowLeft size="m" />
-    </NextLink>
-  );
-};
 
 export const EventHero: React.FC<{
   imageUrl?: string;

--- a/src/domain/event/EventPage.tsx
+++ b/src/domain/event/EventPage.tsx
@@ -1,30 +1,22 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
-import classNames from 'classnames';
-import { Notification, IconArrowLeft, Button, IconAngleUp } from 'hds-react';
-import NextLink from 'next/link';
+import { Notification } from 'hds-react';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React, { ReactElement } from 'react';
 
 import EnrolmentButton from './enrolmentButton/EnrolmentButton';
+import { EnrolmentFormContainer } from './EnrolmentFormContainer';
 import EventBasicInfo from './eventBasicInfo/EventBasicInfo';
-import EventImage from './eventImage/EventImage';
+import { EventHero } from './EventHero';
 import styles from './eventPage.module.scss';
 import EventPageMeta from './eventPageMeta/EventPageMeta';
-import EnrolmentFormSection from './occurrences/EnrolmentFormSection';
 import Occurrences from './occurrences/OccurrencesTable';
-import QueueFormSection from './occurrences/QueueFormSection';
+import { QueueFormContainer } from './QueryFormContainer';
 import { getEventFields, shouldEventSupportQueueEnrolments } from './utils';
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
 import ShareLinks from '../../common/components/shareLinks/ShareLinks';
-import {
-  EventFieldsFragment,
-  OccurrenceFieldsFragment,
-  useEventQuery,
-} from '../../generated/graphql';
+import { useEventQuery } from '../../generated/graphql';
 import useLocale from '../../hooks/useLocale';
 import type { I18nNamespace } from '../../types';
-import { extractLatestReturnPath } from '../../utils/extractLatestReturnPath';
 import { translateValue } from '../../utils/translateUtils';
 import Container from '../app/layout/Container';
 import PageWrapper from '../app/layout/PageWrapper';
@@ -214,155 +206,6 @@ const EventPage = (): ReactElement => {
         )}
       </LoadingSpinner>
     </PageWrapper>
-  );
-};
-
-const EventHero: React.FC<{
-  imageUrl?: string;
-  imageAltText?: string | null;
-  photographerName?: string | null;
-}> = ({ imageAltText, imageUrl, photographerName }) => {
-  const { t } = useTranslation<I18nNamespace>();
-  const { asPath } = useRouter();
-  const [, search] = asPath.split('?');
-  const { returnPath, remainingQueryString } = extractLatestReturnPath(search);
-
-  return (
-    <div className={styles.eventHero}>
-      <Container className={styles.backButtonContainer}>
-        <NextLink
-          legacyBehavior
-          href={{ pathname: returnPath, search: remainingQueryString }}
-        >
-          <a aria-label={t('common:buttonBack')}>
-            <IconArrowLeft size="m" />
-          </a>
-        </NextLink>
-      </Container>
-      <EventImage
-        imageUrl={imageUrl}
-        imageAltText={imageAltText || t('event:eventImageAltText')}
-        photographerName={photographerName}
-      />
-    </div>
-  );
-};
-
-const EnrolmentFormContainer: React.FC<{
-  neededOccurrences?: number;
-  showEnrolmentForm: boolean;
-  selectedOccurrences: string[];
-  setShowEnrolmentForm: (a: boolean) => void;
-  event: EventFieldsFragment;
-  occurrences?: OccurrenceFieldsFragment[];
-  handleOnEnrol: () => void;
-}> = ({
-  neededOccurrences,
-  showEnrolmentForm,
-  selectedOccurrences,
-  setShowEnrolmentForm,
-  event,
-  occurrences,
-  handleOnEnrol,
-}) => {
-  const { t } = useTranslation<I18nNamespace>();
-  const enrolmentFormRef = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    enrolmentFormRef.current?.scrollIntoView?.({ behavior: 'smooth' });
-  }, [showEnrolmentForm]);
-
-  return (
-    <div className={styles.enrolmentFormContainer}>
-      {showEnrolmentForm &&
-        selectedOccurrences.length !== neededOccurrences && (
-          <Notification
-            style={{ marginTop: 'var(--spacing-xl)' }}
-            label={t('enrolment:enrolmentForm.labelChooseRequiredOccurrences', {
-              amount: neededOccurrences,
-            })}
-            type="alert"
-          >
-            {t('enrolment:enrolmentForm.descriptionChooseRequiredOccurrences')}
-          </Notification>
-        )}
-      <div
-        className={classNames(styles.enrolmentFormSection, {
-          [styles.hideEnrolmentForm]:
-            selectedOccurrences.length !== neededOccurrences,
-        })}
-        ref={enrolmentFormRef}
-      >
-        <Button
-          className={styles.cancelEnrolmentButton}
-          variant="supplementary"
-          iconRight={<IconAngleUp />}
-          onClick={() => setShowEnrolmentForm(false)}
-        >
-          {t('enrolment:enrolmentForm.buttonCancelAndCloseForm')}
-        </Button>
-        <EnrolmentFormSection
-          event={event}
-          occurrences={
-            occurrences?.filter((o) => selectedOccurrences.includes(o.id)) ?? []
-          }
-          onCloseForm={() => setShowEnrolmentForm(false)}
-          onEnrol={handleOnEnrol}
-        />
-      </div>
-    </div>
-  );
-};
-
-const QueueFormContainer: React.FC<{
-  showQueueForm: boolean;
-  setShowQueueForm: (a: boolean) => void;
-  event: EventFieldsFragment;
-  handleOnQueue: () => void;
-}> = ({ showQueueForm, setShowQueueForm, event, handleOnQueue }) => {
-  const { t } = useTranslation<I18nNamespace>();
-  const queueFormRef = React.useRef<HTMLDivElement>(null);
-
-  React.useEffect(() => {
-    queueFormRef.current?.scrollIntoView?.({ behavior: 'smooth' });
-  }, [showQueueForm]);
-
-  return (
-    <>
-      <h2 className={styles.enrolmentHeader}>{t('enrolment:queue.title')}</h2>
-      {showQueueForm ? (
-        <div className={styles.enrolmentFormContainer}>
-          <div className={styles.enrolmentFormSection} ref={queueFormRef}>
-            <div className={styles.closeQueueFormButtonWrapper}>
-              <div className={styles.enrolmentText}>
-                {t('enrolment:queue.enrolText')}
-              </div>
-              <Button
-                variant="supplementary"
-                iconRight={<IconAngleUp />}
-                onClick={() => setShowQueueForm(false)}
-              >
-                {t('enrolment:enrolmentForm.buttonCancelAndCloseForm')}
-              </Button>
-            </div>
-            <QueueFormSection
-              event={event}
-              onCloseForm={() => setShowQueueForm(false)}
-              onQueue={handleOnQueue}
-            />
-          </div>
-        </div>
-      ) : (
-        <div className={styles.queueInfoContainer}>
-          <div className={styles.enrolmentText}>
-            {t('enrolment:queue.enrolText')}
-          </div>
-          <Button onClick={() => setShowQueueForm(true)}>
-            {t('enrolment:queue.enrol')}
-          </Button>
-        </div>
-      )}
-    </>
   );
 };
 

--- a/src/domain/event/QueryFormContainer.tsx
+++ b/src/domain/event/QueryFormContainer.tsx
@@ -1,0 +1,59 @@
+import { Button, IconAngleUp } from 'hds-react';
+import { useTranslation } from 'next-i18next';
+import React from 'react';
+
+import styles from './eventPage.module.scss';
+import QueueFormSection from './occurrences/QueueFormSection';
+import { EventFieldsFragment } from '../../generated/graphql';
+
+export const QueueFormContainer: React.FC<{
+  showQueueForm: boolean;
+  setShowQueueForm: (a: boolean) => void;
+  event: EventFieldsFragment;
+  handleOnQueue: () => void;
+}> = ({ showQueueForm, setShowQueueForm, event, handleOnQueue }) => {
+  const { t } = useTranslation();
+  const queueFormRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    queueFormRef.current?.scrollIntoView?.({ behavior: 'smooth' });
+  }, [showQueueForm]);
+
+  return (
+    <>
+      <h2 className={styles.enrolmentHeader}>{t('enrolment:queue.title')}</h2>
+      {showQueueForm ? (
+        <div className={styles.enrolmentFormContainer}>
+          <div className={styles.enrolmentFormSection} ref={queueFormRef}>
+            <div className={styles.closeQueueFormButtonWrapper}>
+              <div className={styles.enrolmentText}>
+                {t('enrolment:queue.enrolText')}
+              </div>
+              <Button
+                variant="supplementary"
+                iconRight={<IconAngleUp />}
+                onClick={() => setShowQueueForm(false)}
+              >
+                {t('enrolment:enrolmentForm.buttonCancelAndCloseForm')}
+              </Button>
+            </div>
+            <QueueFormSection
+              event={event}
+              onCloseForm={() => setShowQueueForm(false)}
+              onQueue={handleOnQueue}
+            />
+          </div>
+        </div>
+      ) : (
+        <div className={styles.queueInfoContainer}>
+          <div className={styles.enrolmentText}>
+            {t('enrolment:queue.enrolText')}
+          </div>
+          <Button onClick={() => setShowQueueForm(true)}>
+            {t('enrolment:queue.enrol')}
+          </Button>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -963,7 +963,10 @@ describe('back button', () => {
     const backLink = screen.getByRole('link', {
       name: /takaisin/i,
     });
-    expect(backLink).toHaveAttribute('href', '/search?text=rock');
+    expect(backLink).toHaveAttribute(
+      'href',
+      `/search?text=rock#event-card:${eventData.id}`
+    );
   });
 
   it('back button renders href correctly returnPath to front page', async () => {
@@ -977,7 +980,7 @@ describe('back button', () => {
     const backLink = screen.getByRole('link', {
       name: /takaisin/i,
     });
-    expect(backLink).toHaveAttribute('href', '/');
+    expect(backLink).toHaveAttribute('href', `/#event-card:${eventData.id}`);
   });
 });
 

--- a/src/domain/event/eventCard/EventCard.tsx
+++ b/src/domain/event/eventCard/EventCard.tsx
@@ -36,10 +36,9 @@ const EventCard: React.FC<Props> = ({ event, link }) => {
   const keywords = [...event.keywords, ...event.audience];
   const enrolmentStatus = getEventEnrolmentStatus(event);
   const { t } = useTranslation();
-
+  const elementId = `event-card:${id}`;
   return (
     <NextLink
-      key={`event-card-${id}`}
       href={link}
       scroll
       aria-label={t('event:eventCard.ariaLabelOpenEvent', {
@@ -48,6 +47,7 @@ const EventCard: React.FC<Props> = ({ event, link }) => {
       className={styles.eventCard}
     >
       <div
+        id={elementId}
         className={styles.imageWrapper}
         style={{
           backgroundImage: `url(${

--- a/src/domain/event/eventCard/EventCard.tsx
+++ b/src/domain/event/eventCard/EventCard.tsx
@@ -16,6 +16,7 @@ import useLocale from '../../../hooks/useLocale';
 import IconClock from '../../../icons/IconClock';
 import type { I18nNamespace } from '../../../types';
 import getLocalisedString from '../../../utils/getLocalisedString';
+import { SCROLL_RESTORATION_ELEMENT_ID_PREFIX } from '../../events/constants';
 import PlaceText from '../../place/placeText/PlaceText';
 import { getEventPlaceholderImage } from '../utils';
 
@@ -36,7 +37,7 @@ const EventCard: React.FC<Props> = ({ event, link }) => {
   const keywords = [...event.keywords, ...event.audience];
   const enrolmentStatus = getEventEnrolmentStatus(event);
   const { t } = useTranslation();
-  const elementId = `event-card:${id}`;
+  const elementId = `${SCROLL_RESTORATION_ELEMENT_ID_PREFIX}${id}`;
   return (
     <NextLink
       href={link}

--- a/src/domain/event/eventCard/EventCard.tsx
+++ b/src/domain/event/eventCard/EventCard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
 import { Button, IconLocation } from 'hds-react';
 import times from 'lodash/times';
 import NextLink from 'next/link';
@@ -36,41 +35,42 @@ const EventCard: React.FC<Props> = ({ event, link }) => {
   const image = event.images[0]?.url;
   const keywords = [...event.keywords, ...event.audience];
   const enrolmentStatus = getEventEnrolmentStatus(event);
+  const { t } = useTranslation();
 
   return (
-    <NextLink legacyBehavior href={link}>
-      <a
-        className={styles.eventCard}
-        // TODO: should we use this? maybe not, the screen reader might not read everything
-        // aria-label={t('event:eventCard.ariaLabelOpenEvent', {
-        //   eventName: name,
-        // })}
-      >
-        <div
-          className={styles.imageWrapper}
-          style={{
-            backgroundImage: `url(${
-              image || getEventPlaceholderImage(id || '')
-            })`,
-          }}
-        ></div>
-        <div className={styles.contentWrapper}>
-          <div className={styles.titleWrapper}>
-            <div className={styles.title}>{name}</div>
-            <div className={styles.description}>{shortDescription}</div>
-          </div>
-          <div className={styles.occurrenceInfoWrapper}>
-            <EventTime event={event} />
-            <EventPlaceInfo event={event} />
-          </div>
-          <KeywordsList
-            keywords={keywords}
-            itemType="button"
-            enrolmentStatus={enrolmentStatus}
-            identifier={event.id}
-          />
+    <NextLink
+      key={`event-card-${id}`}
+      href={link}
+      scroll
+      aria-label={t('event:eventCard.ariaLabelOpenEvent', {
+        eventName: name,
+      })}
+      className={styles.eventCard}
+    >
+      <div
+        className={styles.imageWrapper}
+        style={{
+          backgroundImage: `url(${
+            image || getEventPlaceholderImage(id || '')
+          })`,
+        }}
+      ></div>
+      <div className={styles.contentWrapper}>
+        <div className={styles.titleWrapper}>
+          <div className={styles.title}>{name}</div>
+          <div className={styles.description}>{shortDescription}</div>
         </div>
-      </a>
+        <div className={styles.occurrenceInfoWrapper}>
+          <EventTime event={event} />
+          <EventPlaceInfo event={event} />
+        </div>
+        <KeywordsList
+          keywords={keywords}
+          itemType="button"
+          enrolmentStatus={enrolmentStatus}
+          identifier={event.id}
+        />
+      </div>
     </NextLink>
   );
 };

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -15,6 +15,7 @@ import {
   PEventFieldsFragment,
 } from '../../generated/graphql';
 import { Language } from '../../types';
+import { extractLatestReturnPath } from '../../utils/extractLatestReturnPath';
 import getLocalisedString from '../../utils/getLocalisedString';
 import { formatIntoTime, formatLocalizedDate } from '../../utils/time/format';
 import { isEnrolmentStarted } from '../occurrence/utils';
@@ -187,4 +188,23 @@ export const shouldEventSupportQueueEnrolments = (
     hasEnrolmentStarted &&
     hasOccurrences
   );
+};
+
+// Helper function to extract return path and query string
+const extractReturnPathAndQuery = (search: string | undefined) => {
+  if (!search) {
+    return { returnPath: '/', remainingQueryString: undefined };
+  }
+  const { returnPath, remainingQueryString } = extractLatestReturnPath(search);
+  return { returnPath, remainingQueryString };
+};
+
+// Helper function to create the href object for NextLink
+export const createBackButtonHref = (search: string | undefined) => {
+  const { returnPath, remainingQueryString } =
+    extractReturnPathAndQuery(search);
+  return {
+    pathname: returnPath,
+    search: remainingQueryString,
+  };
 };

--- a/src/domain/events/EventsPage.tsx
+++ b/src/domain/events/EventsPage.tsx
@@ -10,6 +10,7 @@ import EventSearchForm, {
 } from './eventSearchForm/EventSearchForm';
 import styles from './eventsPage.module.scss';
 import { PopularKeywords } from './PopularKeywords';
+import useHashlessReturnPathScrollFix from './useHashlessReturnPathScrollFix';
 import { useUpcomingEvents } from './useUpcomingEvents';
 import { getSearchQueryObject } from './utils';
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
@@ -64,6 +65,8 @@ const EventsPage = (): ReactElement => {
       include: ['keywords', 'location', 'audience', 'in_language'],
     },
   });
+
+  useHashlessReturnPathScrollFix();
 
   const search = (values: EventSearchFormValues) => {
     values = { ...values, organisation: values.organisationId };

--- a/src/domain/events/EventsSearchPage.tsx
+++ b/src/domain/events/EventsSearchPage.tsx
@@ -12,6 +12,7 @@ import EventSearchForm, {
   PanelState,
 } from './eventSearchForm/EventSearchForm';
 import styles from './eventsSearchPage.module.scss';
+import useHashlessReturnPathScrollFix from './useHashlessReturnPathScrollFix';
 import {
   getEventFilterVariables,
   getInitialValues,
@@ -77,30 +78,7 @@ const EventsSearchPage: React.FC = () => {
     setSearchPanelState(getPanelStateFromQuery(router.query));
   }, [router.query]);
 
-  React.useEffect(() => {
-    const [, hash] = router.asPath.split('#');
-    if (router && hash) {
-      // eslint-disable-next-line no-console
-      console.info(
-        'URL contains hash which will now be removed with a shallow router.replace'
-      );
-      router
-        .replace(
-          {
-            hash: undefined,
-          },
-          undefined,
-          { shallow: true }
-        )
-        .catch((e) => {
-          // workaround for https://github.com/vercel/next.js/issues/37362
-          if (!e.cancelled) {
-            throw e;
-          }
-        });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  useHashlessReturnPathScrollFix();
 
   return (
     <PageWrapper title={t('events:eventsSearchPage.title')}>

--- a/src/domain/events/EventsSearchPage.tsx
+++ b/src/domain/events/EventsSearchPage.tsx
@@ -77,6 +77,31 @@ const EventsSearchPage: React.FC = () => {
     setSearchPanelState(getPanelStateFromQuery(router.query));
   }, [router.query]);
 
+  React.useEffect(() => {
+    const [, hash] = router.asPath.split('#');
+    if (router && hash) {
+      // eslint-disable-next-line no-console
+      console.info(
+        'URL contains hash which will now be removed with a shallow router.replace'
+      );
+      router
+        .replace(
+          {
+            hash: undefined,
+          },
+          undefined,
+          { shallow: true }
+        )
+        .catch((e) => {
+          // workaround for https://github.com/vercel/next.js/issues/37362
+          if (!e.cancelled) {
+            throw e;
+          }
+        });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <PageWrapper title={t('events:eventsSearchPage.title')}>
       <div className={styles.searchFormContainer}>

--- a/src/domain/events/__tests__/EventCard.test.tsx
+++ b/src/domain/events/__tests__/EventCard.test.tsx
@@ -170,6 +170,8 @@ describe('EventCard', () => {
         },
       ]);
       const event = fakeEvent({
+        id: 'palvelutarjotin:a0775a20-468a-437b-91ee-f7a9cabea321',
+        internalId: 'palvelutarjotin:a0775a20-468a-437b-91ee-f7a9cabea321',
         name: fakeLocalizedObject('Nimi'),
         shortDescription: fakeLocalizedObject('Kuvaus'),
         keywords: [

--- a/src/domain/events/__tests__/__snapshots__/EventCard.test.tsx.snap
+++ b/src/domain/events/__tests__/__snapshots__/EventCard.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`EventCard List of occurrences renders multiday occurrence time correctl
   >
     <div
       class="imageWrapper"
+      id="event-card:palvelutarjotin:a0775a20-468a-437b-91ee-f7a9cabea321"
       style="background-image: url(https://api.hel.fi/linkedevents-test/media/images/test.png);"
     />
     <div

--- a/src/domain/events/__tests__/__snapshots__/EventCard.test.tsx.snap
+++ b/src/domain/events/__tests__/__snapshots__/EventCard.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`EventCard List of occurrences renders multiday occurrence time correctly 1`] = `
 <div>
   <a
+    aria-label="Siirry tapahtumaan: Nimi"
     class="eventCard"
     href="/#"
   >

--- a/src/domain/events/__tests__/useHashlessReturnPathScrollFix.test.tsx
+++ b/src/domain/events/__tests__/useHashlessReturnPathScrollFix.test.tsx
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react';
+import { useRouter } from 'next/router';
+
+import useHashlessReturnPathScrollFix from '../useHashlessReturnPathScrollFix';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('useHashlessReturnPathScrollFix', () => {
+  const mockedRouter = {
+    asPath: '',
+    pathname: '/test',
+    query: {},
+    replace: jest.fn().mockResolvedValue(true),
+  };
+
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue(mockedRouter);
+    mockedRouter.replace.mockClear();
+    mockedRouter.asPath = '';
+  });
+
+  it('should not call router.replace if there is no hash', () => {
+    renderHook(() => useHashlessReturnPathScrollFix());
+    expect(mockedRouter.replace).not.toHaveBeenCalled();
+  });
+
+  it('should call router.replace with correct parameters if there is a hash', async () => {
+    mockedRouter.asPath = '/test#hash';
+    renderHook(() => useHashlessReturnPathScrollFix());
+    expect(mockedRouter.replace).toHaveBeenCalledWith(
+      {
+        pathname: '/test',
+        query: {},
+        hash: undefined,
+      },
+      undefined,
+      { shallow: true }
+    );
+  });
+
+  it('should catch and not rethrow cancelled errors', async () => {
+    mockedRouter.asPath = '/test#hash';
+    const error = { cancelled: true };
+    mockedRouter.replace.mockRejectedValue(error);
+    renderHook(() => useHashlessReturnPathScrollFix());
+    await expect(mockedRouter.replace()).rejects.toEqual(error);
+  });
+});

--- a/src/domain/events/constants.ts
+++ b/src/domain/events/constants.ts
@@ -15,3 +15,4 @@ export const EVENT_TOP_CATEGORIES = ['yso:p26626'];
 
 export const VIRTUAL_EVENT_LOCATION_ID = 'helsinki:internet';
 export const BOOKABLE_TO_SCHOOL_LOCATION_ID = 'helsinki:bookable';
+export const SCROLL_RESTORATION_ELEMENT_ID_PREFIX = 'event-card:';

--- a/src/domain/events/eventList/EventList.tsx
+++ b/src/domain/events/eventList/EventList.tsx
@@ -37,10 +37,9 @@ const EventList = ({
   showCount = true,
 }: Props): ReactElement => {
   const { asPath } = useRouter();
-
   const [pathname, search] = asPath.split('?');
   const queryString = addParamsToQueryString(search, {
-    returnPath: pathname,
+    returnPath: pathname.split('#')[0],
   });
 
   const { t } = useTranslation<I18nNamespace>();

--- a/src/domain/events/useHashlessReturnPathScrollFix.tsx
+++ b/src/domain/events/useHashlessReturnPathScrollFix.tsx
@@ -1,0 +1,52 @@
+import { useRouter } from 'next/router';
+import React from 'react';
+
+/**
+ * Custom React hook to manually fix scroll restoration and returnPath issues when a URL contains a hash.
+ * The URL hash is needed for scroll restoration (e.g. when navigating back to event search page).
+ * However, since the UI uses returnPath-parameter in the URL to initialize a back arrow -button in UI,
+ * the hash is needed to be removed in order to get that feature to work.
+ *
+ * Next.js automatically scrolls to the element specified by the hash in the URL.
+ * This hook removes the hash from the URL using a shallow router replace.
+ *
+ * This is a workaround for potential issues where Next.js's built-in scroll restoration interferes with
+ * custom scroll handling.
+ *
+ * @remarks
+ * - This hook relies on the `next/router` module.
+ * - It performs a shallow router replace, which means it updates the URL without triggering a full page reload.
+ * - It logs a console message when a hash is detected and removed.
+ * - Includes a workaround for a known Next.js router issue (https://github.com/vercel/next.js/issues/37362)
+ * to prevent uncaught promise rejections.
+ * - This hook should be used within a React functional component.
+ */
+function useHashlessReturnPathScrollFix() {
+  const router = useRouter();
+  React.useEffect(() => {
+    const [, hash] = router.asPath.split('#');
+    if (router && hash) {
+      // eslint-disable-next-line no-console
+      console.info(
+        'URL contains hash which will now be removed with a shallow router.replace'
+      );
+      router
+        .replace(
+          {
+            hash: undefined,
+          },
+          undefined,
+          { shallow: true }
+        )
+        .catch((e) => {
+          // workaround for https://github.com/vercel/next.js/issues/37362
+          if (!e.cancelled) {
+            throw e;
+          }
+        });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+export default useHashlessReturnPathScrollFix;

--- a/src/domain/events/useHashlessReturnPathScrollFix.tsx
+++ b/src/domain/events/useHashlessReturnPathScrollFix.tsx
@@ -33,6 +33,8 @@ function useHashlessReturnPathScrollFix() {
       router
         .replace(
           {
+            pathname: router.pathname,
+            query: router.query,
             hash: undefined,
           },
           undefined,

--- a/src/utils/queryString.ts
+++ b/src/utils/queryString.ts
@@ -35,7 +35,9 @@ export const addParamsToQueryString = (
   queryString: string,
   queryParams: QueryParams
 ): string => {
-  const searchParams = new URLSearchParams(queryString);
+  const [query, hash] = queryString?.split('#') ?? [queryString, undefined];
+
+  const searchParams = new URLSearchParams(query);
   Object.entries(queryParams).forEach(([key, values]) => {
     const param = key as QueryParam;
     if (Array.isArray(values)) {
@@ -46,5 +48,5 @@ export const addParamsToQueryString = (
       searchParams.append(param, getParamValue({ param, value: values }));
     }
   });
-  return '?' + searchParams.toString();
+  return '?' + searchParams.toString() + (hash ? `#${hash}` : '');
 };


### PR DESCRIPTION
PT-1886.

Steps to test:
1. Search an event
2. Click an event card to navigate to event details page
3. Use browser back button or back arrow -button in UI to navigate back to search page
Result: The serach results should be auto loaded (with Apollo cache) and user should be taken to the clicked card.