### PR TITLE
fix: force direction of cards to vertical in cms page search component

### DIFF
--- a/src/domain/headless-cms/components/CmsPageSearch/CmsPageSearch.tsx
+++ b/src/domain/headless-cms/components/CmsPageSearch/CmsPageSearch.tsx
@@ -92,6 +92,7 @@ const CmsPageSearch: React.FC<{
     url: getCmsPagePath(item?.uri ?? ''),
     imageUrl:
       item?.featuredImage?.node?.medium_large || getEventPlaceholderImage(''),
+    direction: 'fixed-vertical',
   });
 
   const customContent = (


### PR DESCRIPTION
PT-1913.

When the cards were listed in a grid of 3 cards (per row), the cards were quite unresponsive in a mobile view. When the layout direction is forced to "fixed-vertical", the result is much more responsive.

<img width="832" alt="image" src="https://github.com/user-attachments/assets/16688f28-9c9d-4b17-b454-0c74badbcf71" />

<img width="488" alt="image" src="https://github.com/user-attachments/assets/de612a44-6e2a-4c3f-86fe-5a5284a3d62d" />
