### PR TITLE
fix: all dates and times should always be fixed to Helsinki's timezone

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
+// Fix the timezone to avoid issues with date/time tests
+process.env.TZ = 'Europe/Helsinki';
+
 module.exports = {
   testEnvironment: 'jest-fixed-jsdom',
   transform: {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.13.5",
+    "@date-fns/tz": "^1.2.0",
     "@jonkoops/matomo-tracker-react": "^0.7.0",
     "@reduxjs/toolkit": "^2.6.1",
     "@sentry/browser": "^9.10.1",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -73,3 +73,10 @@ export const DEFAULT_HEADER_MENU_NAME: Record<SUPPORTED_LANGUAGES, string> = {
 };
 
 export const TOAST_AUTO_CLOSE_DURATION_MS = 10_000;
+
+// Check recommended formats: https://hds.hel.fi/guidelines/data-formats
+
+export const DATE_FORMAT = 'd.M.yyyy';
+export const TIME_FORMAT = 'HH:mm';
+export const DATETIME_FORMAT = `${DATE_FORMAT} ${TIME_FORMAT}`;
+export const TIMEZONE = 'Europe/Helsinki';

--- a/src/domain/enrolment/occurrenceTable/OccurrenceTable.tsx
+++ b/src/domain/enrolment/occurrenceTable/OccurrenceTable.tsx
@@ -3,11 +3,12 @@ import { useTranslation } from 'next-i18next';
 import React from 'react';
 
 import Table from '../../../common/components/table/Table';
+import { DATE_FORMAT } from '../../../constants';
 import { OccurrenceFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import type { I18nNamespace } from '../../../types';
 import formatTimeRange from '../../../utils/formatTimeRange';
-import { DATE_FORMAT, formatLocalizedDate } from '../../../utils/time/format';
+import { formatLocalizedDate } from '../../../utils/time/format';
 import { getAmountOfSeatsLeft } from '../../occurrence/utils';
 import PlaceText from '../../place/placeText/PlaceText';
 

--- a/src/domain/event/occurrences/OccurrenceInfo.tsx
+++ b/src/domain/event/occurrences/OccurrenceInfo.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import EnrolmentFormSection from './EnrolmentFormSection';
 import OccurrenceEnrolmentButton from './OccurrenceEnrolmentButton';
 import styles from './occurrences.module.scss';
+import { DATE_FORMAT } from '../../../constants';
 import {
   OccurrenceFieldsFragment,
   EventFieldsFragment,
@@ -21,7 +22,6 @@ import {
   formatIntoDate,
   formatIntoTime,
   formatLocalizedDate,
-  DATE_FORMAT,
 } from '../../../utils/time/format';
 import OccurrenceGroupInfo from '../../occurrence/occurrenceGroupInfo/OccurrenceGroupInfo';
 import OccurrenceGroupLanguageInfo from '../../occurrence/occurrenceGroupInfo/OccurrenceGroupLanguageInfo';

--- a/src/domain/event/occurrences/OccurrencesTable.tsx
+++ b/src/domain/event/occurrences/OccurrencesTable.tsx
@@ -16,6 +16,7 @@ import { useDateFiltering } from './useDateFiltering';
 import { getEnrolmentError, getOrderedLanguages } from './utils';
 import SrOnly from '../../../common/components/SrOnly/SrOnly';
 import Table from '../../../common/components/table/Table';
+import { DATE_FORMAT } from '../../../constants';
 import {
   EventFieldsFragment,
   OccurrenceFieldsFragment,
@@ -24,7 +25,6 @@ import useLocale from '../../../hooks/useLocale';
 import type { I18nNamespace } from '../../../types';
 import formatTimeRange from '../../../utils/formatTimeRange';
 import {
-  DATE_FORMAT,
   formatDateRange,
   formatIntoDate,
   formatIntoTime,

--- a/src/utils/__tests__/dateUtils.test.ts
+++ b/src/utils/__tests__/dateUtils.test.ts
@@ -1,4 +1,4 @@
-import { convertFinnishDateStrToDate, formatDate } from '../dateUtils';
+import { formatDate } from '../dateUtils';
 
 describe('formatDate function', () => {
   it('format date value', () => {
@@ -11,19 +11,5 @@ describe('formatDate function', () => {
     ).toBe('8.11.2019 12:27');
 
     expect(formatDate(500000000000)).toBe('5.11.1985');
-  });
-});
-
-describe('convertFinnishDateStrToDate function', () => {
-  it('covert string to date', () => {
-    expect(convertFinnishDateStrToDate('')).toBe(null);
-
-    expect(convertFinnishDateStrToDate('12.12.2019')).toStrictEqual(
-      new Date(Date.UTC(2019, 11, 11, 22))
-    );
-
-    expect(convertFinnishDateStrToDate('12122019')).toStrictEqual(
-      new Date(Date.UTC(2019, 11, 11, 22))
-    );
   });
 });

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,18 +1,13 @@
-import {
-  isAfter,
-  isBefore,
-  isSameDay,
-  isValid,
-  parse,
-  format as formatDateStr,
-} from 'date-fns';
+import { TZDate } from '@date-fns/tz';
+import { isAfter, isBefore, isSameDay, format } from 'date-fns';
 import { enGB as en, fi } from 'date-fns/locale';
 import get from 'lodash/get';
 
+import { DATE_FORMAT, TIMEZONE } from '../constants';
 import sv from './date-fns/locale/sv';
-import { DATE_FORMAT } from './time/format';
 
-const locales = { en, fi, sv };
+export const locales = { en, fi, sv };
+
 /**
  * Format date string
  * @param date
@@ -21,70 +16,16 @@ const locales = { en, fi, sv };
  */
 export const formatDate = (
   date: Date | null | number,
-  format = DATE_FORMAT,
+  dateFormat = DATE_FORMAT,
   locale = 'fi'
 ): string => {
   if (!date) {
     return '';
   }
 
-  return formatDateStr(date, format, {
+  return format(new TZDate(new Date(date), TIMEZONE), dateFormat, {
     locale: get(locales, locale),
   }).trim();
-};
-
-/**
- * Test is date valid
- * @param date
- * @returns {boolean}
- */
-const isValidDate = (date: Date): boolean =>
-  isValid(date) && isAfter(date, new Date('1000-01-01'));
-
-/**
- * Test is entered string a date string in Finnish format without dots (e.g. 31122019)
- * @param str
- * @returns {boolean}
- */
-const isShortDateStr = (str: string) =>
-  str.length === 8 && /^[0-9.]+$/.test(str);
-
-/**
- * Convert date string without dots to Finnish date string format (e.g. 31.12.2019)
- * @param str
- * @returns {object}
- */
-const getShortDateStr = (str: string): string =>
-  [str.substring(0, 2), str.substring(2, 4), str.substring(4, 9)].join('.');
-
-/**
- * Get date object from valid Finnish date string
- * @param value
- * @returns {object}
- */
-const getParsedDate = (value: string): Date =>
-  parse(value, DATE_FORMAT, new Date(), { locale: fi });
-
-/**
- * Convert string in Finnish date format (e.g. 31.12.2019) or in format without dots (e.g. 31122019) to Date object
- * @returns {object}
- * @param str
- */
-export const convertFinnishDateStrToDate = (str: string): Date | null => {
-  let parsedDate = getParsedDate(str);
-
-  if (isValidDate(parsedDate)) {
-    return parsedDate;
-  } else if (isShortDateStr(str)) {
-    const dateStr = getShortDateStr(str);
-
-    parsedDate = getParsedDate(dateStr);
-
-    if (isValidDate(parsedDate)) {
-      return parsedDate;
-    }
-  }
-  return null;
 };
 
 export const isSameDayOrAfter = (date: Date, compareDate: Date): boolean => {

--- a/src/utils/time/format.ts
+++ b/src/utils/time/format.ts
@@ -1,33 +1,53 @@
+import { tz } from '@date-fns/tz';
 import { format as formatDateStr } from 'date-fns';
-import { enGB as en, fi } from 'date-fns/locale';
 
+import {
+  DATE_FORMAT,
+  DATETIME_FORMAT,
+  TIME_FORMAT,
+  TIMEZONE,
+} from '../../constants';
 import { Language } from '../../types';
-import sv from '../date-fns/locale/sv';
+import { locales } from '../dateUtils';
 
-const locales = { en, fi, sv };
-
-// Check recommended formats: https://hds.hel.fi/guidelines/data-formats
-
-export const DATE_FORMAT = 'd.M.yyyy';
-export const TIME_FORMAT = 'HH:mm';
-export const DATETIME_FORMAT = `${DATE_FORMAT} ${TIME_FORMAT}`;
-
+/**
+ * Formats a Date object into a time string in the specified timezone.
+ */
 export function formatIntoTime(date: Date): string {
-  return formatDateStr(date, TIME_FORMAT);
+  return formatDateStr(date, TIME_FORMAT, {
+    in: tz(TIMEZONE),
+  });
 }
 
+/**
+ * Formats a Date object into a datetime string in the specified timezone.
+ */
 export function formatIntoDateTime(date: Date): string {
-  return formatDateStr(date, DATETIME_FORMAT);
+  return formatDateStr(date, DATETIME_FORMAT, {
+    in: tz(TIMEZONE),
+  });
 }
 
+/**
+ * Formats a Date object into a date string in the specified timezone.
+ */
 export function formatIntoDate(date: Date): string {
-  return formatDateStr(date, DATE_FORMAT);
+  return formatDateStr(date, DATE_FORMAT, {
+    in: tz(TIMEZONE),
+  });
 }
 
+/**
+ * Formats a start and end Date object into a date range string in the specified timezone.
+ */
 export function formatDateRange(start: Date, end: Date): string {
   return `${formatIntoDate(start)} – ${formatIntoDate(end)}`;
 }
 
+/**
+ * Formats a Date object into a localized date string based on the provided format and locale.
+ * If the date is null, an empty string is returned.
+ */
 export function formatLocalizedDate(
   date: Date | null,
   format = DATE_FORMAT,
@@ -36,8 +56,8 @@ export function formatLocalizedDate(
   if (!date) {
     return '';
   }
-
   return formatDateStr(date, format, {
     locale: locales[locale],
+    in: tz(TIMEZONE),
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -811,6 +811,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz#037817b574262134cabd68fc4ec1a454f168407b"
   integrity sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==
 
+"@date-fns/tz@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@date-fns/tz/-/tz-1.2.0.tgz#81cb3211693830babaf3b96aff51607e143030a6"
+  integrity sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==
+
 "@dual-bundle/import-meta-resolve@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz#519c1549b0e147759e7825701ecffd25e5819f7b"


### PR DESCRIPTION
PT-1901 PT-1903.

The event dates and times should always be in Finnish timezone, no matter what location data is used.

Also, some dead code related to date handling removed.