### PR TITLE
PT-1919 | Add basic Playwright tests & run them in Github actions

### DIFF
--- a/.env.playwright.local.example
+++ b/.env.playwright.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_APP_ORIGIN=http://localhost:3000

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,45 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_API_BASE_URL: https://kultus.api.test.hel.ninja/graphql
+      NEXT_PUBLIC_APP_ORIGIN: http://localhost:3000
+      NEXT_PUBLIC_CAPTCHA_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+      NEXT_PUBLIC_CMS_BASE_URL: https://kultus.app-staging.hkih.hion.dev/graphql
+      NEXT_PUBLIC_FORMIK_PERSIST: true
+      NEXT_PUBLIC_HEADLESS_CMS_ENABLED: true
+      NEXT_PUBLIC_MATOMO_ENABLED: false
+      # Arbitrary values for Matomo as it is disabled, but still required for build to succeed:
+      NEXT_PUBLIC_MATOMO_SITE_ID: 68
+      NEXT_PUBLIC_MATOMO_SRC_URL: matomo.js
+      NEXT_PUBLIC_MATOMO_TRACKER_URL: matomo.php
+      NEXT_PUBLIC_MATOMO_URL_BASE: https://analytics.hel.ninja/
+      NEXT_PUBLIC_NEWSLETTER_ENABLED: false
+      NEXT_PUBLIC_UNIFIED_SEARCH_BASE_URL: https://kuva-unified-search.api.test.hel.ninja/search
+      PORT: 3000
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm install -g yarn && yarn
+    - name: Build production application
+      run: yarn build
+    - name: Install Playwright Browsers
+      run: yarn playwright install --with-deps
+    - name: Run Playwright tests
+      run: yarn test:browser:ci
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -23,17 +23,29 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
+# env files
 .env
-.env.local
+.env.development
 .env.development.local
+.env.local
+.env.playwright
+.env.playwright.local
+.env.production
 .env.production.local
+.env.test
+.env.test.local
 
 # browser test screenshots
 /screenshot
 
-# ItelliJ
+# IntelliJ
 *.iml
 
 screenshots
 /.vscode
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Teachers' UI for Kultus (formerly Palvelutarjotin).
     - [`yarn test:changed`](#yarn-testchanged)
     - [`yarn test:coverage`](#yarn-testcoverage)
     - [`yarn test:debug`](#yarn-testdebug)
+    - [`yarn test:browser`](#yarn-testbrowser)
+    - [`yarn test:browser:ci`](#yarn-testbrowserci)
+    - [`yarn codegen:browser`](#yarn-codegenbrowser)
 - [Headless CMS](#headless-cms)
   - [Headless CMS React Components -lib](#headless-cms-react-components--lib)
 - [Releases, changelogs and deployments](#releases-changelogs-and-deployments)
@@ -412,6 +415,14 @@ Run tests and generate coverage report
 #### `yarn test:debug`
 Debug tests
 
+#### `yarn test:browser`
+Run browser tests in local development.
+
+#### `yarn test:browser:ci`
+Run browser tests in CI/CD pipeline.
+
+#### `yarn codegen:browser`
+Generate code for browser tests using [Playwright's test generator](https://playwright.dev/docs/codegen).
 
 ## Headless CMS
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,6 +41,7 @@ module.exports = {
   testPathIgnorePatterns: [
     '<rootDir>/.next/',
     '<rootDir>/node_modules/',
+    '<rootDir>/src/playwright/',
     '/__mocks__/',
   ],
   coveragePathIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "test:changed": "jest -o",
     "test:coverage": "jest --watchAll=false --coverage",
     "test:staged": "cross-env SASS_PATH=./src/assets/styles jest --findRelatedTests --passWithNoTests",
-    "ci": "jest --verbose --coverage --runInBand"
+    "ci": "jest --verbose --coverage --runInBand",
+    "codegen:browser": "playwright codegen",
+    "test:browser": "playwright test",
+    "test:browser:ci": "yarn test:browser"
   },
   "//": {
     "Why are packages in resolutions?": {
@@ -91,6 +94,7 @@
     "@graphql-codegen/typescript-operations": "^4.6.0",
     "@graphql-codegen/typescript-react-apollo": "^4.3.2",
     "@next/eslint-plugin-next": "^15.2.4",
+    "@playwright/test": "^1.52.0",
     "@stylistic/eslint-plugin": "^4.2.0",
     "@swc/core": "^1.11.15",
     "@swc/jest": "^0.2.37",
@@ -132,6 +136,7 @@
     "jest_workaround": "^0.79.19",
     "lint-staged": "^15.5.0",
     "msw": "^2.7.3",
+    "playwright": "^1.52.0",
     "prettier": "^3.5.3",
     "stylelint": "^16.17.0",
     "stylelint-config-recommended-scss": "^14.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+
+import AppConfig from './src/domain/headless-cms/config';
+import { getCookieConsentGivenCookies } from './src/utils/getCookieConsentGivenCookies';
+
+// Use .env.playwright.local in local development if it exists
+const envFilePath = '.env.playwright.local';
+if (!process.env.CI && fs.existsSync(envFilePath)) {
+  dotenv.config({ path: envFilePath });
+}
+
+// Determine used web server type (i.e. development or production)
+const webServerType = process.env.PLAYWRIGHT_WEB_SERVER ?? '';
+
+if (!['', 'development', 'production'].includes(webServerType)) {
+  throw new Error(
+    `Invalid PLAYWRIGHT_WEB_SERVER: ${webServerType}.` +
+      'Default is production. Only other option is development.'
+  );
+}
+const useDevServer = webServerType == 'development';
+
+// See https://playwright.dev/docs/test-configuration.
+export default defineConfig({
+  testDir: './src/playwright/tests',
+  // Run tests in files in parallel
+  fullyParallel: true,
+  // Fail the build on CI if you accidentally left test.only in the source code.
+  forbidOnly: !!process.env.CI,
+  // Retry on CI only
+  retries: process.env.CI ? 3 : 0,
+  // Opt out of parallel tests on CI.
+  workers: process.env.CI ? 1 : undefined,
+  // Reporter to use. See https://playwright.dev/docs/test-reporters
+  reporter: 'html',
+  // Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions.
+  use: {
+    // Base URL to use in actions like `await page.goto('/')`.
+    baseURL: process.env.NEXT_PUBLIC_APP_ORIGIN,
+
+    // Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer
+    trace: 'on-first-retry',
+
+    storageState: {
+      cookies: getCookieConsentGivenCookies({ domain: AppConfig.hostname }),
+      origins: [],
+    },
+  },
+
+  // Test with the following browsers:
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: useDevServer ? 'yarn dev' : 'yarn start',
+    url: process.env.NEXT_PUBLIC_APP_ORIGIN,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/src/domain/headless-cms/__tests__/config.test.ts
+++ b/src/domain/headless-cms/__tests__/config.test.ts
@@ -1,0 +1,58 @@
+import AppConfig from '../config';
+
+describe('AppConfig', () => {
+  // Store original environment to restore later
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Clear cache and reset environment for each test
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    // Restore original environment
+    process.env = originalEnv;
+  });
+
+  describe('origin', () => {
+    it.each([
+      'http://localhost:3000',
+      'https://kultus.hel.fi',
+      'https://sub.example.com:1234/path',
+    ])('should return the NEXT_PUBLIC_APP_ORIGIN value (%s)', (appOrigin) => {
+      process.env.NEXT_PUBLIC_APP_ORIGIN = appOrigin;
+      expect(AppConfig.origin).toStrictEqual(appOrigin);
+    });
+
+    it('should throw error when NEXT_PUBLIC_APP_ORIGIN is undefined', () => {
+      delete process.env.NEXT_PUBLIC_APP_ORIGIN;
+      expect(() => AppConfig.origin).toThrow(
+        'Environment variable with name NEXT_PUBLIC_APP_ORIGIN was not found'
+      );
+    });
+
+    it('should throw error when NEXT_PUBLIC_APP_ORIGIN is empty string', () => {
+      process.env.NEXT_PUBLIC_APP_ORIGIN = '';
+      expect(() => AppConfig.origin).toThrow(
+        'Environment variable with name NEXT_PUBLIC_APP_ORIGIN was not found'
+      );
+    });
+  });
+
+  describe('hostname', () => {
+    it.each([
+      ['http://localhost:3000', 'localhost'],
+      ['https://kultus.hel.fi', 'kultus.hel.fi'],
+      ['https://sub.example.com:1234/path', 'sub.example.com'],
+    ])('should extract hostname from %s as %s', (origin, expected) => {
+      process.env.NEXT_PUBLIC_APP_ORIGIN = origin;
+      expect(AppConfig.hostname).toStrictEqual(expected);
+    });
+
+    it('should throw error when creating URL from invalid origin', () => {
+      process.env.NEXT_PUBLIC_APP_ORIGIN = 'invalid-url';
+      expect(() => AppConfig.hostname).toThrow();
+    });
+  });
+});

--- a/src/domain/headless-cms/config.ts
+++ b/src/domain/headless-cms/config.ts
@@ -5,6 +5,15 @@ class AppConfig {
       'NEXT_PUBLIC_APP_ORIGIN'
     );
   }
+
+  /**
+   * The hostname of the application.
+   * @example "localhost" or "kultus.hel.fi", so no protocol, port or pathname.
+   */
+  static get hostname() {
+    return new URL(AppConfig.origin).hostname;
+  }
+
   static get cmsGraphqlEndpoint() {
     return getEnvOrError(
       process.env.NEXT_PUBLIC_CMS_BASE_URL,

--- a/src/playwright/README.md
+++ b/src/playwright/README.md
@@ -1,0 +1,92 @@
+# Playwright Tests
+
+This directory contains [Playwright](https://playwright.dev/) tests for the Palvelutarjotin UI project.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Project Structure](#project-structure)
+- [Setup](#setup)
+- [Running Tests](#running-tests)
+- [Page Object Model](#page-object-model)
+- [Test Fixtures](#test-fixtures)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Project Structure
+
+```
+src/playwright/
+├── pages/               # Page object models
+│   ...
+│   └── search.page.ts   # e.g. SearchPage page object model
+├── tests/               # Tests
+│   ...
+│   └── search.spec.ts   # e.g. search related tests
+├── testWithFixtures.ts  # Test fixtures setup
+```
+
+## Setup
+
+- Run `yarn playwright install` to install the [browsers](https://playwright.dev/docs/browsers)
+- Copy `.env.playwright.local.example` to `.env.playwright.local` in project root
+  - This is needed to set `NEXT_PUBLIC_APP_ORIGIN` (i.e. where the UI is) for the Playwright tests
+
+## Running Tests
+
+See [Playwright's Running and debugging tests](https://playwright.dev/docs/running-tests) documentation.
+
+Using the **production build** of the UI for testing is **recommended**,
+because the development server can be so slow as to make the tests fail.
+
+But, if it happens that in your environment the development server is fast enough,
+you can use it by setting:
+- `PLAYWRIGHT_WEB_SERVER=development` in `.env.playwright.local`
+
+Otherwise the Playwright tests will use the production build.
+
+If you chose to use the production build, build it with `yarn build` before running the tests.
+
+Then run the Playwright tests:
+```bash
+yarn test:browser
+```
+which will spin up the web server and run all tests.
+
+Other useful commands (from [Running and debugging tests](https://playwright.dev/docs/running-tests)):
+
+- Start interactive UI mode: `yarn test:browser --ui`
+- Run tests only on Desktop Chrome: `yarn test:browser --project=chromium`
+- Run tests in a specific file: `yarn test:browser filename`
+- Run tests in debug mode: `yarn test:browser --debug`
+- Run last failed tests: `yarn test:browser --last-failed`
+- Autogenerate tests with [codegen](https://playwright.dev/docs/codegen): `yarn codegen:browser`
+
+## Page Object Model
+
+The tests use the [Page Object Model](https://playwright.dev/docs/pom) pattern to represent different pages in the application:
+
+- [BasePage](./pages/base.page.ts) - Base class for all page objects
+  - [SearchCapablePage](./pages/searchCapable.page.ts) - Base class for pages that have a search box
+    - [FrontPage](./pages/front.page.ts) - Main landing page with language variants
+    - [SearchPage](./pages/search.page.ts) - Search results page
+  - [CmsPage](./pages/cms.page.ts) - Content management system page
+    - [AccessibilityStatementCmsPage](./pages/accessibilityStatementCms.page.ts) - Accessibility statement page
+
+## Test Fixtures
+
+[Fixtures](https://playwright.dev/docs/test-fixtures) provide convenient access to page objects in tests, e.g.:
+
+```typescript
+// NOTE: Must import test from testWithFixtures or custom fixtures won't be available!
+import { test } from '../testWithFixtures';
+
+test('search button works', async ({ frontPageEn, searchPage }) => {
+  await frontPageEn.clickSearchButton('Search events');
+  await searchPage.isReady();
+  await searchPage.isEnglish();
+});
+```
+
+Available custom fixtures can be seen in [custom fixtures file](./testWithFixtures.ts).

--- a/src/playwright/constants.ts
+++ b/src/playwright/constants.ts
@@ -1,0 +1,1 @@
+export const LANGUAGES = ['fi', 'sv', 'en'] as const;

--- a/src/playwright/pages/accessibilityStatementCms.page.ts
+++ b/src/playwright/pages/accessibilityStatementCms.page.ts
@@ -1,0 +1,25 @@
+import type { Page } from '@playwright/test';
+
+import type { Timeout } from '../types';
+import { CmsPage } from './cms.page';
+
+export class AccessibilityStatementCmsPage extends CmsPage {
+  protected readonly timeout: Timeout;
+
+  constructor(page: Page) {
+    super(page);
+    this.timeout = { timeout: 10_000 }; // CMS page load can be slow
+  }
+
+  async isFinnish() {
+    await this.hasTitle('Saavutettavuusseloste', this.timeout);
+  }
+
+  async isSwedish() {
+    await this.hasTitle('Tillgänglighetsutlåtande', this.timeout);
+  }
+
+  async isEnglish() {
+    await this.hasTitle('Accessibility Statement', this.timeout);
+  }
+}

--- a/src/playwright/pages/base.page.ts
+++ b/src/playwright/pages/base.page.ts
@@ -1,0 +1,80 @@
+import type { Locator, Page } from '@playwright/test';
+import isEqual from 'lodash/isEqual';
+
+import { expect } from '../testWithFixtures';
+import type { FooterLink, HeaderButton, Timeout } from '../types';
+
+export class BasePage {
+  protected readonly page: Page;
+  protected readonly h1: Locator;
+  protected readonly footer: Locator;
+  protected readonly header: Locator;
+  protected readonly mainContent: Locator;
+  protected readonly cookieConsentBox: Locator;
+  protected readonly cookieConsentApprove: Locator;
+
+  constructor(page: Page) {
+    if (this.constructor === BasePage) {
+      throw new Error(
+        'Abstract BasePage class cannot be instantiated directly'
+      );
+    }
+    this.page = page;
+    this.h1 = page.locator('h1');
+    this.header = page.getByRole('banner');
+    this.footer = page.getByRole('contentinfo');
+    this.mainContent = page.locator('#main-content');
+    this.cookieConsentBox = page.locator('#cookie-consent-content');
+    this.cookieConsentApprove = page.getByTestId(
+      'cookie-consent-approve-required-button'
+    );
+  }
+
+  async isReady() {
+    await this.page.waitForLoadState('networkidle', { timeout: 10_000 }); // Network can be slow
+  }
+
+  async reload() {
+    return await this.page.reload();
+  }
+
+  async clickFooterLink(name: FooterLink) {
+    await this.footer.getByRole('link', { name }).first().click();
+  }
+
+  async clickHeaderButton(name: HeaderButton) {
+    await this.header.getByRole('button', { name }).first().click();
+  }
+
+  async isCookieConsentBoxVisible() {
+    await expect(this.cookieConsentBox).toBeVisible();
+  }
+
+  async isCookieConsentBoxHidden(timeout?: Timeout) {
+    await expect(this.cookieConsentBox).not.toBeVisible(timeout);
+  }
+
+  /**
+   * Wait for given milliseconds.
+   * @param delayMs milliseconds to wait
+   */
+  async waitForMs(delayMs: number) {
+    await this.page.waitForTimeout(delayMs);
+  }
+
+  async approveCookies() {
+    await this.cookieConsentApprove.click();
+  }
+
+  async containsSearchParams(searchParams: URLSearchParams) {
+    await expect(this.page).toHaveURL((url) =>
+      [...searchParams.keys()].every((key) =>
+        isEqual(url.searchParams.get(key), searchParams.get(key))
+      )
+    );
+  }
+
+  protected async hasTitle(text: string, timeout?: Timeout) {
+    await expect(this.h1).toContainText(text, timeout);
+  }
+}

--- a/src/playwright/pages/cms.page.ts
+++ b/src/playwright/pages/cms.page.ts
@@ -1,0 +1,18 @@
+import type { Page } from '@playwright/test';
+
+import { BasePage } from './base.page';
+import { LANGUAGES } from '../constants';
+import { expect } from '../testWithFixtures';
+
+export class CmsPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async isReady() {
+    await super.isReady();
+    await expect(this.page).toHaveURL((url) =>
+      LANGUAGES.some((lang) => url.pathname.startsWith(`/${lang}/cms-page/`))
+    );
+  }
+}

--- a/src/playwright/pages/front.page.ts
+++ b/src/playwright/pages/front.page.ts
@@ -1,0 +1,30 @@
+import type { Page } from '@playwright/test';
+
+import { SearchCapablePage } from './searchCapable.page';
+import type { Language } from '../../types';
+
+type AllowedFrontPagePaths = '/' | `/${Language}`;
+
+export class FrontPage extends SearchCapablePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  static async create(page: Page, path: AllowedFrontPagePaths) {
+    const frontPage = new FrontPage(page);
+    await frontPage.page.goto(path);
+    return frontPage;
+  }
+
+  async isFinnish() {
+    await this.hasTitle('Kulttuuri- ja toimintakalenteri');
+  }
+
+  async isSwedish() {
+    await this.hasTitle('Kultur- och verksamhetskalendern');
+  }
+
+  async isEnglish() {
+    await this.hasTitle('Cultural and activity calendar');
+  }
+}

--- a/src/playwright/pages/search.page.ts
+++ b/src/playwright/pages/search.page.ts
@@ -1,0 +1,43 @@
+import type { Page } from '@playwright/test';
+
+import type { Language } from '../../types';
+import { LANGUAGES } from '../constants';
+import { expect } from '../testWithFixtures';
+import { SearchCapablePage } from './searchCapable.page';
+
+const EVENT_COUNT_REGEX = {
+  fi: /Tapahtumat \d+ kpl/,
+  sv: /Evenemang \d+ st/,
+  en: /Events \d+ pc/,
+} as const;
+
+export class SearchPage extends SearchCapablePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async isReady() {
+    await super.isReady();
+    await expect(this.page).toHaveURL((url) =>
+      LANGUAGES.some((lang) => url.pathname == `/${lang}/search`)
+    );
+  }
+
+  async isFinnish() {
+    return await this.testEventCountHeading('fi');
+  }
+
+  async isSwedish() {
+    return await this.testEventCountHeading('sv');
+  }
+
+  async isEnglish() {
+    return await this.testEventCountHeading('en');
+  }
+
+  private async testEventCountHeading(lang: Language) {
+    return await expect(
+      this.page.getByRole('heading', { name: EVENT_COUNT_REGEX[lang] })
+    ).toBeVisible({ timeout: 10_000 }); // Search page load can be slow
+  }
+}

--- a/src/playwright/pages/searchCapable.page.ts
+++ b/src/playwright/pages/searchCapable.page.ts
@@ -1,0 +1,29 @@
+import type { Page } from '@playwright/test';
+
+import { BasePage } from './base.page';
+import type { SearchButton, SearchOption, SearchTextBox } from '../types';
+
+export class SearchCapablePage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+    if (this.constructor === SearchCapablePage) {
+      throw new Error(
+        'Abstract SearchCapablePage class cannot be instantiated directly'
+      );
+    }
+  }
+
+  async clickSearchOption(name: SearchOption) {
+    await this.mainContent.getByRole('option', { name }).first().click();
+  }
+
+  async fillSearchTextBox(name: SearchTextBox, value: string) {
+    const searchTextBox = this.page.getByRole('textbox', { name });
+    await searchTextBox.click(); // First open the text box by clicking on it
+    await searchTextBox.fill(value);
+  }
+
+  async clickSearchButton(name: SearchButton) {
+    await this.mainContent.getByRole('button', { name }).first().click();
+  }
+}

--- a/src/playwright/testWithFixtures.ts
+++ b/src/playwright/testWithFixtures.ts
@@ -1,0 +1,46 @@
+// Disable linter rule that erroneously thinks Playwright's use function is a React hook:
+/* eslint-disable react-hooks/rules-of-hooks */
+import { test as base } from '@playwright/test';
+
+import { AccessibilityStatementCmsPage } from './pages/accessibilityStatementCms.page';
+import { FrontPage } from './pages/front.page';
+import { SearchPage } from './pages/search.page';
+
+type TestFixtures = {
+  // Base fixtures
+  accessibilityStatementCmsPage: AccessibilityStatementCmsPage;
+  searchPage: SearchPage;
+  // Parametrized versions of base fixtures
+  frontPage: FrontPage;
+  frontPageFi: FrontPage;
+  frontPageSv: FrontPage;
+  frontPageEn: FrontPage;
+};
+
+export const test = base.extend<TestFixtures>({
+  accessibilityStatementCmsPage: async ({ page }, use) => {
+    await use(new AccessibilityStatementCmsPage(page));
+  },
+
+  searchPage: async ({ page }, use) => {
+    await use(new SearchPage(page));
+  },
+
+  frontPage: async ({ page }, use) => {
+    await use(await FrontPage.create(page, '/'));
+  },
+
+  frontPageFi: async ({ page }, use) => {
+    await use(await FrontPage.create(page, '/fi'));
+  },
+
+  frontPageSv: async ({ page }, use) => {
+    await use(await FrontPage.create(page, '/sv'));
+  },
+
+  frontPageEn: async ({ page }, use) => {
+    await use(await FrontPage.create(page, '/en'));
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/src/playwright/tests/accessibilityStatement.spec.ts
+++ b/src/playwright/tests/accessibilityStatement.spec.ts
@@ -1,0 +1,43 @@
+import { test } from '../testWithFixtures';
+
+test.describe(() => {
+  // These tests seem to be a bit flaky at times,
+  // so let's retry them a couple of times to avoid false negatives.
+  test.describe.configure({ retries: 2 });
+
+  test('Finnish accessibility statement available through footer link at /', async ({
+    frontPage,
+    accessibilityStatementCmsPage,
+  }) => {
+    await frontPage.clickFooterLink('Saavutettavuusseloste');
+    await accessibilityStatementCmsPage.isReady();
+    await accessibilityStatementCmsPage.isFinnish();
+  });
+
+  test('Finnish accessibility statement available through footer link at /fi', async ({
+    frontPageFi,
+    accessibilityStatementCmsPage,
+  }) => {
+    await frontPageFi.clickFooterLink('Saavutettavuusseloste');
+    await accessibilityStatementCmsPage.isReady();
+    await accessibilityStatementCmsPage.isFinnish();
+  });
+
+  test('Swedish accessibility statement available through footer link at /sv', async ({
+    frontPageSv,
+    accessibilityStatementCmsPage,
+  }) => {
+    await frontPageSv.clickFooterLink('Tillgänglighetsutlåtande');
+    await accessibilityStatementCmsPage.isReady();
+    await accessibilityStatementCmsPage.isSwedish();
+  });
+
+  test('English accessibility statement available through footer link at /en', async ({
+    frontPageEn,
+    accessibilityStatementCmsPage,
+  }) => {
+    await frontPageEn.clickFooterLink('Accessibility Statement');
+    await accessibilityStatementCmsPage.isReady();
+    await accessibilityStatementCmsPage.isEnglish();
+  });
+});

--- a/src/playwright/tests/cookieConsent.ts
+++ b/src/playwright/tests/cookieConsent.ts
@@ -1,0 +1,32 @@
+import AppConfig from '../../domain/headless-cms/config';
+import { getCookieConsentGivenCookies } from '../../utils/getCookieConsentGivenCookies';
+import { test, expect } from '../testWithFixtures';
+
+test('cookie consent is given by default', async ({ context }) => {
+  const cookies = await context.cookies();
+  expect(cookies).toEqual(
+    expect.arrayContaining(
+      getCookieConsentGivenCookies({ domain: AppConfig.hostname })
+    )
+  );
+});
+
+test('cookie consent box shows up, and can be approved', async ({
+  frontPage,
+  context,
+}) => {
+  await context.clearCookies();
+  await frontPage.reload();
+  await frontPage.isCookieConsentBoxVisible();
+  await frontPage.approveCookies();
+  await frontPage.isCookieConsentBoxHidden();
+});
+
+[0, 2_000, 5_000].forEach((delayMs) => {
+  test(`cookie consent box does not show after ${delayMs}ms when cookies are already set`, async ({
+    frontPage,
+  }) => {
+    await frontPage.waitForMs(delayMs);
+    await frontPage.isCookieConsentBoxHidden({ timeout: 0 }); // Instant check
+  });
+});

--- a/src/playwright/tests/languageChange.spec.ts
+++ b/src/playwright/tests/languageChange.spec.ts
@@ -1,0 +1,40 @@
+import { test } from '../testWithFixtures';
+
+test.describe(() => {
+  // Front page language tests can be a bit flaky when run in parallel
+  // with other tests, so let's retry them a couple of times to avoid false negatives.
+  test.describe.configure({ retries: 2 });
+
+  test('front page language can be changed using header language selector', async ({
+    frontPage,
+  }) => {
+    await frontPage.clickHeaderButton('Suomi');
+    await frontPage.isReady();
+    await frontPage.isFinnish();
+    await frontPage.clickHeaderButton('Svenska');
+    await frontPage.isReady();
+    await frontPage.isSwedish();
+    await frontPage.clickHeaderButton('English');
+    await frontPage.isReady();
+    await frontPage.isEnglish();
+    await frontPage.clickHeaderButton('Suomi');
+    await frontPage.isReady();
+    await frontPage.isFinnish();
+  });
+
+  test('/ page is in Finnish', async ({ frontPage }) => {
+    await frontPage.isFinnish();
+  });
+
+  test('/fi page is in Finnish', async ({ frontPageFi }) => {
+    await frontPageFi.isFinnish();
+  });
+
+  test('/sv page is in Swedish', async ({ frontPageSv }) => {
+    await frontPageSv.isSwedish();
+  });
+
+  test('/en page is in English', async ({ frontPageEn }) => {
+    await frontPageEn.isEnglish();
+  });
+});

--- a/src/playwright/tests/search.spec.ts
+++ b/src/playwright/tests/search.spec.ts
@@ -1,0 +1,79 @@
+import { test } from '../testWithFixtures';
+
+test.describe(() => {
+  // Search page tests are flaky, possibly because of network issues
+  // so let's retry them a couple of times to avoid false negatives.
+  test.describe.configure({ retries: 2 });
+
+  test(`pressing search button on Finnish front page goes to Finnish search page`, async ({
+    frontPageFi,
+    searchPage,
+  }) => {
+    await frontPageFi.clickSearchButton('Hae tapahtumia');
+    await searchPage.isReady();
+    await searchPage.isFinnish();
+  });
+
+  test(`pressing search button on Swedish front page goes to Swedish search page`, async ({
+    frontPageSv,
+    searchPage,
+  }) => {
+    await frontPageSv.clickSearchButton('Sök evenemang');
+    await searchPage.isReady();
+    await searchPage.isSwedish();
+  });
+
+  test(`pressing search button on English front page goes to English search page`, async ({
+    frontPageEn,
+    searchPage,
+  }) => {
+    await frontPageEn.clickSearchButton('Search events');
+    await searchPage.isReady();
+    await searchPage.isEnglish();
+  });
+
+  test(`searching with text and target group on Finnish front page goes to Finnish search page`, async ({
+    frontPageFi,
+    searchPage,
+  }) => {
+    await frontPageFi.clickSearchButton('Kohderyhmät');
+    await frontPageFi.clickSearchOption('0-2 vuotiaat');
+    await frontPageFi.fillSearchTextBox('Hae tapahtumia', 'Testiteksti');
+    await frontPageFi.clickSearchButton('Hae tapahtumia');
+    await searchPage.isReady();
+    await searchPage.isFinnish();
+    await searchPage.containsSearchParams(
+      new URLSearchParams({ text: 'Testiteksti', targetGroups: 'kultus:40' })
+    );
+  });
+
+  test(`searching with text and target group on Swedish front page goes to Swedish search page`, async ({
+    frontPageSv,
+    searchPage,
+  }) => {
+    await frontPageSv.clickSearchButton('Målgrupp');
+    await frontPageSv.clickSearchOption('0-2 år');
+    await frontPageSv.fillSearchTextBox('Sök evenemang', 'Testtext');
+    await frontPageSv.clickSearchButton('Sök evenemang');
+    await searchPage.isReady();
+    await searchPage.isSwedish();
+    await searchPage.containsSearchParams(
+      new URLSearchParams({ text: 'Testtext', targetGroups: 'kultus:40' })
+    );
+  });
+
+  test(`searching with text and target group on English front page goes to English search page`, async ({
+    frontPageEn,
+    searchPage,
+  }) => {
+    await frontPageEn.clickSearchButton('Target groups');
+    await frontPageEn.clickSearchOption('0-2 years');
+    await frontPageEn.fillSearchTextBox('Search events', 'Test text');
+    await frontPageEn.clickSearchButton('Search events');
+    await searchPage.isReady();
+    await searchPage.isEnglish();
+    await searchPage.containsSearchParams(
+      new URLSearchParams({ text: 'Test text', targetGroups: 'kultus:40' })
+    );
+  });
+});

--- a/src/playwright/types.ts
+++ b/src/playwright/types.ts
@@ -1,0 +1,16 @@
+export type Timeout = { timeout?: number };
+export type LanguageButton = 'Suomi' | 'Svenska' | 'English';
+export type HeaderButton = LanguageButton;
+export type AccessibilityStatement =
+  | 'Saavutettavuusseloste'
+  | 'Tillgänglighetsutlåtande'
+  | 'Accessibility Statement';
+export type FooterLink = AccessibilityStatement;
+
+export type TargetGroupButton = 'Kohderyhmät' | 'Målgrupp' | 'Target groups';
+export type ZeroToTwoYears = '0-2 vuotiaat' | '0-2 år' | '0-2 years';
+export type TargetGroupOption = ZeroToTwoYears;
+export type SearchOption = TargetGroupOption;
+export type SearchEvents = 'Hae tapahtumia' | 'Sök evenemang' | 'Search events';
+export type SearchButton = SearchEvents | TargetGroupButton;
+export type SearchTextBox = SearchEvents;

--- a/src/utils/__tests__/getCookieConsentGivenCookies.test.ts
+++ b/src/utils/__tests__/getCookieConsentGivenCookies.test.ts
@@ -1,0 +1,59 @@
+import { getCookieConsentGivenCookies } from '../getCookieConsentGivenCookies';
+
+const sharedCookieData = {
+  expires: -1,
+  httpOnly: false,
+  path: '/',
+  sameSite: 'Lax',
+  secure: false,
+} as const;
+
+const encodedCookieConsent =
+  // eslint-disable-next-line max-len
+  '%7B%22wordpress%22%3Atrue%2C%22linkedevents%22%3Atrue%2C%22i18next%22%3Atrue%2C%22city-of-helsinki-cookie-consents%22%3Atrue%2C%22city-of-helsinki-consent-version%22%3Atrue%2C%22matomo%22%3Atrue%7D' as const;
+
+describe('getCookieConsentGivenCookies', () => {
+  test.each([
+    {
+      domain: 'localhost',
+      expectedResult: [
+        {
+          domain: 'localhost',
+          name: 'city-of-helsinki-consent-version',
+          value: '1',
+          ...sharedCookieData,
+        },
+        {
+          domain: 'localhost',
+          name: 'city-of-helsinki-cookie-consents',
+          value: encodedCookieConsent,
+          ...sharedCookieData,
+        },
+      ],
+    },
+    {
+      domain: 'kultus.hel.fi',
+      expectedResult: [
+        {
+          domain: '.kultus.hel.fi',
+          name: 'city-of-helsinki-consent-version',
+          value: '1',
+          ...sharedCookieData,
+        },
+        {
+          domain: '.kultus.hel.fi',
+          name: 'city-of-helsinki-cookie-consents',
+          value: encodedCookieConsent,
+          ...sharedCookieData,
+        },
+      ],
+    },
+  ])(
+    'getCookieConsentGivenCookies({ domain: "$domain"}) returns expected result',
+    ({ domain, expectedResult }) => {
+      expect(getCookieConsentGivenCookies({ domain })).toStrictEqual(
+        expectedResult
+      );
+    }
+  );
+});

--- a/src/utils/getCookieConsentGivenCookies.ts
+++ b/src/utils/getCookieConsentGivenCookies.ts
@@ -1,0 +1,39 @@
+type CookieProps = {
+  domain: string;
+};
+
+const getSharedCookieData = ({ domain }: CookieProps) =>
+  ({
+    path: '/',
+    domain: domain == 'localhost' ? domain : `.${domain}`,
+    expires: -1,
+    httpOnly: false,
+    secure: false,
+    sameSite: 'Lax',
+  }) as const;
+
+/**
+ * Get the cookies that are set when the user has given consent to all cookies.
+ * @param props - Cookie properties, e.g. domain
+ */
+export const getCookieConsentGivenCookies = (props: CookieProps) => [
+  {
+    name: 'city-of-helsinki-consent-version',
+    value: '1',
+    ...getSharedCookieData(props),
+  },
+  {
+    name: 'city-of-helsinki-cookie-consents',
+    value: encodeURIComponent(
+      JSON.stringify({
+        wordpress: true,
+        linkedevents: true,
+        i18next: true,
+        'city-of-helsinki-cookie-consents': true,
+        'city-of-helsinki-consent-version': true,
+        matomo: true,
+      })
+    ),
+    ...getSharedCookieData(props),
+  },
+];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "dom",
       "dom.iterable",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,6 +2083,13 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.0.tgz#8dff61038cb5884789d8b323d9869e5363b976f7"
   integrity sha512-vsJDAkYR6qCPu+ioGScGiMYR7LvZYIXh/dlQeviqoTWNCVfKTLYD/LkNWH4Mxsv2a5vpIRc77FN5DnmK1eBggQ==
 
+"@playwright/test@^1.52.0":
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.52.0.tgz#267ec595b43a8f4fa5e444ea503689629e91a5b8"
+  integrity sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==
+  dependencies:
+    playwright "1.52.0"
+
 "@popperjs/core@2.11.5":
   version "2.11.5"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
@@ -2427,26 +2434,6 @@
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
   integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
 
-"@textlint/ast-node-types@^12.6.1":
-  version "12.6.1"
-  resolved "https://registry.yarnpkg.com/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz#35ecefe74e701d7f632c083d4fda89cab1b89012"
-  integrity sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==
-
-"@textlint/markdown-to-ast@^12.1.1":
-  version "12.6.1"
-  resolved "https://registry.yarnpkg.com/@textlint/markdown-to-ast/-/markdown-to-ast-12.6.1.tgz#fcccb5733b3e76cd0db78a323763ab101f2d803b"
-  integrity sha512-T0HO+VrU9VbLRiEx/kH4+gwGMHNMIGkp0Pok+p0I33saOOLyhfGvwOKQgvt2qkxzQEV2L5MtGB8EnW4r5d3CqQ==
-  dependencies:
-    "@textlint/ast-node-types" "^12.6.1"
-    debug "^4.3.4"
-    mdast-util-gfm-autolink-literal "^0.1.3"
-    remark-footnotes "^3.0.0"
-    remark-frontmatter "^3.0.0"
-    remark-gfm "^1.0.0"
-    remark-parse "^9.0.0"
-    traverse "^0.6.7"
-    unified "^9.2.2"
-
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
@@ -2626,13 +2613,6 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.16.tgz#94ae78fab4a38d73086e962d0b65c30d816bfb0a"
   integrity sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==
 
-"@types/mdast@^3.0.0":
-  version "3.0.15"
-  resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.15.tgz#49c524a263f30ffa28b71ae282f813ed000ab9f5"
-  integrity sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==
-  dependencies:
-    "@types/unist" "^2"
-
 "@types/node@*":
   version "22.13.16"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.16.tgz#802cff8e4c3b3fc7461c2adcc92d73d89779edad"
@@ -2698,11 +2678,6 @@
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
-
-"@types/unist@^2", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.11.tgz#11af57b127e32487774841f7a4e54eab166d03c4"
-  integrity sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==
 
 "@types/ws@^8.0.0":
   version "8.18.1"
@@ -3078,13 +3053,6 @@ ajv@^8.0.1, ajv@^8.11.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
 
-anchor-markdown-header@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/anchor-markdown-header/-/anchor-markdown-header-0.6.0.tgz#908f2031281766f44ac350380ca0de77ab7065b8"
-  integrity sha512-v7HJMtE1X7wTpNFseRhxsY/pivP4uAJbidVhPT+yhz4i/vV1+qx371IXuV9V7bN6KjFtheLJxqaSm0Y/8neJTA==
-  dependencies:
-    emoji-regex "~10.1.0"
-
 ansi-escapes@^4.2.1, ansi-escapes@^4.3.0, ansi-escapes@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
@@ -3434,11 +3402,6 @@ babel-preset-jest@^29.6.3:
     babel-plugin-jest-hoist "^29.6.3"
     babel-preset-current-node-syntax "^1.0.0"
 
-bail@^1.0.0:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.5.tgz#b6fa133404a392cbc1f8c4bf63f5953351e7a776"
-  integrity sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -3608,11 +3571,6 @@ capital-case@^1.0.4:
     tslib "^2.0.3"
     upper-case-first "^2.0.2"
 
-ccount@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
-  integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
-
 chalk@4.1.2, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -3688,21 +3646,6 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
-
-character-entities-legacy@^1.0.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz#94bc1845dce70a5bb9d2ecc748725661293d8fc1"
-  integrity sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==
-
-character-entities@^1.0.0:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.4.tgz#e12c3939b7eaf4e5b15e7ad4c5e28e1d48c5b16b"
-  integrity sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==
-
-character-reference-invalid@^1.0.0:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz#083329cda0eae272ab3dbbf37e9a382c13af1560"
-  integrity sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -4173,7 +4116,7 @@ debounce@^1.2.0:
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
-debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.7, debug@^4.4.0:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.7, debug@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
@@ -4284,18 +4227,6 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-doctoc@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/doctoc/-/doctoc-2.2.1.tgz#83f6a6bf4df97defbe027c9a82d13091a138ffe2"
-  integrity sha512-qNJ1gsuo7hH40vlXTVVrADm6pdg30bns/Mo7Nv1SxuXSM1bwF9b4xQ40a6EFT/L1cI+Yylbyi8MPI4G4y7XJzQ==
-  dependencies:
-    "@textlint/markdown-to-ast" "^12.1.1"
-    anchor-markdown-header "^0.6.0"
-    htmlparser2 "^7.2.0"
-    minimist "^1.2.6"
-    underscore "^1.13.2"
-    update-section "^0.3.3"
-
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
@@ -4313,15 +4244,6 @@ dom-accessibility-api@^0.6.3:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
-dom-serializer@^1.0.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.4.1.tgz#de5d41b1aea290215dc45a6dae8adcf1d32e2d30"
-  integrity sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^4.2.0"
-    entities "^2.0.0"
-
 dom-serializer@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
@@ -4331,7 +4253,7 @@ dom-serializer@^2.0.0:
     domhandler "^5.0.2"
     entities "^4.2.0"
 
-domelementtype@^2.0.1, domelementtype@^2.2.0, domelementtype@^2.3.0:
+domelementtype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
@@ -4350,28 +4272,12 @@ domhandler@5.0.3, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-domhandler@^4.2.0, domhandler@^4.2.2:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
-  integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
-  dependencies:
-    domelementtype "^2.2.0"
-
 dompurify@*, dompurify@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.4.tgz#af5a5a11407524431456cf18836c55d13441cd8e"
   integrity sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
-
-domutils@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
-  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
-  dependencies:
-    dom-serializer "^1.0.1"
-    domelementtype "^2.2.0"
-    domhandler "^4.2.0"
 
 domutils@^3.1.0:
   version "3.2.2"
@@ -4457,21 +4363,6 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
-
-emoji-regex@~10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.1.0.tgz#d50e383743c0f7a5945c47087295afc112e3cf66"
-  integrity sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==
-
-entities@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
-  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
-
-entities@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
-  integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
 entities@^4.2.0, entities@^4.5.0:
   version "4.5.0"
@@ -4928,11 +4819,6 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-extend@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
-  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
 external-editor@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
@@ -5010,13 +4896,6 @@ fastq@^1.6.0:
   integrity sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==
   dependencies:
     reusify "^1.0.4"
-
-fault@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/fault/-/fault-1.0.4.tgz#eafcfc0a6d214fc94601e170df29954a4f842f13"
-  integrity sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==
-  dependencies:
-    format "^0.2.0"
 
 fb-watchman@^2.0.0:
   version "2.0.2"
@@ -5165,11 +5044,6 @@ form-data@^4.0.0, form-data@^4.0.1:
     es-set-tostringtag "^2.1.0"
     mime-types "^2.1.12"
 
-format@^0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
-  integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
-
 formdata-polyfill@^4.0.10:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
@@ -5195,6 +5069,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@^2.3.2:
   version "2.3.3"
@@ -5638,16 +5517,6 @@ htmlparser2@9.0.0:
     domutils "^3.1.0"
     entities "^4.5.0"
 
-htmlparser2@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-7.2.0.tgz#8817cdea38bbc324392a90b1990908e81a65f5a5"
-  integrity sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^4.2.2"
-    domutils "^2.8.0"
-    entities "^3.0.1"
-
 http-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz#5129800203520d434f142bc78ff3c170800f2b43"
@@ -5889,19 +5758,6 @@ is-absolute@^1.0.0:
     is-relative "^1.0.0"
     is-windows "^1.0.1"
 
-is-alphabetical@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
-  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
-
-is-alphanumerical@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
-  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
-  dependencies:
-    is-alphabetical "^1.0.0"
-    is-decimal "^1.0.0"
-
 is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz#65742e1e687bd2cc666253068fd8707fe4d44280"
@@ -5942,11 +5798,6 @@ is-boolean-object@^1.2.1:
     call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
 
-is-buffer@^2.0.0:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
-  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
-
 is-bun-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-bun-module/-/is-bun-module-2.0.0.tgz#4d7859a87c0fcac950c95e666730e745eae8bddd"
@@ -5982,11 +5833,6 @@ is-date-object@^1.0.5, is-date-object@^1.1.0:
   dependencies:
     call-bound "^1.0.2"
     has-tostringtag "^1.0.2"
-
-is-decimal@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
-  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -6039,11 +5885,6 @@ is-glob@4.0.3, is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   dependencies:
     is-extglob "^2.1.1"
 
-is-hexadecimal@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
-  integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
-
 is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
@@ -6083,11 +5924,6 @@ is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
   integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
-
-is-plain-obj@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
-  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
 is-plain-object@^5.0.0:
   version "5.0.0"
@@ -7131,11 +6967,6 @@ log-update@^6.1.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
-longest-streak@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
-  integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
-
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -7198,13 +7029,6 @@ map-cache@^0.2.0:
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==
 
-markdown-table@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-2.0.0.tgz#194a90ced26d31fe753d8b9434430214c011865b"
-  integrity sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==
-  dependencies:
-    repeat-string "^1.0.0"
-
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
@@ -7214,100 +7038,6 @@ mathml-tag-names@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
   integrity sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
-
-mdast-util-find-and-replace@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-1.1.1.tgz#b7db1e873f96f66588c321f1363069abf607d1b5"
-  integrity sha512-9cKl33Y21lyckGzpSmEQnIDjEfeeWelN5s1kUW1LwdB0Fkuq2u+4GdqcGEygYxJE8GVqCl0741bYXHgamfWAZA==
-  dependencies:
-    escape-string-regexp "^4.0.0"
-    unist-util-is "^4.0.0"
-    unist-util-visit-parents "^3.0.0"
-
-mdast-util-footnote@^0.1.0:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/mdast-util-footnote/-/mdast-util-footnote-0.1.7.tgz#4b226caeab4613a3362c144c94af0fdd6f7e0ef0"
-  integrity sha512-QxNdO8qSxqbO2e3m09KwDKfWiLgqyCurdWTQ198NpbZ2hxntdc+VKS4fDJCmNWbAroUdYnSthu+XbZ8ovh8C3w==
-  dependencies:
-    mdast-util-to-markdown "^0.6.0"
-    micromark "~2.11.0"
-
-mdast-util-from-markdown@^0.8.0:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
-  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    mdast-util-to-string "^2.0.0"
-    micromark "~2.11.0"
-    parse-entities "^2.0.0"
-    unist-util-stringify-position "^2.0.0"
-
-mdast-util-frontmatter@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-frontmatter/-/mdast-util-frontmatter-0.2.0.tgz#8bd5cd55e236c03e204a036f7372ebe9e6748240"
-  integrity sha512-FHKL4w4S5fdt1KjJCwB0178WJ0evnyyQr5kXTM3wrOVpytD0hrkvd+AOOjU9Td8onOejCkmZ+HQRT3CZ3coHHQ==
-  dependencies:
-    micromark-extension-frontmatter "^0.2.0"
-
-mdast-util-gfm-autolink-literal@^0.1.0, mdast-util-gfm-autolink-literal@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz#9c4ff399c5ddd2ece40bd3b13e5447d84e385fb7"
-  integrity sha512-GjmLjWrXg1wqMIO9+ZsRik/s7PLwTaeCHVB7vRxUwLntZc8mzmTsLVr6HW1yLokcnhfURsn5zmSVdi3/xWWu1A==
-  dependencies:
-    ccount "^1.0.0"
-    mdast-util-find-and-replace "^1.1.0"
-    micromark "^2.11.3"
-
-mdast-util-gfm-strikethrough@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-0.2.3.tgz#45eea337b7fff0755a291844fbea79996c322890"
-  integrity sha512-5OQLXpt6qdbttcDG/UxYY7Yjj3e8P7X16LzvpX8pIQPYJ/C2Z1qFGMmcw+1PZMUM3Z8wt8NRfYTvCni93mgsgA==
-  dependencies:
-    mdast-util-to-markdown "^0.6.0"
-
-mdast-util-gfm-table@^0.1.0:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-table/-/mdast-util-gfm-table-0.1.6.tgz#af05aeadc8e5ee004eeddfb324b2ad8c029b6ecf"
-  integrity sha512-j4yDxQ66AJSBwGkbpFEp9uG/LS1tZV3P33fN1gkyRB2LoRL+RR3f76m0HPHaby6F4Z5xr9Fv1URmATlRRUIpRQ==
-  dependencies:
-    markdown-table "^2.0.0"
-    mdast-util-to-markdown "~0.6.0"
-
-mdast-util-gfm-task-list-item@^0.1.0:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-0.1.6.tgz#70c885e6b9f543ddd7e6b41f9703ee55b084af10"
-  integrity sha512-/d51FFIfPsSmCIRNp7E6pozM9z1GYPIkSy1urQ8s/o4TC22BZ7DqfHFWiqBD23bc7J3vV1Fc9O4QIHBlfuit8A==
-  dependencies:
-    mdast-util-to-markdown "~0.6.0"
-
-mdast-util-gfm@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/mdast-util-gfm/-/mdast-util-gfm-0.1.2.tgz#8ecddafe57d266540f6881f5c57ff19725bd351c"
-  integrity sha512-NNkhDx/qYcuOWB7xHUGWZYVXvjPFFd6afg6/e2g+SV4r9q5XUcCbV4Wfa3DLYIiD+xAEZc6K4MGaE/m0KDcPwQ==
-  dependencies:
-    mdast-util-gfm-autolink-literal "^0.1.0"
-    mdast-util-gfm-strikethrough "^0.2.0"
-    mdast-util-gfm-table "^0.1.0"
-    mdast-util-gfm-task-list-item "^0.1.0"
-    mdast-util-to-markdown "^0.6.1"
-
-mdast-util-to-markdown@^0.6.0, mdast-util-to-markdown@^0.6.1, mdast-util-to-markdown@~0.6.0:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz#b33f67ca820d69e6cc527a93d4039249b504bebe"
-  integrity sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    longest-streak "^2.0.0"
-    mdast-util-to-string "^2.0.0"
-    parse-entities "^2.0.0"
-    repeat-string "^1.0.0"
-    zwitch "^1.0.0"
-
-mdast-util-to-string@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
-  integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
 
 mdn-data@2.0.14:
   version "2.0.14"
@@ -7353,73 +7083,6 @@ meros@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/meros/-/meros-1.3.0.tgz#c617d2092739d55286bf618129280f362e6242f2"
   integrity sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==
-
-micromark-extension-footnote@^0.3.0:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/micromark-extension-footnote/-/micromark-extension-footnote-0.3.2.tgz#129b74ef4920ce96719b2c06102ee7abb2b88a20"
-  integrity sha512-gr/BeIxbIWQoUm02cIfK7mdMZ/fbroRpLsck4kvFtjbzP4yi+OPVbnukTc/zy0i7spC2xYE/dbX1Sur8BEDJsQ==
-  dependencies:
-    micromark "~2.11.0"
-
-micromark-extension-frontmatter@^0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/micromark-extension-frontmatter/-/micromark-extension-frontmatter-0.2.2.tgz#61b8e92e9213e1d3c13f5a59e7862f5ca98dfa53"
-  integrity sha512-q6nPLFCMTLtfsctAuS0Xh4vaolxSFUWUWR6PZSrXXiRy+SANGllpcqdXFv2z07l0Xz/6Hl40hK0ffNCJPH2n1A==
-  dependencies:
-    fault "^1.0.0"
-
-micromark-extension-gfm-autolink-literal@~0.5.0:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-0.5.7.tgz#53866c1f0c7ef940ae7ca1f72c6faef8fed9f204"
-  integrity sha512-ePiDGH0/lhcngCe8FtH4ARFoxKTUelMp4L7Gg2pujYD5CSMb9PbblnyL+AAMud/SNMyusbS2XDSiPIRcQoNFAw==
-  dependencies:
-    micromark "~2.11.3"
-
-micromark-extension-gfm-strikethrough@~0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-0.6.5.tgz#96cb83356ff87bf31670eefb7ad7bba73e6514d1"
-  integrity sha512-PpOKlgokpQRwUesRwWEp+fHjGGkZEejj83k9gU5iXCbDG+XBA92BqnRKYJdfqfkrRcZRgGuPuXb7DaK/DmxOhw==
-  dependencies:
-    micromark "~2.11.0"
-
-micromark-extension-gfm-table@~0.4.0:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-table/-/micromark-extension-gfm-table-0.4.3.tgz#4d49f1ce0ca84996c853880b9446698947f1802b"
-  integrity sha512-hVGvESPq0fk6ALWtomcwmgLvH8ZSVpcPjzi0AjPclB9FsVRgMtGZkUcpE0zgjOCFAznKepF4z3hX8z6e3HODdA==
-  dependencies:
-    micromark "~2.11.0"
-
-micromark-extension-gfm-tagfilter@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-0.3.0.tgz#d9f26a65adee984c9ccdd7e182220493562841ad"
-  integrity sha512-9GU0xBatryXifL//FJH+tAZ6i240xQuFrSL7mYi8f4oZSbc+NvXjkrHemeYP0+L4ZUT+Ptz3b95zhUZnMtoi/Q==
-
-micromark-extension-gfm-task-list-item@~0.3.0:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-0.3.3.tgz#d90c755f2533ed55a718129cee11257f136283b8"
-  integrity sha512-0zvM5iSLKrc/NQl84pZSjGo66aTGd57C1idmlWmE87lkMcXrTxg1uXa/nXomxJytoje9trP0NDLvw4bZ/Z/XCQ==
-  dependencies:
-    micromark "~2.11.0"
-
-micromark-extension-gfm@^0.3.0:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/micromark-extension-gfm/-/micromark-extension-gfm-0.3.3.tgz#36d1a4c089ca8bdfd978c9bd2bf1a0cb24e2acfe"
-  integrity sha512-oVN4zv5/tAIA+l3GbMi7lWeYpJ14oQyJ3uEim20ktYFAcfX1x3LNlFGGlmrZHt7u9YlKExmyJdDGaTt6cMSR/A==
-  dependencies:
-    micromark "~2.11.0"
-    micromark-extension-gfm-autolink-literal "~0.5.0"
-    micromark-extension-gfm-strikethrough "~0.6.5"
-    micromark-extension-gfm-table "~0.4.0"
-    micromark-extension-gfm-tagfilter "~0.3.0"
-    micromark-extension-gfm-task-list-item "~0.3.0"
-
-micromark@^2.11.3, micromark@~2.11.0, micromark@~2.11.3:
-  version "2.11.4"
-  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
-  integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
-  dependencies:
-    debug "^4.0.0"
-    parse-entities "^2.0.0"
 
 micromatch@^4.0.4, micromatch@^4.0.5, micromatch@^4.0.8:
   version "4.0.8"
@@ -7898,18 +7561,6 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
-parse-entities@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"
-  integrity sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==
-  dependencies:
-    character-entities "^1.0.0"
-    character-entities-legacy "^1.0.0"
-    character-reference-invalid "^1.0.0"
-    is-alphanumerical "^1.0.0"
-    is-decimal "^1.0.0"
-    is-hexadecimal "^1.0.0"
-
 parse-filepath@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/parse-filepath/-/parse-filepath-1.0.2.tgz#a632127f53aaf3d15876f5872f3ffac763d6c891"
@@ -8035,6 +7686,20 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.52.0.tgz#238f1f0c3edd4ebba0434ce3f4401900319a3dca"
+  integrity sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==
+
+playwright@1.52.0, playwright@^1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.52.0.tgz#26cb9a63346651e1c54c8805acfd85683173d4bd"
+  integrity sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==
+  dependencies:
+    playwright-core "1.52.0"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"
@@ -8399,37 +8064,6 @@ relay-runtime@12.0.0:
     fbjs "^3.0.0"
     invariant "^2.2.4"
 
-remark-footnotes@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/remark-footnotes/-/remark-footnotes-3.0.0.tgz#5756b56f8464fa7ed80dbba0c966136305d8cb8d"
-  integrity sha512-ZssAvH9FjGYlJ/PBVKdSmfyPc3Cz4rTWgZLI4iE/SX8Nt5l3o3oEjv3wwG5VD7xOjktzdwp5coac+kJV9l4jgg==
-  dependencies:
-    mdast-util-footnote "^0.1.0"
-    micromark-extension-footnote "^0.3.0"
-
-remark-frontmatter@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/remark-frontmatter/-/remark-frontmatter-3.0.0.tgz#ca5d996361765c859bd944505f377d6b186a6ec6"
-  integrity sha512-mSuDd3svCHs+2PyO29h7iijIZx4plX0fheacJcAoYAASfgzgVIcXGYSq9GFyYocFLftQs8IOmmkgtOovs6d4oA==
-  dependencies:
-    mdast-util-frontmatter "^0.2.0"
-    micromark-extension-frontmatter "^0.2.0"
-
-remark-gfm@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-1.0.0.tgz#9213643001be3f277da6256464d56fd28c3b3c0d"
-  integrity sha512-KfexHJCiqvrdBZVbQ6RopMZGwaXz6wFJEfByIuEwGf0arvITHjiKKZ1dpXujjH9KZdm1//XJQwgfnJ3lmXaDPA==
-  dependencies:
-    mdast-util-gfm "^0.1.0"
-    micromark-extension-gfm "^0.3.0"
-
-remark-parse@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-9.0.0.tgz#4d20a299665880e4f4af5d90b7c7b8a935853640"
-  integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
-  dependencies:
-    mdast-util-from-markdown "^0.8.0"
-
 remedial@^1.0.7:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/remedial/-/remedial-1.0.8.tgz#a5e4fd52a0e4956adbaf62da63a5a46a78c578a0"
@@ -8444,11 +8078,6 @@ remove-trailing-spaces@^1.0.6:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/remove-trailing-spaces/-/remove-trailing-spaces-1.0.9.tgz#39c270a309ea16fda84253ffbdeb1b5afa0aa271"
   integrity sha512-xzG7w5IRijvIkHIjDk65URsJJ7k4J95wmcArY5PRcmjldIOl7oTvG8+X2Ag690R7SfwiOcHrWZKVc1Pp5WIOzA==
-
-repeat-string@^1.0.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
-  integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -9428,20 +9057,6 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-traverse@^0.6.7:
-  version "0.6.11"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.11.tgz#e8daa071b101ae66767fffa6f177aa6f7110068e"
-  integrity sha512-vxXDZg8/+p3gblxB6BhhG5yWVn1kGRlaL8O78UDXc3wRnPizB5g83dcvWV1jpDMIPnjZjOFuxlMmE82XJ4407w==
-  dependencies:
-    gopd "^1.2.0"
-    typedarray.prototype.slice "^1.0.5"
-    which-typed-array "^1.1.18"
-
-trough@^1.0.0:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
-  integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
-
 ts-api-utils@^1.0.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.4.3.tgz#bfc2215fe6528fecab2b0fba570a2e8a4263b064"
@@ -9582,20 +9197,6 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
-typedarray.prototype.slice@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.5.tgz#a40f896968573b33cbb466a61622d3ee615a0728"
-  integrity sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg==
-  dependencies:
-    call-bind "^1.0.8"
-    define-properties "^1.2.1"
-    es-abstract "^1.23.9"
-    es-errors "^1.3.0"
-    get-proto "^1.0.1"
-    math-intrinsics "^1.1.0"
-    typed-array-buffer "^1.0.3"
-    typed-array-byte-offset "^1.0.4"
-
 typescript@^5.8.2:
   version "5.8.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
@@ -9621,11 +9222,6 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==
 
-underscore@^1.13.2:
-  version "1.13.7"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.7.tgz#970e33963af9a7dda228f17ebe8399e5fbe63a10"
-  integrity sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==
-
 undici-types@~6.19.2:
   version "6.19.8"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
@@ -9640,38 +9236,6 @@ unicorn-magic@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
   integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
-
-unified@^9.2.2:
-  version "9.2.2"
-  resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.2.tgz#67649a1abfc3ab85d2969502902775eb03146975"
-  integrity sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==
-  dependencies:
-    bail "^1.0.0"
-    extend "^3.0.0"
-    is-buffer "^2.0.0"
-    is-plain-obj "^2.0.0"
-    trough "^1.0.0"
-    vfile "^4.0.0"
-
-unist-util-is@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.1.0.tgz#976e5f462a7a5de73d94b706bac1b90671b57797"
-  integrity sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==
-
-unist-util-stringify-position@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz#cce3bfa1cdf85ba7375d1d5b17bdc4cada9bd9da"
-  integrity sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==
-  dependencies:
-    "@types/unist" "^2.0.2"
-
-unist-util-visit-parents@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz#65a6ce698f78a6b0f56aa0e88f13801886cdaef6"
-  integrity sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    unist-util-is "^4.0.0"
 
 universalify@^0.2.0:
   version "0.2.0"
@@ -9713,11 +9277,6 @@ update-browserslist-db@^1.1.1:
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.1"
-
-update-section@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/update-section/-/update-section-0.3.3.tgz#458f17820d37820dc60e20b86d94391b00123158"
-  integrity sha512-BpRZMZpgXLuTiKeiu7kK0nIPwGdyrqrs6EDSaXtjD/aQ2T+qVo9a5hRC3HN3iJjCMxNT/VxoLGQ7E/OzE5ucnw==
 
 upper-case-first@^2.0.2:
   version "2.0.2"
@@ -9789,24 +9348,6 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
-
-vfile-message@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-2.0.4.tgz#5b43b88171d409eae58477d13f23dd41d52c371a"
-  integrity sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    unist-util-stringify-position "^2.0.0"
-
-vfile@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/vfile/-/vfile-4.2.1.tgz#03f1dce28fc625c625bc6514350fbdb00fa9e624"
-  integrity sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    is-buffer "^2.0.0"
-    unist-util-stringify-position "^2.0.0"
-    vfile-message "^2.0.0"
 
 void-elements@3.1.0:
   version "3.1.0"
@@ -10165,8 +9706,3 @@ zen-observable@0.8.15:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
   integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
-
-zwitch@^1.0.0:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.5.tgz#d11d7381ffed16b742f6af7b3f223d5cd9fe9920"
-  integrity sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==


### PR DESCRIPTION
## Description :sparkles:

Done:
- Add basic playwright tests
- Run the playwright tests in Github actions

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[PT-1919](https://helsinkisolutionoffice.atlassian.net/browse/PT-1919)

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

See [src/playwright/README.md](https://github.com/City-of-Helsinki/palvelutarjotin-ui/blob/c1cf967cd2ba23e7ee941f8b741d6780832ffd28/src/playwright/README.md).

```bash
$ yarn playwright test
yarn run v1.22.22
$ C:\dev\projects\City-of-Helsinki\kultus-ui\node_modules\.bin\playwright test

Running 15 tests using 8 workers
  15 passed (15.8s)

To open last HTML report run:

  yarn playwright show-report

Done in 16.56s.
```

## Screenshots :camera_flash:

After running `yarn playwright test` I ran `yarn playwright show-report` and here's screenshot of that:
- ![playwright-show-report](https://github.com/user-attachments/assets/002219ed-02ab-4763-9cd8-ee4270dc2b73)

## Additional notes :spiral_notepad:


[PT-1919]: https://helsinkisolutionoffice.atlassian.net/browse/PT-1919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ