### PR TITLE
fix: flex-wrap footer links when they do not fit in single row

### DIFF
--- a/src/domain/app/footer/Footer.tsx
+++ b/src/domain/app/footer/Footer.tsx
@@ -55,6 +55,7 @@ const FooterSection = (): React.ReactElement => {
           />
         }
         onBackToTopClick={handleBackToTop}
+        className={styles.footerBase}
       >
         {!loading &&
           data?.menu?.menuItems?.nodes?.map((navigationItem) => {

--- a/src/domain/app/footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/domain/app/footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`Footer matches snapshot 1`] = `
         appName
       </h2>
       <div
-        class="FooterBase-module_base__2f0eu"
+        class="FooterBase-module_base__2f0eu footerBase"
       >
         <hr
           aria-hidden="true"

--- a/src/domain/app/footer/footer.module.scss
+++ b/src/domain/app/footer/footer.module.scss
@@ -11,3 +11,7 @@
     width: 100% !important;
   }
 }
+
+.footerBase div[class^='FooterBase-module_links'] {
+  flex-wrap: wrap;
+}

--- a/src/domain/app/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
+++ b/src/domain/app/layout/__tests__/__snapshots__/PageLayout.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`PageLayout matches snapshot 1`] = `
           appName
         </h2>
         <div
-          class="FooterBase-module_base__2f0eu"
+          class="FooterBase-module_base__2f0eu footerBase"
         >
           <hr
             aria-hidden="true"


### PR DESCRIPTION
PT-1916

Sometimes the footer links does not fit in a single row, so they should be wrapped to the next line.

<img width="776" alt="image" src="https://github.com/user-attachments/assets/b58a21a6-62c0-4927-8087-fdc487f965b7" />
