### PR TITLE
fix: show contact info also when contact person is not available

### DIFF
--- a/public/locales/en/event.json
+++ b/public/locales/en/event.json
@@ -67,6 +67,7 @@
   "photographerText": "Photo: {{photographer}}",
   "eventImageAltText": "Event image",
   "contactPerson": "Contact person",
+  "contactInfo": "Contact information",
   "occurrencesTitle": "Occurrences ({{count}} pcs)",
   "categorisation": {
     "labelCategories": "Categories",

--- a/public/locales/fi/event.json
+++ b/public/locales/fi/event.json
@@ -67,6 +67,7 @@
   "photographerText": "Kuva: {{photographer}}",
   "eventImageAltText": "Tapahtuman kuva",
   "contactPerson": "Yhteyshenkilö",
+  "contactInfo": "Yhteystiedot",
   "occurrencesTitle": "Tapahtumat ({{count}} kpl)",
   "categorisation": {
     "labelCategories": "Kategoriat",

--- a/public/locales/sv/event.json
+++ b/public/locales/sv/event.json
@@ -67,6 +67,7 @@
   "photographerText": "Foto: {{photographer}}",
   "eventImageAltText": "Händelsebild",
   "contactPerson": "Kontaktperson",
+  "contactInfo": "Kontaktinformation",
   "occurrencesTitle": "Evenemang ({{count}} st.)",
   "categorisation": {
     "labelAudience": "Målgrupp",

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -314,7 +314,7 @@ it('renders page and event information correctly', async () => {
     data.contactPersonPhoneNumber,
     data.contactPersonName,
     data.contactPersonEmail,
-    eventMessages.contactPerson,
+    eventMessages.contactInfo,
   ];
 
   const queryByRole = [

--- a/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
+++ b/src/domain/event/eventBasicInfo/EventBasicInfo.tsx
@@ -143,10 +143,10 @@ const OrganisationInfo: React.FC<{
           {t('event:organisation.showAllOrganisationEvents')}
         </NextLink>
       </p>
-      {contactPerson && (
+      {(contactPerson || contactEmail || contactPhoneNumber) && (
         <div className={styles.contactInfo}>
-          <p>{t('event:contactPerson')}</p>
-          <p>{contactPerson}</p>
+          <p>{t('event:contactInfo')}</p>
+          {contactPerson && <p>{contactPerson}</p>}
           {contactEmail && <p>{contactEmail}</p>}
           {contactPhoneNumber && <p>{contactPhoneNumber}</p>}
         </div>


### PR DESCRIPTION
PT-1898

The contact information is now shown also without contact person:
<img width="980" alt="image" src="https://github.com/user-attachments/assets/646b9898-fdfa-4e3f-83b4-df34177cb57a" />
