### PR TITLE
fix: only 1 enrolment notification should be shown at once

### DIFF
--- a/src/domain/event/occurrences/EnrolmentFormSection.tsx
+++ b/src/domain/event/occurrences/EnrolmentFormSection.tsx
@@ -1,5 +1,5 @@
 import { isApolloError } from '@apollo/client';
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
@@ -66,6 +66,7 @@ const EnrolmentFormSection: React.FC<{
           ...omit(router.query, [
             ENROLMENT_URL_PARAMS.EVENT_ID,
             ENROLMENT_URL_PARAMS.OCCURRENCES,
+            ENROLMENT_URL_PARAMS.QUEUE_CREATED, // Cannot queue and enrol at the same time
           ]),
           [ENROLMENT_URL_PARAMS.NOTIFICATION_TYPE]:
             data.data?.enrolOccurrence?.enrolments?.[0]?.notificationType,

--- a/src/domain/event/occurrences/QueueFormSection.tsx
+++ b/src/domain/event/occurrences/QueueFormSection.tsx
@@ -1,4 +1,4 @@
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
 import React from 'react';
@@ -55,6 +55,7 @@ const QueueFormSection: React.FC<{
           ...omit(router.query, [
             ENROLMENT_URL_PARAMS.EVENT_ID,
             ENROLMENT_URL_PARAMS.OCCURRENCES,
+            ENROLMENT_URL_PARAMS.ENROLMENT_CREATED, // Cannot queue and enrol at the same time
           ]),
           [ENROLMENT_URL_PARAMS.QUEUE_CREATED]: true,
         },


### PR DESCRIPTION
PT-1800.

The notifications of enrolment queue and enrolment reservation query are controlled with URL search parameters. Sync the queue enrolment and real enrolment URL search parameters so that the 2 notifications are not shown at the same time.
