### PR TITLE
PT-1911 | Clarify that Gruppo client needs no password as per documentation

### DIFF
--- a/src/clients/gruppo/gruppoClient.ts
+++ b/src/clients/gruppo/gruppoClient.ts
@@ -15,7 +15,9 @@ axiosClient.interceptors.request.use(
     if (apiKey && config?.headers) {
       config.auth = {
         username: apiKey,
-        password: 'x',
+        // https://www.campaignmonitor.com/api/v3-2/getting-started/#authenticating-with-an-api-key
+        // "You can leave the password field blank or enter a dummy value like ‘x’."
+        password: '',
       };
     }
     return config;


### PR DESCRIPTION
## Description :sparkles:

Clarify that Gruppo client needs no password as per [documentation](https://www.campaignmonitor.com/api/v3-2/getting-started/#authenticating-with-an-api-key):
- `You can leave the password field blank or enter a dummy value like ‘x’.`

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[PT-1911](https://helsinkisolutionoffice.atlassian.net/browse/PT-1911)

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
