### PR TITLE
Fix search params handling on language change and refactor header component

### DIFF
--- a/src/domain/app/header/Header.tsx
+++ b/src/domain/app/header/Header.tsx
@@ -1,10 +1,6 @@
 import { useRouter } from 'next/router';
 import React from 'react';
-import {
-  MenuItem,
-  Navigation,
-  LanguageCodeEnum,
-} from 'react-helsinki-headless-cms';
+import { MenuItem, Navigation } from 'react-helsinki-headless-cms';
 
 import HeaderNotification from './HeaderNotification';
 import { useCmsMenuItems } from './useCmsMenuItems';
@@ -20,10 +16,6 @@ const Header: React.FC = () => {
   const { menu } = useCmsMenuItems();
   const getPathnameForLanguage = useGetPathnameForLanguage();
 
-  const localePath =
-    locale !== LanguageCodeEnum.Fi.toLowerCase()
-      ? `/${locale.toLowerCase()}`
-      : '';
   const goToPage =
     (pathname: string) =>
     (event?: React.MouseEvent<HTMLAnchorElement> | Event) => {
@@ -38,7 +30,7 @@ const Header: React.FC = () => {
         menu={menu}
         onTitleClick={goToPage(ROUTES.HOME)}
         getIsItemActive={(menuItem: MenuItem) =>
-          getIsItemActive(menuItem, localePath)
+          getIsItemActive(menuItem, locale)
         }
         getPathnameForLanguage={getPathnameForLanguage}
       />

--- a/src/domain/app/header/Header.tsx
+++ b/src/domain/app/header/Header.tsx
@@ -1,69 +1,29 @@
-import { ParsedUrlQuery } from 'querystring';
-
 import { useRouter } from 'next/router';
-import React, { useCallback } from 'react';
+import React from 'react';
 import {
   MenuItem,
   Navigation,
-  Language as RHHCLanguage,
   LanguageCodeEnum,
 } from 'react-helsinki-headless-cms';
-import { useMenuQuery } from 'react-helsinki-headless-cms/apollo';
 
 import HeaderNotification from './HeaderNotification';
-import { DEFAULT_HEADER_MENU_NAME } from '../../../constants';
-import { PageIdType, usePageQuery } from '../../../generated/graphql-cms';
+import { useCmsMenuItems } from './useCmsMenuItems';
+import { useGetPathnameForLanguage } from './useGetPathnameForLanguage';
 import useLocale from '../../../hooks/useLocale';
-import { isFeatureEnabled } from '../../../utils/featureFlags';
-import stringifyUrlObject from '../../../utils/stringifyUrlObject';
-import { useCMSApolloClient } from '../../headless-cms/apollo/apolloClient';
 import { HARDCODED_LANGUAGES } from '../../headless-cms/constants';
-import { stripLocaleFromUri } from '../../headless-cms/utils';
-import { PATHNAMES, ROUTES } from '../routes/constants';
-import { getCmsPagePath } from '../routes/utils';
+import { getIsItemActive } from '../../headless-cms/utils';
+import { ROUTES } from '../routes/constants';
 
 const Header: React.FC = () => {
   const router = useRouter();
   const locale = useLocale();
+  const { menu } = useCmsMenuItems();
+  const getPathnameForLanguage = useGetPathnameForLanguage();
+
   const localePath =
     locale !== LanguageCodeEnum.Fi.toLowerCase()
       ? `/${locale.toLowerCase()}`
       : '';
-  const isCmsPage = router.pathname === PATHNAMES.CMS_PAGE;
-
-  const { menu } = useCmsMenuItems();
-
-  const languageOptions = useCmsLanguageOptions({ skip: !isCmsPage });
-
-  const getCurrentParsedUrlQuery = useCallback(
-    () => ({
-      ...router.query,
-      ...(window
-        ? Object.fromEntries(new URLSearchParams(window.location.search))
-        : {}),
-    }),
-    [router.query]
-  );
-
-  const getIsItemActive = (menuItem: MenuItem): boolean => {
-    return (
-      typeof window !== 'undefined' &&
-      window.location.pathname.includes(
-        `${localePath}${getCmsPagePath(
-          stripLocaleFromUri(menuItem.path ?? '')
-        )}`.replace(/\/$/, '')
-      )
-    );
-  };
-
-  // on language switch item click
-  const getPathnameForLanguage = (language: RHHCLanguage): string => {
-    const languageCode = language.code ?? LanguageCodeEnum.Fi;
-    return isCmsPage
-      ? getCmsHref(languageCode.toLowerCase())
-      : getOriginHref(languageCode);
-  };
-
   const goToPage =
     (pathname: string) =>
     (event?: React.MouseEvent<HTMLAnchorElement> | Event) => {
@@ -71,92 +31,20 @@ const Header: React.FC = () => {
       router.push(pathname);
     };
 
-  const getCmsHref = (lang: string) => {
-    const nav = languageOptions?.find((languageOption) => {
-      return languageOption.locale?.toLowerCase() === lang;
-    });
-
-    // if no translated url found, redirect to root
-    if (!nav) {
-      return `/${lang}`;
-    }
-    return `/${lang}${getCmsPagePath(stripLocaleFromUri(nav?.uri ?? ''))}`;
-  };
-
-  const getOriginHref = (language: LanguageCodeEnum): string => {
-    return getLocalizedCmsItemUrl(
-      router.pathname,
-      getCurrentParsedUrlQuery(),
-      language
-    ).toLocaleLowerCase();
-  };
-
-  const getLocalizedCmsItemUrl = (
-    pathname: string,
-    query: ParsedUrlQuery,
-    locale: LanguageCodeEnum
-  ): string => {
-    const path = `/${locale.toLowerCase()}`;
-    return `${path}${stringifyUrlObject({
-      query: query,
-      pathname,
-    })}`;
-  };
-
   return (
     <>
       <Navigation
         languages={HARDCODED_LANGUAGES}
         menu={menu}
         onTitleClick={goToPage(ROUTES.HOME)}
-        getIsItemActive={getIsItemActive}
+        getIsItemActive={(menuItem: MenuItem) =>
+          getIsItemActive(menuItem, localePath)
+        }
         getPathnameForLanguage={getPathnameForLanguage}
       />
       <HeaderNotification />
     </>
   );
-};
-
-const useCmsLanguageOptions = ({ skip = false }: { skip?: boolean } = {}) => {
-  const router = useRouter();
-  const cmsClient = useCMSApolloClient();
-
-  const { data: pageData } = usePageQuery({
-    client: cmsClient,
-    variables: {
-      id: `${router.asPath.replace('/cms-page', '')}/`,
-      idType: PageIdType.Uri,
-    },
-    skip,
-  });
-
-  return !skip
-    ? [
-        {
-          uri: pageData?.page?.uri,
-          locale: pageData?.page?.language?.code?.toLowerCase(),
-        },
-        ...(pageData?.page?.translations?.map((translation) => ({
-          uri: translation?.uri,
-          locale: translation?.language?.code?.toLowerCase(),
-        })) ?? []),
-      ]
-    : [];
-};
-
-const useCmsMenuItems = () => {
-  const locale = useLocale();
-  const { data: navigationData } = useMenuQuery({
-    skip: !isFeatureEnabled('HEADLESS_CMS') || !locale,
-    variables: {
-      id: DEFAULT_HEADER_MENU_NAME[locale],
-      menuIdentifiersOnly: true,
-    },
-  });
-
-  return {
-    menu: navigationData?.menu,
-  };
 };
 
 export default Header;

--- a/src/domain/app/header/__tests__/useGetPathnameForLanguage.test.tsx
+++ b/src/domain/app/header/__tests__/useGetPathnameForLanguage.test.tsx
@@ -1,0 +1,162 @@
+// src/domain/app/header/useGetPathnameForLanguage.test.tsx
+
+import { renderHook } from '@testing-library/react';
+import { useRouter } from 'next/router';
+import { LanguageCodeEnum } from 'react-helsinki-headless-cms';
+
+import { getCmsHref, getHrefForNonCmsPage } from '../../../headless-cms/utils';
+import { PATHNAMES } from '../../routes/constants';
+import { useCmsLanguageOptions } from '../useCmsLanguageOptions';
+import { useGetPathnameForLanguage } from '../useGetPathnameForLanguage';
+
+// --- Mocks ---
+// Mock next/router
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+// Mock useCmsLanguageOptions hook
+jest.mock('../useCmsLanguageOptions', () => ({
+  useCmsLanguageOptions: jest.fn(),
+}));
+
+// Mock utility functions
+jest.mock('../../../headless-cms/utils', () => ({
+  getCmsHref: jest.fn(),
+  getHrefForNonCmsPage: jest.fn(),
+}));
+
+// Type assertion for mocks
+const mockedUseRouter = useRouter as jest.Mock;
+const mockedUseCmsLanguageOptions = useCmsLanguageOptions as jest.Mock;
+const mockedGetCmsHref = getCmsHref as jest.Mock;
+const mockedGetHrefForNonCmsPage = getHrefForNonCmsPage as jest.Mock;
+// --- End Mocks ---
+
+describe('useGetPathnameForLanguage', () => {
+  const mockLanguageOptions = [
+    { id: '1', locale: LanguageCodeEnum.Fi, slug: 'fi-slug', name: 'Suomi' },
+    { id: '2', locale: LanguageCodeEnum.En, slug: 'en-slug', name: 'English' },
+  ];
+  const mockQuery = { param1: 'value1', param2: 'value2' };
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    jest.clearAllMocks();
+    mockedUseCmsLanguageOptions.mockReturnValue(mockLanguageOptions);
+    mockedGetCmsHref.mockReturnValue('/mocked/cms/path/fi');
+    mockedGetHrefForNonCmsPage.mockReturnValue('/mocked/non-cms/path/fi');
+  });
+
+  it('should return a function', () => {
+    mockedUseRouter.mockReturnValue({
+      pathname: '/some/page',
+      query: {},
+    });
+    const { result } = renderHook(() => useGetPathnameForLanguage());
+    expect(typeof result.current).toBe('function');
+  });
+
+  describe('when on a CMS page', () => {
+    beforeEach(() => {
+      mockedUseRouter.mockReturnValue({
+        pathname: PATHNAMES.CMS_PAGE,
+        query: { slug: ['cms', 'page'] }, // Example query for CMS page
+      });
+    });
+
+    it('should call getCmsHref with correct language code and options', () => {
+      const { result } = renderHook(() => useGetPathnameForLanguage());
+      const getPathname = result.current;
+      const targetLanguage = {
+        id: 'suomi',
+        code: LanguageCodeEnum.En,
+        name: 'English',
+      };
+      mockedGetCmsHref.mockReturnValueOnce('/mocked/cms/path/en');
+
+      const pathname = getPathname(targetLanguage);
+
+      expect(mockedUseCmsLanguageOptions).toHaveBeenCalledWith({ skip: false });
+      expect(mockedGetCmsHref).toHaveBeenCalledTimes(1);
+      expect(mockedGetCmsHref).toHaveBeenCalledWith(
+        LanguageCodeEnum.En,
+        mockLanguageOptions
+      );
+      expect(mockedGetHrefForNonCmsPage).not.toHaveBeenCalled();
+      expect(pathname).toBe('/mocked/cms/path/en');
+    });
+
+    it('should use Finnish (Fi) as fallback if language code is missing', () => {
+      const { result } = renderHook(() => useGetPathnameForLanguage());
+      const getPathname = result.current;
+      const targetLanguage = { id: 'suomi', name: 'Suomi' }; // No code property
+      mockedGetCmsHref.mockReturnValueOnce('/mocked/cms/path/fi-fallback');
+
+      const pathname = getPathname(targetLanguage);
+
+      expect(mockedGetCmsHref).toHaveBeenCalledTimes(1);
+      expect(mockedGetCmsHref).toHaveBeenCalledWith(
+        LanguageCodeEnum.Fi, // Fallback code
+        mockLanguageOptions
+      );
+      expect(mockedGetHrefForNonCmsPage).not.toHaveBeenCalled();
+      expect(pathname).toBe('/mocked/cms/path/fi-fallback');
+    });
+  });
+
+  describe('when on a non-CMS page', () => {
+    const nonCmsPathname = '/regular/page';
+
+    beforeEach(() => {
+      mockedUseRouter.mockReturnValue({
+        pathname: nonCmsPathname,
+        query: mockQuery,
+      });
+    });
+
+    it('should call getHrefForNonCmsPage with correct pathname, query, and language code', () => {
+      const { result } = renderHook(() => useGetPathnameForLanguage());
+      const getPathname = result.current;
+      const targetLanguage = {
+        id: 'suomi',
+        code: LanguageCodeEnum.Sv,
+        name: 'Svenska',
+      };
+      mockedGetHrefForNonCmsPage.mockReturnValueOnce('/mocked/non-cms/path/sv');
+
+      const pathname = getPathname(targetLanguage);
+
+      // Should skip fetching CMS options
+      expect(mockedUseCmsLanguageOptions).toHaveBeenCalledWith({ skip: true });
+      expect(mockedGetHrefForNonCmsPage).toHaveBeenCalledTimes(1);
+      expect(mockedGetHrefForNonCmsPage).toHaveBeenCalledWith(
+        nonCmsPathname,
+        mockQuery,
+        LanguageCodeEnum.Sv
+      );
+      expect(mockedGetCmsHref).not.toHaveBeenCalled();
+      expect(pathname).toBe('/mocked/non-cms/path/sv');
+    });
+
+    it('should use Finnish (Fi) as fallback if language code is missing', () => {
+      const { result } = renderHook(() => useGetPathnameForLanguage());
+      const getPathname = result.current;
+      const targetLanguage = { id: 'suomi', name: 'Suomi' }; // No code property
+      mockedGetHrefForNonCmsPage.mockReturnValueOnce(
+        '/mocked/non-cms/path/fi-fallback'
+      );
+
+      const pathname = getPathname(targetLanguage);
+
+      expect(mockedGetHrefForNonCmsPage).toHaveBeenCalledTimes(1);
+      expect(mockedGetHrefForNonCmsPage).toHaveBeenCalledWith(
+        nonCmsPathname,
+        mockQuery,
+        LanguageCodeEnum.Fi // Fallback code
+      );
+      expect(mockedGetCmsHref).not.toHaveBeenCalled();
+      expect(pathname).toBe('/mocked/non-cms/path/fi-fallback');
+    });
+  });
+});

--- a/src/domain/app/header/useCmsLanguageOptions.tsx
+++ b/src/domain/app/header/useCmsLanguageOptions.tsx
@@ -1,0 +1,33 @@
+import { useRouter } from 'next/router';
+
+import { PageIdType, usePageQuery } from '../../../generated/graphql-cms';
+import { useCMSApolloClient } from '../../headless-cms/apollo/apolloClient';
+
+export const useCmsLanguageOptions = ({
+  skip = false,
+}: { skip?: boolean } = {}) => {
+  const router = useRouter();
+  const cmsClient = useCMSApolloClient();
+
+  const { data: pageData } = usePageQuery({
+    client: cmsClient,
+    variables: {
+      id: `${router.asPath.replace('/cms-page', '')}/`,
+      idType: PageIdType.Uri,
+    },
+    skip,
+  });
+
+  return !skip
+    ? [
+        {
+          uri: pageData?.page?.uri,
+          locale: pageData?.page?.language?.code?.toLowerCase(),
+        },
+        ...(pageData?.page?.translations?.map((translation) => ({
+          uri: translation?.uri,
+          locale: translation?.language?.code?.toLowerCase(),
+        })) ?? []),
+      ]
+    : [];
+};

--- a/src/domain/app/header/useCmsMenuItems.tsx
+++ b/src/domain/app/header/useCmsMenuItems.tsx
@@ -1,0 +1,20 @@
+import { useMenuQuery } from 'react-helsinki-headless-cms/apollo';
+
+import { DEFAULT_HEADER_MENU_NAME } from '../../../constants';
+import useLocale from '../../../hooks/useLocale';
+import { isFeatureEnabled } from '../../../utils/featureFlags';
+
+export const useCmsMenuItems = () => {
+  const locale = useLocale();
+  const { data: navigationData } = useMenuQuery({
+    skip: !isFeatureEnabled('HEADLESS_CMS') || !locale,
+    variables: {
+      id: DEFAULT_HEADER_MENU_NAME[locale],
+      menuIdentifiersOnly: true,
+    },
+  });
+
+  return {
+    menu: navigationData?.menu,
+  };
+};

--- a/src/domain/app/header/useGetPathnameForLanguage.tsx
+++ b/src/domain/app/header/useGetPathnameForLanguage.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import {
   Language as RHHCLanguage,
   LanguageCodeEnum,
@@ -14,36 +14,30 @@ export function useGetPathnameForLanguage() {
   const isCmsPage = pathname === PATHNAMES.CMS_PAGE;
   const languageOptions = useCmsLanguageOptions({ skip: !isCmsPage });
 
-  const currentParsedUrlQuery = useMemo(() => {
-    const searchParams = window
-      ? Object.fromEntries(new URLSearchParams(window.location.search))
-      : {};
-    return {
-      ...query,
-      ...searchParams,
-    };
-  }, [query]);
-
-  const getOriginHref = useCallback(
+  // Generates the target URL for the current non-CMS page in the specified language
+  const getHrefForNonCmsPage = useCallback(
     (language: LanguageCodeEnum): string => {
       return getLocalizedCmsItemUrl(
         pathname,
-        currentParsedUrlQuery,
+        query,
         language
       ).toLocaleLowerCase();
     },
-    [pathname, currentParsedUrlQuery]
+    [pathname, query]
   );
 
-  // on language switch item click
+  // Callback function to get the appropriate pathname when switching languages
   const getPathnameForLanguage = useCallback(
     (language: RHHCLanguage): string => {
       const languageCode = language.code ?? LanguageCodeEnum.Fi;
+
+      // If it's a CMS page, get the specific CMS href for that language
+      // Otherwise, generate the localized URL for the current non-CMS page
       return isCmsPage
         ? getCmsHref(languageCode.toLowerCase(), languageOptions)
-        : getOriginHref(languageCode);
+        : getHrefForNonCmsPage(languageCode);
     },
-    [isCmsPage, languageOptions, getOriginHref]
+    [isCmsPage, languageOptions, getHrefForNonCmsPage]
   );
 
   return getPathnameForLanguage;

--- a/src/domain/app/header/useGetPathnameForLanguage.tsx
+++ b/src/domain/app/header/useGetPathnameForLanguage.tsx
@@ -6,7 +6,7 @@ import {
 } from 'react-helsinki-headless-cms';
 
 import { useCmsLanguageOptions } from './useCmsLanguageOptions';
-import { getCmsHref, getLocalizedCmsItemUrl } from '../../headless-cms/utils';
+import { getCmsHref, getHrefForNonCmsPage } from '../../headless-cms/utils';
 import { PATHNAMES } from '../routes/constants';
 
 export function useGetPathnameForLanguage() {
@@ -14,30 +14,17 @@ export function useGetPathnameForLanguage() {
   const isCmsPage = pathname === PATHNAMES.CMS_PAGE;
   const languageOptions = useCmsLanguageOptions({ skip: !isCmsPage });
 
-  // Generates the target URL for the current non-CMS page in the specified language
-  const getHrefForNonCmsPage = useCallback(
-    (language: LanguageCodeEnum): string => {
-      return getLocalizedCmsItemUrl(
-        pathname,
-        query,
-        language
-      ).toLocaleLowerCase();
-    },
-    [pathname, query]
-  );
-
   // Callback function to get the appropriate pathname when switching languages
   const getPathnameForLanguage = useCallback(
     (language: RHHCLanguage): string => {
       const languageCode = language.code ?? LanguageCodeEnum.Fi;
-
       // If it's a CMS page, get the specific CMS href for that language
       // Otherwise, generate the localized URL for the current non-CMS page
       return isCmsPage
-        ? getCmsHref(languageCode.toLowerCase(), languageOptions)
-        : getHrefForNonCmsPage(languageCode);
+        ? getCmsHref(languageCode, languageOptions)
+        : getHrefForNonCmsPage(pathname, query, languageCode);
     },
-    [isCmsPage, languageOptions, getHrefForNonCmsPage]
+    [isCmsPage, languageOptions, pathname, query]
   );
 
   return getPathnameForLanguage;

--- a/src/domain/app/header/useGetPathnameForLanguage.tsx
+++ b/src/domain/app/header/useGetPathnameForLanguage.tsx
@@ -1,0 +1,44 @@
+import { useRouter } from 'next/router';
+import { useCallback } from 'react';
+import {
+  Language as RHHCLanguage,
+  LanguageCodeEnum,
+} from 'react-helsinki-headless-cms';
+
+import { useCmsLanguageOptions } from './useCmsLanguageOptions';
+import { getCmsHref, getLocalizedCmsItemUrl } from '../../headless-cms/utils';
+import { PATHNAMES } from '../routes/constants';
+
+export function useGetPathnameForLanguage() {
+  const router = useRouter();
+  const isCmsPage = router.pathname === PATHNAMES.CMS_PAGE;
+  const languageOptions = useCmsLanguageOptions({ skip: !isCmsPage });
+
+  const getCurrentParsedUrlQuery = useCallback(
+    () => ({
+      ...router.query,
+      ...(window
+        ? Object.fromEntries(new URLSearchParams(window.location.search))
+        : {}),
+    }),
+    [router.query]
+  );
+
+  const getOriginHref = (language: LanguageCodeEnum): string => {
+    return getLocalizedCmsItemUrl(
+      router.pathname,
+      getCurrentParsedUrlQuery(),
+      language
+    ).toLocaleLowerCase();
+  };
+
+  // on language switch item click
+  const getPathnameForLanguage = (language: RHHCLanguage): string => {
+    const languageCode = language.code ?? LanguageCodeEnum.Fi;
+    return isCmsPage
+      ? getCmsHref(languageCode.toLowerCase(), languageOptions)
+      : getOriginHref(languageCode);
+  };
+
+  return getPathnameForLanguage;
+}

--- a/src/domain/headless-cms/__tests__/utils.test.ts
+++ b/src/domain/headless-cms/__tests__/utils.test.ts
@@ -582,7 +582,7 @@ describe('getLocalizedCmsItemUrl', () => {
       pathname: '/UPPER/CASE',
       query: {},
       language: LanguageCodeEnum.En,
-      expected: '/en/upper/case', // Expect lowercase output
+      expected: '/en/UPPER/CASE', // Expect same case level
       description: 'EN: Uppercase path input',
     },
   ])(
@@ -632,7 +632,7 @@ describe('getCmsHref', () => {
     {
       language: LanguageCodeEnum.Fi,
       options: [{ uri: '/fi/UPPER', locale: 'FI' }], // Uppercase locale
-      expected: '/fi/cms-page/upper', // Expect lowercase output and locale match
+      expected: '/fi/cms-page/UPPER', // Expect same case level in pathname except in locale
       description: 'FI: Uppercase locale in options',
     },
     {
@@ -679,8 +679,27 @@ describe('getHrefForNonCmsPage', () => {
       pathname: '/UPPER/PAGE',
       query: {},
       language: LanguageCodeEnum.Sv,
-      expected: '/sv/upper/page', // Expect lowercase
+      expected: '/sv/UPPER/PAGE', // Expect same case level
       description: 'SV: Uppercase path',
+    },
+    {
+      pathname: '/search',
+      query: {
+        text: 'satutuokio',
+        date: '2025-04-13T21:00:00.000Z',
+        endDate: '2027-04-05T21:00:00.000Z',
+        inLanguage: ['en', 'fi', 'sv'],
+        places: 'tprek:8324',
+        targetGroups: 'kultus:51',
+        categories: 'kultus:18',
+        additionalCriteria: 'kultus:4',
+      },
+      language: LanguageCodeEnum.Fi,
+      expected:
+        // expect locale added and parameters in alphabetical order
+        // eslint-disable-next-line max-len
+        '/fi/search?additionalCriteria=kultus%3A4&categories=kultus%3A18&date=2025-04-13T21%3A00%3A00.000Z&endDate=2027-04-05T21%3A00%3A00.000Z&inLanguage=en&inLanguage=fi&inLanguage=sv&places=tprek%3A8324&targetGroups=kultus%3A51&text=satutuokio',
+      description: 'Search page with filters',
     },
   ])(
     'getHrefForNonCmsPage returns $expected for $description',

--- a/src/domain/headless-cms/__tests__/utils.test.ts
+++ b/src/domain/headless-cms/__tests__/utils.test.ts
@@ -533,12 +533,13 @@ describe('getIsItemActive', () => {
     }
   );
 
-  it('should handle window being undefined (SSR)', () => {
-    const originalWindow = global.window;
-    // @ts-expect-error: Simulate SSR environment where window is undefined
-    delete global.window;
+  it('should return false when window is undefined (SSR environment)', () => {
+    const windowSpy = jest.spyOn(global as any, 'window', 'get');
+    windowSpy.mockReturnValue(undefined);
+
     expect(getIsItemActive(menuItem, 'fi')).toBe(false);
-    global.window = originalWindow; // Restore window
+
+    windowSpy.mockRestore(); // Clean up the mock
   });
 });
 

--- a/src/domain/headless-cms/utils.ts
+++ b/src/domain/headless-cms/utils.ts
@@ -381,11 +381,11 @@ export const getLocalizedCmsItemUrl = (
   query: ParsedUrlQuery,
   language: LanguageCodeEnum
 ): string => {
-  const path = `/${language}`;
+  const path = `/${language.toLowerCase()}`;
   return `${path}${stringifyUrlObject({
     query: query,
     pathname,
-  })}`.toLowerCase();
+  })}`;
 };
 
 /**
@@ -404,14 +404,15 @@ export const getCmsHref = (
     locale: string | undefined;
   }[]
 ) => {
+  const locale = language.toLowerCase();
   const nav = languageOptions?.find((languageOption) => {
-    return languageOption.locale?.toLowerCase() === language.toLowerCase();
+    return languageOption.locale?.toLowerCase() === locale;
   });
   // if no translated url found, redirect to root
   if (!nav) {
-    return `/${language}`.toLowerCase();
+    return `/${locale}`;
   }
-  return `/${language}${getCmsPagePath(stripLocaleFromUri(nav?.uri ?? ''))}`.toLowerCase();
+  return `/${locale}${getCmsPagePath(stripLocaleFromUri(nav?.uri ?? ''))}`;
 };
 
 /**
@@ -428,5 +429,5 @@ export const getHrefForNonCmsPage = (
   query: ParsedUrlQuery,
   language: LanguageCodeEnum
 ): string => {
-  return getLocalizedCmsItemUrl(pathname, query, language).toLowerCase();
+  return getLocalizedCmsItemUrl(pathname, query, language);
 };

--- a/src/domain/headless-cms/utils.ts
+++ b/src/domain/headless-cms/utils.ts
@@ -239,8 +239,13 @@ export const getRoutedInternalHrefForLocale = (
 
 export const getIsItemActive = (
   menuItem: MenuItem,
-  localePath: string
+  locale: string
 ): boolean => {
+  const localePath =
+    locale !== LanguageCodeEnum.Fi.toLowerCase()
+      ? `/${locale.toLowerCase()}`
+      : '';
+
   const target = `${localePath}${getCmsPagePath(
     stripLocaleFromUri(menuItem.path ?? '')
   )}`.replace(/\/$/, '');
@@ -249,32 +254,40 @@ export const getIsItemActive = (
   );
 };
 
+export const getLocalizedCmsItemUrl = (
+  pathname: string,
+  query: ParsedUrlQuery,
+  language: LanguageCodeEnum
+): string => {
+  const path = `/${language}`;
+  return `${path}${stringifyUrlObject({
+    query: query,
+    pathname,
+  })}`.toLowerCase();
+};
+
 export const getCmsHref = (
-  lang: string,
+  language: LanguageCodeEnum,
   languageOptions: {
     uri: string | null | undefined;
     locale: string | undefined;
   }[]
 ) => {
   const nav = languageOptions?.find((languageOption) => {
-    return languageOption.locale?.toLowerCase() === lang;
+    return languageOption.locale?.toLowerCase() === language.toLowerCase();
   });
-
   // if no translated url found, redirect to root
   if (!nav) {
-    return `/${lang}`;
+    return `/${language}`.toLowerCase();
   }
-  return `/${lang}${getCmsPagePath(stripLocaleFromUri(nav?.uri ?? ''))}`;
+  return `/${language}${getCmsPagePath(stripLocaleFromUri(nav?.uri ?? ''))}`.toLowerCase();
 };
 
-export const getLocalizedCmsItemUrl = (
+// Generates the target URL for the current non-CMS page in the specified language
+export const getHrefForNonCmsPage = (
   pathname: string,
   query: ParsedUrlQuery,
-  locale: LanguageCodeEnum
+  language: LanguageCodeEnum
 ): string => {
-  const path = `/${locale.toLowerCase()}`;
-  return `${path}${stringifyUrlObject({
-    query: query,
-    pathname,
-  })}`;
+  return getLocalizedCmsItemUrl(pathname, query, language).toLowerCase();
 };

--- a/src/domain/headless-cms/utils.ts
+++ b/src/domain/headless-cms/utils.ts
@@ -347,6 +347,10 @@ export const getIsItemActive = (
   menuItem: MenuItem,
   locale: string
 ): boolean => {
+  if (!menuItem.path) {
+    return false;
+  }
+
   const localePath =
     locale !== LanguageCodeEnum.Fi.toLowerCase()
       ? `/${locale.toLowerCase()}`

--- a/src/domain/headless-cms/utils.ts
+++ b/src/domain/headless-cms/utils.ts
@@ -1,6 +1,9 @@
+import { ParsedUrlQuery } from 'querystring';
+
 import {
   ModuleItemTypeEnum,
   LanguageCodeEnum,
+  MenuItem,
 } from 'react-helsinki-headless-cms';
 import {
   MenuDocument,
@@ -15,6 +18,7 @@ import {
   DEFAULT_HEADER_MENU_NAME,
 } from '../../constants';
 import type { Language } from '../../types';
+import stringifyUrlObject from '../../utils/stringifyUrlObject';
 import { getCmsArticlePath, getCmsPagePath } from '../app/routes/utils';
 
 export const getUriID = (slugs: string[], locale: Language): string => {
@@ -231,4 +235,46 @@ export const getRoutedInternalHrefForLocale = (
     ? getCmsPagePath(linkWithoutLocale)
     : linkWithoutLocale;
   return removeTrailingSlash(`${localePath}${resolvedLink}`).replace(/^$/, '/'); // "" -> "/"
+};
+
+export const getIsItemActive = (
+  menuItem: MenuItem,
+  localePath: string
+): boolean => {
+  const target = `${localePath}${getCmsPagePath(
+    stripLocaleFromUri(menuItem.path ?? '')
+  )}`.replace(/\/$/, '');
+  return (
+    typeof window !== 'undefined' && window.location.pathname.includes(target)
+  );
+};
+
+export const getCmsHref = (
+  lang: string,
+  languageOptions: {
+    uri: string | null | undefined;
+    locale: string | undefined;
+  }[]
+) => {
+  const nav = languageOptions?.find((languageOption) => {
+    return languageOption.locale?.toLowerCase() === lang;
+  });
+
+  // if no translated url found, redirect to root
+  if (!nav) {
+    return `/${lang}`;
+  }
+  return `/${lang}${getCmsPagePath(stripLocaleFromUri(nav?.uri ?? ''))}`;
+};
+
+export const getLocalizedCmsItemUrl = (
+  pathname: string,
+  query: ParsedUrlQuery,
+  locale: LanguageCodeEnum
+): string => {
+  const path = `/${locale.toLowerCase()}`;
+  return `${path}${stringifyUrlObject({
+    query: query,
+    pathname,
+  })}`;
 };

--- a/src/domain/headless-cms/utils.ts
+++ b/src/domain/headless-cms/utils.ts
@@ -21,6 +21,14 @@ import type { Language } from '../../types';
 import stringifyUrlObject from '../../utils/stringifyUrlObject';
 import { getCmsArticlePath, getCmsPagePath } from '../app/routes/utils';
 
+/**
+ * Generates a URI ID based on an array of slugs and a locale.
+ * Prepends the locale to the slugs for all languages except Finnish.
+ *
+ * @param slugs An array of URI slugs.
+ * @param locale The current locale ('fi', 'sv', or 'en').
+ * @returns The generated URI ID with leading and trailing slashes. Returns '/' if no slugs are provided.
+ */
 export const getUriID = (slugs: string[], locale: Language): string => {
   if (!slugs) return '/';
   if (locale === 'fi') {
@@ -29,6 +37,12 @@ export const getUriID = (slugs: string[], locale: Language): string => {
   return `/${locale}/${slugs.join('/')}/`;
 };
 
+/**
+ * Extracts an array of slugs from a URI string by removing the locale prefix and splitting the remaining path.
+ *
+ * @param uri The URI string (can be null or undefined).
+ * @returns An array of slugs, or null if the URI (after stripping locale) is empty.
+ */
 export const getSlugFromUri = (uri?: string | null): string[] | null => {
   const uriWithoutLang = stripLocaleFromUri(uri ?? '');
   if (uriWithoutLang) {
@@ -37,17 +51,40 @@ export const getSlugFromUri = (uri?: string | null): string[] | null => {
   return null;
 };
 
+/**
+ * Strips the locale prefix (/en, /sv, /fi) from the beginning of a URI string (case-insensitive).
+ *
+ * @param uri The URI string.
+ * @returns The URI without the leading locale prefix.
+ */
 export const stripLocaleFromUri = (uri: string): string => {
   return uri.replace(/^\/(en|sv|fi)(?![a-z0-9])/i, '');
 };
 
+/**
+ * Removes the trailing slash from a URI string.
+ *
+ * @param uri The URI string.
+ * @returns The URI without a trailing slash.
+ */
 export const removeTrailingSlash = (uri: string): string => {
   return uri.replace(/\/$/, '');
 };
 
-// '/segment1/segment2/' -> ['/segment1/', '/segment1/segment2/']
-// current implementation required both leading and trailing slashes
-// to include all breadcrumbs
+/**
+ * Converts a URI into an array of breadcrumb segments.
+ * It strips the locale, splits the URI into slugs, and then transforms these
+ * slugs into URI segments with leading and trailing slashes.
+ *
+ * Example:
+ * '/segment1/segment2/' -> ['/segment1/', '/segment1/segment2/']
+ *
+ * current implementation required both leading and trailing slashes
+ * to include all breadcrumbs
+ *
+ * @param uri The URI string.
+ * @returns An array of breadcrumb URI segments. Returns an empty array for an empty URI after stripping the locale.
+ */
 export const uriToBreadcrumbs = (uri: string): string[] => {
   return slugsToUriSegments(
     stripLocaleFromUri(uri)
@@ -57,6 +94,13 @@ export const uriToBreadcrumbs = (uri: string): string[] => {
   );
 };
 
+/**
+ * Converts an array of slugs into an array of URI segments, where each segment includes all preceding slugs.
+ * Each segment has a leading and a trailing slash.
+ *
+ * @param slugs An array of URI slugs.
+ * @returns An array of URI segments.
+ */
 export const slugsToUriSegments = (slugs: string[]): string[] => {
   return slugs.map((slug, index) => {
     return `/${slugs.slice(0, index + 1).join('/')}/`;
@@ -85,7 +129,12 @@ const LANGUAGE_CODE_ENUM_TO_LANGUAGE = {
   [LanguageCodeEnum.Sv]: 'sv',
 } as const satisfies Record<LanguageCodeEnum, Language>;
 
-/** Is node from MenuQuery a valid Page object? */
+/**
+ * Checks if a given node from a MenuQuery result is a valid `Page` object.
+ *
+ * @param node The node to check.
+ * @returns True if the node is a valid `Page` object, false otherwise.
+ */
 const isValidPage = (node: unknown): node is ValidPage => {
   return Boolean(
     typeof node === 'object' &&
@@ -105,7 +154,12 @@ const isValidPage = (node: unknown): node is ValidPage => {
   );
 };
 
-/** Convert a valid Page object to PageInfo. */
+/**
+ * Converts a valid `Page` object from the MenuQuery into a `PageInfo` object.
+ *
+ * @param node A valid `Page` object.
+ * @returns A `PageInfo` object containing the URI, slug, and locale.
+ */
 const nodeToPageInfo = (node: ValidPage): PageInfo => {
   return {
     uri: node.uri,
@@ -114,7 +168,12 @@ const nodeToPageInfo = (node: ValidPage): PageInfo => {
   };
 };
 
-/** Get all PageInfo objects from a Page recursively. */
+/**
+ * Recursively extracts all `PageInfo` objects from a given node, including its connected translations.
+ *
+ * @param node The node to traverse.
+ * @returns An array of `PageInfo` objects found within the node and its translations.
+ */
 const getPageInfosFromNode = (node: unknown): PageInfo[] => {
   const result: PageInfo[] = [];
 
@@ -125,7 +184,13 @@ const getPageInfosFromNode = (node: unknown): PageInfo[] => {
   return result;
 };
 
-/** Get all unique menu pages from headless CMS for all languages. */
+/**
+ * Fetches all unique menu pages from the headless CMS for all configured languages.
+ * It queries both the header and footer menus and extracts page information,
+ * ensuring no duplicate pages are included in the final result.
+ *
+ * @returns A promise that resolves to an array of unique `PageInfo` objects, sorted alphabetically by slug.
+ */
 export const getAllMenuPages = async (): Promise<PageInfo[]> => {
   // Slug to page info mapping to avoid duplicates. Slugs must be unique i.e.
   // slug should be able to be used to identify a page in a specific language.
@@ -174,6 +239,14 @@ export const getAllMenuPages = async (): Promise<PageInfo[]> => {
   );
 };
 
+/**
+ * Generates the correct internal href based on the link and its module item type.
+ * It uses specific path generation functions for articles and pages.
+ *
+ * @param link The target link string.
+ * @param type The module item type (e.g., Article, Page).
+ * @returns The resolved internal href, or '#' if the link is undefined and not an article or page.
+ */
 export function getRoutedInternalHref(
   link: string | null | undefined,
   type?: ModuleItemTypeEnum
@@ -188,9 +261,13 @@ export function getRoutedInternalHref(
 }
 
 /**
- * Rewrite the URLs with internal URLS.
- * @param apolloResponseData The fetch result in JSON format
- * @returns A JSON with manipulated content transformed with URLRewriteMapping
+ * Recursively rewrites internal URLs within an Apollo response data object based on
+ * the URLRewriteMapping in the application configuration. It iterates through the
+ * object's properties and replaces any string values that match a defined regex
+ * with the corresponding replacement.
+ *
+ * @param apolloResponseData The Apollo fetch result in JSON format.
+ * @returns A new JSON object with internal URLs rewritten according to the configuration.
  */
 export function rewriteInternalURLs(
   apolloResponseData: Record<string, unknown>
@@ -212,18 +289,38 @@ export function rewriteInternalURLs(
   return JSON.parse(JSON.stringify(apolloResponseData, replacer));
 }
 
-/** Known non-CMS pages without trailing slash. */
+/**
+ * An array of known non-CMS page paths (without trailing slashes).
+ */
 const KNOWN_NON_CMS_PAGES = [
   '', // root without slash
   '/search',
   '/newsletter',
 ];
 
+/**
+ * Determines if a given link corresponds to an internal CMS page.
+ * It checks if the link, after removing the locale prefix and any trailing slash,
+ * is NOT included in the `KNOWN_NON_CMS_PAGES` array.
+ *
+ * @param link The link string to check (can be null or undefined).
+ * @returns True if the link is likely an internal CMS page, false otherwise.
+ */
 export const isInternalHrefCmsPage = (link?: string | null) => {
   const linkWithoutLocale = removeTrailingSlash(stripLocaleFromUri(link ?? ''));
   return !KNOWN_NON_CMS_PAGES.includes(linkWithoutLocale);
 };
 
+/**
+ * Generates a routed internal href for a specific locale.
+ * For CMS pages, it uses `getCmsPagePath` to ensure the correct CMS path.
+ * For non-CMS pages, it returns the link without the original locale.
+ *
+ * @param locale The target locale ('fi', 'sv', or 'en').
+ * @param link The original link string (can be null or undefined).
+ * @returns The routed internal href for the given locale.
+ * Returns '/' if the resolved link is empty.
+ */
 export const getRoutedInternalHrefForLocale = (
   locale: Language,
   link?: string | null
@@ -237,6 +334,15 @@ export const getRoutedInternalHrefForLocale = (
   return removeTrailingSlash(`${localePath}${resolvedLink}`).replace(/^$/, '/'); // "" -> "/"
 };
 
+/**
+ * Checks if a given menu item is currently active based on the browser's location.
+ * It constructs the expected target path for the menu item in the specified locale
+ * and compares it (case-insensitively) with the current window's pathname.
+ *
+ * @param menuItem The menu item object, which should have a 'path' property.
+ * @param locale The current locale string (e.g., 'fi', 'sv', 'en').
+ * @returns True if the menu item's target path matches the beginning of the current URL, false otherwise.
+ */
 export const getIsItemActive = (
   menuItem: MenuItem,
   locale: string
@@ -254,6 +360,18 @@ export const getIsItemActive = (
   );
 };
 
+/**
+ * Generates a localized URL for a CMS item.
+ * It constructs the URL by combining the specified language prefix with the pathname and query parameters.
+ *
+ * @param pathname The base path of the CMS item.
+ * @param query The parsed URL query parameters.
+ * @param language The target language code (e.g., 'FI', 'SV', 'EN').
+ * @returns The fully localized URL in lowercase.
+ */
+// NOTE: `getLocalizedCmsItemUrl` could be renmaed to be more generic,
+// but is left as it is, while it's only used in CMS context.
+// It's easier to deprecate and easier to reuse when the context is clear.
 export const getLocalizedCmsItemUrl = (
   pathname: string,
   query: ParsedUrlQuery,
@@ -266,6 +384,15 @@ export const getLocalizedCmsItemUrl = (
   })}`.toLowerCase();
 };
 
+/**
+ * Retrieves the localized CMS href for a given language based on the provided language options.
+ * It searches for the language option matching the specified language and constructs the CMS URL.
+ * If no translation is found for the language, it returns the root path for that language.
+ *
+ * @param language The target language code (e.g., 'FI', 'SV', 'EN').
+ * @param languageOptions An array of language options, each containing a URI and a locale.
+ * @returns The localized CMS href in lowercase.
+ */
 export const getCmsHref = (
   language: LanguageCodeEnum,
   languageOptions: {
@@ -283,7 +410,15 @@ export const getCmsHref = (
   return `/${language}${getCmsPagePath(stripLocaleFromUri(nav?.uri ?? ''))}`.toLowerCase();
 };
 
-// Generates the target URL for the current non-CMS page in the specified language
+/**
+ * Generates the target URL for the current non-CMS page in the specified language.
+ * It reuses the `getLocalizedCmsItemUrl` function as the URL structure is the same for non-CMS pages.
+ *
+ * @param pathname The current pathname of the non-CMS page.
+ * @param query The parsed URL query parameters.
+ * @param language The target language code (e.g., 'FI', 'SV', 'EN').
+ * @returns The localized URL for the non-CMS page in lowercase.
+ */
 export const getHrefForNonCmsPage = (
   pathname: string,
   query: ParsedUrlQuery,


### PR DESCRIPTION
PT-1894.

The search filters were activated in search form properly, because the parameter names are case sensitive and the search params of the URL were lower cased.

Split the Header component code content to new hooks and util functions, so it's easier to manage and to understand, but also easier to test.

<img width="1104" alt="image" src="https://github.com/user-attachments/assets/1e9e4d07-d47b-42eb-83b3-daa461ae8c36" />
