### PR TITLE
Fix place selector's critical accessibility issue

### DIFF
--- a/src/common/components/multiSelectDropdown/MultiSelectDropdown.tsx
+++ b/src/common/components/multiSelectDropdown/MultiSelectDropdown.tsx
@@ -53,6 +53,7 @@ export interface MultiselectDropdownProps {
   value: string[];
   className?: string;
   helpText?: string;
+  filterByInput?: boolean;
 }
 
 const MultiSelectDropdown: React.FC<MultiselectDropdownProps> = ({
@@ -73,6 +74,7 @@ const MultiSelectDropdown: React.FC<MultiselectDropdownProps> = ({
   value,
   className,
   helpText,
+  filterByInput = true,
 }) => {
   const { t } = useTranslation<I18nNamespace>();
   const inputPlaceholderText =
@@ -85,17 +87,32 @@ const MultiSelectDropdown: React.FC<MultiselectDropdownProps> = ({
   const toggleButton = React.useRef<HTMLButtonElement | null>(null);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
 
-  const filteredOptions = React.useMemo(() => {
-    return [
-      showSelectAll && {
-        text: selectAllText || t('common:multiSelectDropdown.selectAll'),
-        value: SELECT_ALL,
-      },
-      ...options.filter((option) =>
-        option.text.toLowerCase().includes(input.toLowerCase())
-      ),
-    ].filter((e) => e) as Option[];
-  }, [input, options, selectAllText, showSelectAll, t]);
+  const filteredOptions = React.useMemo<Option[]>((): Option[] => {
+    const selectAllOption: Option | undefined = showSelectAll
+      ? {
+          text: selectAllText || t('common:multiSelectDropdown.selectAll'),
+          value: SELECT_ALL,
+        }
+      : undefined;
+
+    const result: Option[] = [];
+
+    if (selectAllOption) {
+      result.push(selectAllOption);
+    }
+
+    if (filterByInput) {
+      result.push(
+        ...options.filter((option) =>
+          option.text.toLowerCase().includes(input.toLowerCase())
+        )
+      );
+    } else {
+      result.push(...options);
+    }
+
+    return result;
+  }, [filterByInput, input, options, selectAllText, showSelectAll, t]);
 
   const handleInputValueChange = React.useCallback(
     (val: string) => {

--- a/src/domain/events/eventSearchForm/__tests__/useFetchPlacesByIds.test.tsx
+++ b/src/domain/events/eventSearchForm/__tests__/useFetchPlacesByIds.test.tsx
@@ -6,7 +6,7 @@ import {
   PlaceQuery,
   PlaceDocument,
   PlaceFieldsFragment,
-} from '../../../../generated/graphql'; // Adjust the import path as needed
+} from '../../../../generated/graphql';
 import useFetchPlacesByIds from '../useFetchPlacesByIds';
 
 interface MockPlaceInput {
@@ -61,6 +61,7 @@ describe('useFetchPlacesByIds Hook', () => {
             {children}
           </MockedProvider>
         ),
+        initialProps: { ids: successfulMockIds },
       }
     );
 
@@ -74,7 +75,11 @@ describe('useFetchPlacesByIds Hook', () => {
   });
 
   it('should handle an empty array of ids', async () => {
-    const { result } = renderHook(() => useFetchPlacesByIds([]), { wrapper });
+    const ids: string[] = []; // use obj as parameter to prevent forever loop
+    const { result } = renderHook(() => useFetchPlacesByIds(ids), {
+      wrapper,
+      initialProps: { ids: [] },
+    });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBeNull();
@@ -84,6 +89,7 @@ describe('useFetchPlacesByIds Hook', () => {
   it('should handle undefined ids', async () => {
     const { result } = renderHook(() => useFetchPlacesByIds(undefined), {
       wrapper,
+      initialProps: { ids: undefined },
     });
 
     await waitFor(() => expect(result.current.loading).toBe(false));
@@ -92,7 +98,8 @@ describe('useFetchPlacesByIds Hook', () => {
   });
 
   it('should handle a network error for one of the requests', async () => {
-    const { result } = renderHook(() => useFetchPlacesByIds(['1', '2', '3']), {
+    const ids = ['1', '2', '3']; // use obj as parameter to prevent forever loop
+    const { result } = renderHook(() => useFetchPlacesByIds(ids), {
       wrapper: ({ children }) => (
         <MockedProvider
           mocks={[
@@ -137,8 +144,8 @@ describe('useFetchPlacesByIds Hook', () => {
       },
       ...generateSuccessfulMocks(['2']),
     ];
-
-    const { result } = renderHook(() => useFetchPlacesByIds(['1', '2']), {
+    const ids = ['1', '2']; // use obj as parameter to prevent forever loop
+    const { result } = renderHook(() => useFetchPlacesByIds(ids), {
       wrapper: ({ children }) => (
         <MockedProvider mocks={graphQLErrorMock}>{children}</MockedProvider>
       ),
@@ -150,7 +157,8 @@ describe('useFetchPlacesByIds Hook', () => {
   });
 
   it('should handle a successful fetch with a null place', async () => {
-    const { result } = renderHook(() => useFetchPlacesByIds(['1', '2']), {
+    const ids = ['1', '2']; // use obj as parameter to prevent forever loop
+    const { result } = renderHook(() => useFetchPlacesByIds(ids), {
       wrapper: ({ children }) => (
         <MockedProvider
           mocks={[

--- a/src/domain/events/eventSearchForm/__tests__/useFetchPlacesByIds.test.tsx
+++ b/src/domain/events/eventSearchForm/__tests__/useFetchPlacesByIds.test.tsx
@@ -1,0 +1,180 @@
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+
+import {
+  PlaceQuery,
+  PlaceDocument,
+  PlaceFieldsFragment,
+} from '../../../../generated/graphql'; // Adjust the import path as needed
+import useFetchPlacesByIds from '../useFetchPlacesByIds';
+
+interface MockPlaceInput {
+  id: string;
+  internalId: string;
+  nameFi: string;
+}
+
+const createMockPlace = ({
+  id,
+  internalId,
+  nameFi,
+}: MockPlaceInput): PlaceFieldsFragment => ({
+  __typename: 'Place',
+  id,
+  internalId,
+  name: { __typename: 'LocalisedObject', fi: nameFi, en: null, sv: null },
+  telephone: null,
+  addressLocality: null,
+  streetAddress: null,
+});
+
+const successfulMockIds = ['1', '2', '3'];
+
+const generateSuccessfulMocks = (
+  ids: string[]
+): MockedResponse<PlaceQuery>[] => {
+  return ids.map((id) => ({
+    request: {
+      query: PlaceDocument,
+      variables: { id },
+    },
+    result: {
+      data: {
+        place: createMockPlace({ id, internalId: id, nameFi: `Place ${id}` }),
+      },
+    },
+  }));
+};
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MockedProvider mocks={[]}>{children}</MockedProvider>
+);
+
+describe('useFetchPlacesByIds Hook', () => {
+  it('should fetch multiple places successfully', async () => {
+    const { result } = renderHook(
+      () => useFetchPlacesByIds(successfulMockIds),
+      {
+        wrapper: ({ children }) => (
+          <MockedProvider mocks={generateSuccessfulMocks(successfulMockIds)}>
+            {children}
+          </MockedProvider>
+        ),
+      }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeNull();
+    expect(result.current.places).toStrictEqual(
+      successfulMockIds.map((id) =>
+        createMockPlace({ id, internalId: id, nameFi: `Place ${id}` })
+      )
+    );
+  });
+
+  it('should handle an empty array of ids', async () => {
+    const { result } = renderHook(() => useFetchPlacesByIds([]), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeNull();
+    expect(result.current.places).toEqual([]);
+  });
+
+  it('should handle undefined ids', async () => {
+    const { result } = renderHook(() => useFetchPlacesByIds(undefined), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeNull();
+    expect(result.current.places).toEqual([]);
+  });
+
+  it('should handle a network error for one of the requests', async () => {
+    const { result } = renderHook(() => useFetchPlacesByIds(['1', '2', '3']), {
+      wrapper: ({ children }) => (
+        <MockedProvider
+          mocks={[
+            {
+              request: {
+                query: PlaceDocument,
+                variables: { id: '1' },
+              },
+              result: {
+                data: { place: null },
+                errors: [new Error('Network error')],
+              },
+            },
+            ...generateSuccessfulMocks(['2', '3']),
+          ]}
+        >
+          {children}
+        </MockedProvider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.places).toEqual([]);
+  });
+
+  it('should handle a GraphQL error (ApolloError)', async () => {
+    const graphQLErrorMock: MockedResponse<PlaceQuery>[] = [
+      {
+        request: {
+          query: PlaceDocument,
+          variables: { id: '1' },
+        },
+        result: {
+          errors: [
+            {
+              message: 'GraphQL error occurred',
+              extensions: { code: 'GRAPHQL_ERROR' },
+            },
+          ],
+        },
+      },
+      ...generateSuccessfulMocks(['2']),
+    ];
+
+    const { result } = renderHook(() => useFetchPlacesByIds(['1', '2']), {
+      wrapper: ({ children }) => (
+        <MockedProvider mocks={graphQLErrorMock}>{children}</MockedProvider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.places).toEqual([]);
+  });
+
+  it('should handle a successful fetch with a null place', async () => {
+    const { result } = renderHook(() => useFetchPlacesByIds(['1', '2']), {
+      wrapper: ({ children }) => (
+        <MockedProvider
+          mocks={[
+            {
+              request: {
+                query: PlaceDocument,
+                variables: { id: '1' },
+              },
+              result: { data: { place: null } },
+            },
+            ...generateSuccessfulMocks(['2']),
+          ]}
+        >
+          {children}
+        </MockedProvider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBeNull();
+    expect(result.current.places).toStrictEqual(
+      ['2'].map((id) =>
+        createMockPlace({ id, internalId: id, nameFi: `Place ${id}` })
+      )
+    );
+  });
+});

--- a/src/domain/events/eventSearchForm/useFetchPlacesByIds.tsx
+++ b/src/domain/events/eventSearchForm/useFetchPlacesByIds.tsx
@@ -80,6 +80,8 @@ function useFetchPlacesByIds(ids?: string[]) {
   useEffect(() => {
     if (ids?.length) {
       fetchPlaces(ids);
+    } else {
+      setPlaces([]);
     }
 
     // Cleanup function to abort any pending requests when the component unmounts or the 'ids' change.
@@ -88,7 +90,7 @@ function useFetchPlacesByIds(ids?: string[]) {
       abortControllersRef.current = [];
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); //  This useEffect should only run when the component mounts and unmounts.
+  }, [ids]);
 
   return { places, loading, error };
 }

--- a/src/domain/events/eventSearchForm/useFetchPlacesByIds.tsx
+++ b/src/domain/events/eventSearchForm/useFetchPlacesByIds.tsx
@@ -1,0 +1,96 @@
+import { useApolloClient, ApolloError } from '@apollo/client';
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+import {
+  PlaceDocument,
+  PlaceFieldsFragment,
+  PlaceQuery,
+} from '../../../generated/graphql';
+
+/**
+ * Custom React hook to fetch multiple places by their IDs using Apollo Client.
+ *
+ * @param ids - An optional array of place IDs to fetch.
+ * - If provided, the hook fetches places with these IDs.
+ * - If `undefined` or an empty array is provided, the hook does not perform any fetching and returns initial state.
+ * @returns An object containing the fetched places, loading state, and any error that occurred during the fetch.
+ */
+function useFetchPlacesByIds(ids?: string[]) {
+  const client = useApolloClient();
+  const [places, setPlaces] = useState<PlaceFieldsFragment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<ApolloError | Error | null>(null);
+  const abortControllersRef = useRef<AbortController[]>([]);
+
+  const fetchPlaces = useCallback(
+    async (placeIds: string[]) => {
+      // Handle the case where no IDs are provided.  This prevents unnecessary API calls.
+      if (!placeIds || placeIds.length === 0) {
+        setPlaces([]);
+        setLoading(false);
+        return;
+      }
+
+      // Initialize loading state and clear any previous errors.
+      setLoading(true);
+      setError(null);
+      abortControllersRef.current = []; // Reset AbortControllers for a new fetch
+
+      try {
+        // Create an AbortController for each query.  This allows us to cancel the requests if needed.
+        const controllers = placeIds.map(() => new AbortController());
+        abortControllersRef.current = controllers; // Store AbortControllers
+
+        // Execute the Apollo Client queries in parallel.
+        const promises = placeIds.map((id, index) =>
+          client.query<PlaceQuery>({
+            query: PlaceDocument,
+            variables: { id },
+            // Pass the AbortController's signal to the fetchOptions.
+            context: { fetchOptions: { signal: controllers[index].signal } },
+          })
+        );
+
+        // Wait for all queries to complete.
+        const results = await Promise.all(promises);
+
+        // Process the results.  Extract the place data and filter out any null values.
+        const fetchedPlaces: PlaceFieldsFragment[] = results
+          .map((result) => result.data?.place)
+          .filter((place): place is PlaceFieldsFragment => !!place);
+
+        setPlaces(fetchedPlaces);
+      } catch (err: unknown) {
+        // Handle errors during the fetch.  If an error occurs, abort any pending requests.
+        abortControllersRef.current.forEach((controller) => controller.abort());
+
+        if (err instanceof ApolloError || err instanceof Error) {
+          setError(err);
+        } else {
+          setError(new Error('An unexpected error occurred'));
+        }
+      } finally {
+        setLoading(false);
+        abortControllersRef.current = [];
+      }
+    },
+    [client]
+  );
+
+  useEffect(() => {
+    if (ids?.length) {
+      fetchPlaces(ids);
+    }
+
+    // Cleanup function to abort any pending requests when the component unmounts or the 'ids' change.
+    return () => {
+      abortControllersRef.current.forEach((controller) => controller.abort());
+      abortControllersRef.current = [];
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); //  This useEffect should only run when the component mounts and unmounts.
+
+  return { places, loading, error };
+}
+
+export default useFetchPlacesByIds;

--- a/src/domain/place/placeSelector/PlaceSelector.tsx
+++ b/src/domain/place/placeSelector/PlaceSelector.tsx
@@ -1,46 +1,118 @@
+import uniqBy from 'lodash/uniqBy';
 import React from 'react';
 
 import PlaceText from '..//placeText/PlaceText';
 import MultiSelectDropdown, {
   MultiselectDropdownProps,
 } from '../../../common/components/multiSelectDropdown/MultiSelectDropdown';
+import type { Option } from '../../../common/components/multiSelectDropdown/MultiSelectDropdown';
 import { usePlacesQuery } from '../../../generated/graphql';
 import useDebounce from '../../../hooks/useDebounce';
 import useLocale from '../../../hooks/useLocale';
 import getLocalisedString from '../../../utils/getLocalisedString';
+import useFetchPlacesByIds from '../../events/eventSearchForm/useFetchPlacesByIds';
+
+const DEFAULT_DATA_SOURCE = 'tprek';
+const DEFAULT_PAGE_SIZE = 10;
 
 type Props = Omit<MultiselectDropdownProps, 'options'>;
 
-const PlaceSelector: React.FC<Props> = ({
-  inputValue,
-  setInputValue,
-  ...props
-}) => {
+/**
+ * Provides options for the MultiSelectDropdown based on a search query.
+ */
+const usePlacesSearchQueryOptions = (searchValue: string): Option[] => {
   const locale = useLocale();
-
-  const [internalInputValue, setInternalInputValue] = React.useState('');
-  const input = inputValue !== undefined ? inputValue : internalInputValue;
-  const searchValue = useDebounce(input, 300);
-
-  const { data: placesData } = usePlacesQuery({
+  const { data } = usePlacesQuery({
     skip: !searchValue,
     variables: {
-      dataSource: 'tprek',
-      pageSize: 10,
+      dataSource: DEFAULT_DATA_SOURCE,
+      pageSize: DEFAULT_PAGE_SIZE,
       text: searchValue,
     },
   });
 
   const placeOptions = React.useMemo(() => {
-    return (
-      placesData?.places?.data
-        .map((place) => ({
-          text: getLocalisedString(place.name || {}, locale),
-          value: place.id || '',
-        }))
-        .sort((a, b) => (a.text > b.text ? 1 : -1)) || []
+    const placesData = data?.places?.data;
+    if (!placesData) {
+      return [];
+    }
+    return placesData
+      .map(
+        (place): Option => ({
+          text: getLocalisedString(place.name ?? null, locale),
+          value: place.id ?? '',
+        })
+      )
+      .sort((a, b) => a.text.localeCompare(b.text));
+  }, [locale, data?.places?.data]);
+
+  return placeOptions;
+};
+
+/**
+ * Provides options for the MultiSelectDropdown based on selected place IDs.
+ */
+const useSelectedPlacesOptions = ({
+  selectedPlacesIds,
+}: {
+  selectedPlacesIds: string[];
+}): Option[] => {
+  const locale = useLocale();
+  const { places: selectedPlaces } = useFetchPlacesByIds(selectedPlacesIds);
+
+  const selectedPlacesOptions = React.useMemo(() => {
+    if (!selectedPlaces) return [];
+    return selectedPlaces.map(
+      (place): Option => ({
+        text: getLocalisedString(place.name ?? null, locale),
+        value: place.id ?? '',
+      })
     );
-  }, [locale, placesData?.places?.data]);
+  }, [locale, selectedPlaces]);
+
+  return selectedPlacesOptions;
+};
+
+/**
+ * A specialized MultiSelectDropdown component for selecting places.
+ *
+ * Fetches place options based on search input and selected values, and displays place names using PlaceText.
+ */
+const PlaceSelector: React.FC<Props> = ({
+  inputValue,
+  setInputValue,
+  ...props
+}) => {
+  const { value, fixedOptions } = props;
+
+  const [internalInputValue, setInternalInputValue] = React.useState('');
+  const input = inputValue !== undefined ? inputValue : internalInputValue;
+  const searchValue = useDebounce(input, 300);
+
+  // The options that are listed after a search for options has been made
+  const optionsFilteredBySearch = usePlacesSearchQueryOptions(searchValue);
+
+  // Fixed options are always visible (e.g remote, reservable)
+  const fixedOptionsIds = React.useMemo(
+    () => fixedOptions?.map((option) => option.value) ?? [],
+    [fixedOptions]
+  );
+
+  // Selected places ids should not include the fixed ids or they are duplicated
+  const selectedPlacesIds = React.useMemo(() => {
+    return value.filter((pid) => !fixedOptionsIds.includes(pid));
+  }, [value, fixedOptionsIds]);
+
+  // Query places names for selected ids and make them options
+  const selectedOptions = useSelectedPlacesOptions({
+    selectedPlacesIds,
+  });
+
+  // Remove duplicates, because search result can contain some of the selected items
+  const options = React.useMemo(
+    () => uniqBy([...optionsFilteredBySearch, ...selectedOptions], 'value'),
+    [optionsFilteredBySearch, selectedOptions]
+  );
 
   const renderOptionText = (id: string) => <PlaceText placeId={id} />;
 
@@ -48,9 +120,10 @@ const PlaceSelector: React.FC<Props> = ({
     <MultiSelectDropdown
       {...props}
       inputValue={input}
-      options={placeOptions}
+      options={options}
       renderOptionText={renderOptionText}
-      setInputValue={setInputValue || setInternalInputValue}
+      setInputValue={setInputValue ?? setInternalInputValue}
+      filterByInput={false}
     />
   );
 };


### PR DESCRIPTION
PT-1495.

Add a new hook that can be used to fetch multiple Place documents with a list of their ids.

When options were filtered and then some of them were selected, if the menu was closed, you could not unselect the selected options without searching them again with a filter feature.


All the selected optiosn are now always included in the results:

<img width="253" alt="image" src="https://github.com/user-attachments/assets/c91db6be-d63d-402c-b0ad-9b3ad518d2a4" />

When the place selector does not have a search filter on, it shows the selected values:

<img width="282" alt="image" src="https://github.com/user-attachments/assets/2e6e6b6c-39fb-4cff-a145-f574a7ffb90d" />

