### PR TITLE
Replace hard coded privacy statement links with instructions to find it from footer

### DIFF
--- a/public/locales/en/enrolment.json
+++ b/public/locales/en/enrolment.json
@@ -7,7 +7,7 @@
     "buttonResetForm": "Reset form",
     "buttonSubmit": "Submit registration",
     "buttonSubmitEnquiry": "Submit Enquiry",
-    "infoText1": "We do not use the information you provide for marketing purposes.",
+    "infoText1": "We do not use the information you provide for marketing purposes. You can find the link to the privacy policy at the bottom of this page.",
     "infoText2": "We will send you a separate confirmation message once the organizer has processed and confirmed your registration.",
     "labelHasEmailNotification": "By e-mail",
     "labelHasSmsNotification": "By SMS",

--- a/public/locales/en/newsletter.json
+++ b/public/locales/en/newsletter.json
@@ -16,6 +16,6 @@
   },
   "subscribeNewsletterPage": {
     "pageTitle": "Subscribe to our newsletters!",
-    "leadText": "<Paragraph>By subscribing to the Kultus newsletter, I agree that the information I send will be stored in the Gruppo subscriber register. You can unsubscribe from the newsletter at any time. You can find the link to the privacy policy at the bottom of this page.</Paragraph><Paragraph>Regarding the administration of the Gruppo account and the newsletter, you can be in contact with the admin of Kultus: <MailToAdminLink aria-label=\"Administrator email: {{adminMail}}\">{{adminMail}}</MailToAdminLink>.</Paragraph>"
+    "leadText": "<Paragraph>By subscribing to the Kultus newsletter, I agree that the information I send will be stored in the Gruppo subscriber register. You can unsubscribe at any time by clicking the link at the end of the newsletter. You can find the link to the privacy policy at the bottom of this page.</Paragraph><Paragraph>Regarding the administration of the Gruppo account and the newsletter, you can be in contact with the admin of Kultus: <MailToAdminLink aria-label=\"Administrator email: {{adminMail}}\">{{adminMail}}</MailToAdminLink>.</Paragraph>"
   }
 }

--- a/public/locales/en/newsletter.json
+++ b/public/locales/en/newsletter.json
@@ -16,6 +16,6 @@
   },
   "subscribeNewsletterPage": {
     "pageTitle": "Subscribe to our newsletters!",
-    "leadText": "<Paragraph>By subscribing to the Kultus newsletter, I agree that the information I send will be stored in the Gruppo subscriber register. You can unsubscribe from the newsletter at any time. <PrivacyStatementLink aria-label=\"Show the privacy statement. {{openInNewTab}}\">Privacy statement</PrivacyStatementLink>.</Paragraph><Paragraph>Regarding the administration of the Gruppo account and the newsletter, you can be in contact with the admin of Kultus: <MailToAdminLink aria-label=\"Administrator email: {{adminMail}}\">{{adminMail}}</MailToAdminLink>.</Paragraph>"
+    "leadText": "<Paragraph>By subscribing to the Kultus newsletter, I agree that the information I send will be stored in the Gruppo subscriber register. You can unsubscribe from the newsletter at any time. You can find the link to the privacy policy at the bottom of this page.</Paragraph><Paragraph>Regarding the administration of the Gruppo account and the newsletter, you can be in contact with the admin of Kultus: <MailToAdminLink aria-label=\"Administrator email: {{adminMail}}\">{{adminMail}}</MailToAdminLink>.</Paragraph>"
   }
 }

--- a/public/locales/fi/enrolment.json
+++ b/public/locales/fi/enrolment.json
@@ -7,7 +7,7 @@
     "buttonResetForm": "Tyhjennä lomake",
     "buttonSubmit": "Lähetä ilmoittautuminen",
     "buttonSubmitEnquiry": "Lähetä varaustiedustelu",
-    "infoText1": "Emme käytä antamiasi tietoja markkinointiin.",
+    "infoText1": "Emme käytä antamiasi tietoja markkinointiin. Linkin tietosuojaselosteeseen löydät tämän sivun alalaidasta.",
     "infoText2": "Lähetämme sinulle erillisen vahvistusviestin, kun järjestäjä on käsitellyt ja vahvistanut ilmoittautumisesi.",
     "labelHasEmailNotification": "Sähköpostilla",
     "labelHasSmsNotification": "Tekstiviestillä",

--- a/public/locales/fi/newsletter.json
+++ b/public/locales/fi/newsletter.json
@@ -16,6 +16,6 @@
   },
   "subscribeNewsletterPage": {
     "pageTitle": "Tilaa uutiskirje",
-    "leadText": "<Paragraph>Tilaamalla Kultus-uutiskirjeen hyväksyn, että lähettämäni tiedot tallennetaan Kulttuuri- ja vapaa-aika toimialan Gruppo-tilaajarekisteriin. Uutiskirjeen tilauksen voi perua milloin tahansa. <PrivacyStatementLink aria-label=\"Näytä rekisteriseloste. {{openInNewTab}}\">Rekisteriselosteet</PrivacyStatementLink>.</Paragraph><Paragraph>Gruppo-tilin hallintaan ja uutiskirjetilaukseen liittyen voit olla yhteydessä Kultuksen ylläpitäjään: <MailToAdminLink aria-label=\"Ylläpitäjän sähköposti: {{adminMail}}\">{{adminMail}}</MailToAdminLink>.</Paragraph>"
+    "leadText": "<Paragraph>Tilaamalla Kultus-uutiskirjeen hyväksyn, että lähettämäni tiedot tallennetaan Kulttuuri- ja vapaa-aika toimialan Gruppo-tilaajarekisteriin. Uutiskirjeen tilauksen voi perua milloin tahansa. Linkin tietosuojaselosteeseen löydät tämän sivun alalaidasta.</Paragraph><Paragraph>Gruppo-tilin hallintaan ja uutiskirjetilaukseen liittyen voit olla yhteydessä Kultuksen ylläpitäjään: <MailToAdminLink aria-label=\"Ylläpitäjän sähköposti: {{adminMail}}\">{{adminMail}}</MailToAdminLink>.</Paragraph>"
   }
 }

--- a/public/locales/fi/newsletter.json
+++ b/public/locales/fi/newsletter.json
@@ -16,6 +16,6 @@
   },
   "subscribeNewsletterPage": {
     "pageTitle": "Tilaa uutiskirje",
-    "leadText": "<Paragraph>Tilaamalla Kultus-uutiskirjeen hyväksyn, että lähettämäni tiedot tallennetaan Kulttuuri- ja vapaa-aika toimialan Gruppo-tilaajarekisteriin. Uutiskirjeen tilauksen voi perua milloin tahansa. Linkin tietosuojaselosteeseen löydät tämän sivun alalaidasta.</Paragraph><Paragraph>Gruppo-tilin hallintaan ja uutiskirjetilaukseen liittyen voit olla yhteydessä Kultuksen ylläpitäjään: <MailToAdminLink aria-label=\"Ylläpitäjän sähköposti: {{adminMail}}\">{{adminMail}}</MailToAdminLink>.</Paragraph>"
+    "leadText": "<Paragraph>Tilaamalla Kultus-uutiskirjeen hyväksyn, että lähettämäni tiedot tallennetaan Kulttuuri- ja vapaa-aika toimialan Gruppo-tilaajarekisteriin. Uutiskirjeen tilauksen voit lopettaa milloin tahansa uutiskirjeen lopussa olevasta linkistä. Linkin tietosuojaselosteeseen löydät tämän sivun alalaidasta.</Paragraph><Paragraph>Gruppo-tilin hallintaan ja uutiskirjetilaukseen liittyen voit olla yhteydessä Kultuksen ylläpitäjään: <MailToAdminLink aria-label=\"Ylläpitäjän sähköposti: {{adminMail}}\">{{adminMail}}</MailToAdminLink>.</Paragraph>"
   }
 }

--- a/public/locales/sv/enrolment.json
+++ b/public/locales/sv/enrolment.json
@@ -7,7 +7,7 @@
     "buttonResetForm": "Töm formuläret",
     "buttonSubmit": "Skicka registrering",
     "buttonSubmitEnquiry": "Skicka anmälan",
-    "infoText1": "Uppgifterna som du tillhandahåller kommer inte att användas för marknadsföringsändamål av oss.",
+    "infoText1": "Uppgifterna som du tillhandahåller kommer inte att användas för marknadsföringsändamål av oss. Länken till integritetspolicyn finns längst ned på denna sida.",
     "infoText2": "Vi skickar dig en separat bekräftelse när arrangören har behandlat och bekräftat din anmälan.",
     "labelHasEmailNotification": "Via e-post",
     "labelHasSmsNotification": "Via SMS",

--- a/public/locales/sv/newsletter.json
+++ b/public/locales/sv/newsletter.json
@@ -16,6 +16,6 @@
   },
   "subscribeNewsletterPage": {
     "pageTitle": "Beställ vårt nyhetsbrev!",
-    "leadText": "<Paragraph>Genom att prenumerera på nyhetsbrevet Kultus godkänner jag att mina uppgifter sparas i Gruppo-registret, som upprätthålls av Kultur och Fritid. Nyhetsbrevet kan avbeställas när som helst. Länken till integritetspolicyn finns längst ned på denna sida.</Paragraph><Paragraph>Berörande administrationen av Gruppo-kontot och nyhetsbrevet kan du vara i kontakt med admin för Kultus: <MailToAdminLink aria-label=\"Admin email: {{adminMail}}\">{{adminMail}}</MailToAdminLink>.</Paragraph>"
+    "leadText": "<Paragraph>Genom att prenumerera på nyhetsbrevet Kultus godkänner jag att mina uppgifter sparas i Gruppo-registret, som upprätthålls av Kultur och Fritid. Du kan när som helst avsluta prenumerationen genom att klicka på länken i slutet av nyhetsbrevet. Länken till integritetspolicyn finns längst ned på denna sida.</Paragraph><Paragraph>Berörande administrationen av Gruppo-kontot och nyhetsbrevet kan du vara i kontakt med admin för Kultus: <MailToAdminLink aria-label=\"Admin email: {{adminMail}}\">{{adminMail}}</MailToAdminLink>.</Paragraph>"
   }
 }

--- a/public/locales/sv/newsletter.json
+++ b/public/locales/sv/newsletter.json
@@ -16,6 +16,6 @@
   },
   "subscribeNewsletterPage": {
     "pageTitle": "Beställ vårt nyhetsbrev!",
-    "leadText": "<Paragraph>Genom att prenumerera på nyhetsbrevet Kultus godkänner jag att mina uppgifter sparas i Gruppo-registret, som upprätthålls av Kultur och Fritid. Nyhetsbrevet kan avbeställas när som helst. Se närmare info om registren: <PrivacyStatementLink aria-label=\"Se registerbeskrivningen. {{openInNewTab}}\">Registerbeskrivning</PrivacyStatementLink>.</Paragraph><Paragraph>Berörande administrationen av Gruppo-kontot och nyhetsbrevet kan du vara i kontakt med admin för Kultus: <MailToAdminLink aria-label=\"Admin email: {{adminMail}}\">{{adminMail}}</MailToAdminLink>.</Paragraph>"
+    "leadText": "<Paragraph>Genom att prenumerera på nyhetsbrevet Kultus godkänner jag att mina uppgifter sparas i Gruppo-registret, som upprätthålls av Kultur och Fritid. Nyhetsbrevet kan avbeställas när som helst. Länken till integritetspolicyn finns längst ned på denna sida.</Paragraph><Paragraph>Berörande administrationen av Gruppo-kontot och nyhetsbrevet kan du vara i kontakt med admin för Kultus: <MailToAdminLink aria-label=\"Admin email: {{adminMail}}\">{{adminMail}}</MailToAdminLink>.</Paragraph>"
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,12 +36,6 @@ export const ALL_I18N_NAMESPACES = [
   'occurrence',
 ] as const;
 
-export const PRIVACY_POLICY_LINKS = {
-  fi: 'https://hkih.production.geniem.io/uploads/sites/5/2022/11/739f5edc-rekisteriseloste-kultus.fi_.pdf',
-  en: 'https://hkih.production.geniem.io/uploads/sites/5/2022/11/bf2f8d34-rekisteriseloste-kultus.fi_en.pdf',
-  sv: 'https://hkih.production.geniem.io/uploads/sites/5/2022/11/0d425f44-rekisteriseloste-kultus.fi_sv.pdf',
-};
-
 export const ADMIN_EMAIL = {
   fi: 'kultus@hel.fi',
   en: 'kultus@hel.fi',

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -22,9 +22,8 @@ import UnitPlaceSelectorField from '../../../common/components/form/fields/UnitP
 import FormErrorNotification from '../../../common/components/form/FormErrorNotification';
 import FormGroup from '../../../common/components/form/FormGroup';
 import FormikPersist from '../../../common/components/formikPersist/FormikPersist';
-import { FORM_NAMES, PRIVACY_POLICY_LINKS } from '../../../constants';
+import { FORM_NAMES } from '../../../constants';
 import { Language } from '../../../generated/graphql';
-import useLocale from '../../../hooks/useLocale';
 import type { I18nNamespace } from '../../../types';
 import keyify from '../../../utils/keyify';
 import { translateValue } from '../../../utils/translateUtils';
@@ -52,7 +51,6 @@ const EnrolmentForm: React.FC<Props> = ({
   actionType = 'enrolment',
 }) => {
   const { t } = useTranslation<I18nNamespace>();
-  const locale = useLocale();
 
   const { options: studyLevelOptions } = useStudyLevels();
 
@@ -339,17 +337,7 @@ const EnrolmentForm: React.FC<Props> = ({
               </FormGroup>
             </div>
             <FormGroup>
-              <p>
-                {t('enrolment:enrolmentForm.infoText1')}{' '}
-                <a
-                  href={PRIVACY_POLICY_LINKS[locale]}
-                  target="_blank"
-                  rel="noreferrer"
-                  className={styles.privacyPolicyLink}
-                >
-                  {t('common:privacyPolicy')}
-                </a>
-              </p>
+              <p>{t('enrolment:enrolmentForm.infoText1')}</p>
             </FormGroup>
             <FormGroup>
               <div className={styles.checkboxWrapper}>

--- a/src/domain/newsletter/SubscribeNewsletterPage.tsx
+++ b/src/domain/newsletter/SubscribeNewsletterPage.tsx
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { FormikHelpers } from 'formik';
-import { IconLinkExternal, Notification } from 'hds-react';
-import NextLink from 'next/link';
+import { Notification } from 'hds-react';
 import { Trans, useTranslation } from 'next-i18next';
 import * as React from 'react';
 
@@ -11,28 +10,12 @@ import NewsletterSubscribeForm, {
 } from './newsletterSubscribeForm/NewsletterSubscribeForm';
 import styles from './subscribeNewsletterPage.module.scss';
 import { convertSubscribeFormData } from '../../clients/gruppo/lib/subscribers';
-import { ADMIN_EMAIL, PRIVACY_POLICY_LINKS } from '../../constants';
+import { ADMIN_EMAIL } from '../../constants';
 import useLocale from '../../hooks/useLocale';
 import type { I18nNamespace } from '../../types';
 import Container from '../app/layout/Container';
 import PageWrapper from '../app/layout/PageWrapper';
 import { ROUTES } from '../app/routes/constants';
-
-const PrivacyStatementLink = ({
-  url,
-  children,
-  ...rest
-}: {
-  url: string;
-  children?: React.ReactNode;
-} & React.HTMLProps<HTMLAnchorElement>) => (
-  <NextLink legacyBehavior href={url} passHref>
-    <a {...rest}>
-      {children}
-      <IconLinkExternal className={styles.privacyStatementIcon} />
-    </a>
-  </NextLink>
-);
 
 const SubscribeNewsletterPage: React.FC = () => {
   const { t } = useTranslation<I18nNamespace>();
@@ -105,13 +88,6 @@ const SubscribeNewsletterPage: React.FC = () => {
                 adminMail: ADMIN_EMAIL[locale],
               }}
               components={{
-                PrivacyStatementLink: (
-                  <PrivacyStatementLink
-                    url={PRIVACY_POLICY_LINKS[locale]}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  />
-                ),
                 // eslint-disable-next-line jsx-a11y/anchor-has-content
                 MailToAdminLink: <a href={`mailto:${ADMIN_EMAIL[locale]}`} />,
                 Paragraph: <p />,

--- a/src/domain/newsletter/__tests__/__snapshots__/SubscribeNewsletterPage.test.tsx.snap
+++ b/src/domain/newsletter/__tests__/__snapshots__/SubscribeNewsletterPage.test.tsx.snap
@@ -15,31 +15,7 @@ exports[`SubscribeNewsletterPage renders correctly 1`] = `
           </h2>
           <div>
             <p>
-              Tilaamalla Kultus-uutiskirjeen hyväksyn, että lähettämäni tiedot tallennetaan Kulttuuri- ja vapaa-aika toimialan Gruppo-tilaajarekisteriin. Uutiskirjeen tilauksen voi perua milloin tahansa. 
-              <a
-                aria-label="Näytä rekisteriseloste. Avautuu uudessa välilehdessä"
-                href="https://hkih.production.geniem.io/uploads/sites/5/2022/11/739f5edc-rekisteriseloste-kultus.fi_.pdf"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Rekisteriselosteet
-                <svg
-                  aria-hidden="true"
-                  aria-label="link-external"
-                  class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik privacyStatementIcon"
-                  role="img"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    clip-rule="evenodd"
-                    d="M5 3V19H21V21H3V3H5ZM21 3V12H19V6.413L9.91421 15.5L8.5 14.0858L17.585 5H12V3H21Z"
-                    fill="currentColor"
-                    fill-rule="evenodd"
-                  />
-                </svg>
-              </a>
-              .
+              Tilaamalla Kultus-uutiskirjeen hyväksyn, että lähettämäni tiedot tallennetaan Kulttuuri- ja vapaa-aika toimialan Gruppo-tilaajarekisteriin. Uutiskirjeen tilauksen voi perua milloin tahansa. Linkin tietosuojaselosteeseen löydät tämän sivun alalaidasta.
             </p>
             <p>
               Gruppo-tilin hallintaan ja uutiskirjetilaukseen liittyen voit olla yhteydessä Kultuksen ylläpitäjään: 

--- a/src/domain/newsletter/__tests__/__snapshots__/SubscribeNewsletterPage.test.tsx.snap
+++ b/src/domain/newsletter/__tests__/__snapshots__/SubscribeNewsletterPage.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`SubscribeNewsletterPage renders correctly 1`] = `
           </h2>
           <div>
             <p>
-              Tilaamalla Kultus-uutiskirjeen hyväksyn, että lähettämäni tiedot tallennetaan Kulttuuri- ja vapaa-aika toimialan Gruppo-tilaajarekisteriin. Uutiskirjeen tilauksen voi perua milloin tahansa. Linkin tietosuojaselosteeseen löydät tämän sivun alalaidasta.
+              Tilaamalla Kultus-uutiskirjeen hyväksyn, että lähettämäni tiedot tallennetaan Kulttuuri- ja vapaa-aika toimialan Gruppo-tilaajarekisteriin. Uutiskirjeen tilauksen voit lopettaa milloin tahansa uutiskirjeen lopussa olevasta linkistä. Linkin tietosuojaselosteeseen löydät tämän sivun alalaidasta.
             </p>
             <p>
               Gruppo-tilin hallintaan ja uutiskirjetilaukseen liittyen voit olla yhteydessä Kultuksen ylläpitäjään: 


### PR DESCRIPTION
PT-1915.


<img width="1137" alt="image" src="https://github.com/user-attachments/assets/b07816e7-3d9c-4428-9a9d-745342e931da" />

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/458a3143-14b3-4fc2-8e64-f5eff7501b6d" />
