### PR TITLE
fix: stricter yarn config + removed unnecessary package

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--install.frozen-lockfile true

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "dotenv": "^16.4.7",
     "eslint": "^9.23.0",
     "eslint-import-resolver-typescript": "^4.3.1",
-    "eslint-js": "eslint/js",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-no-only-tests": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4688,10 +4688,6 @@ eslint-import-resolver-typescript@^4.3.1:
     tinyglobby "^0.2.12"
     unrs-resolver "^1.3.3"
 
-eslint-js@eslint/js:
-  version "1.0.0"
-  resolved "https://codeload.github.com/eslint/js/tar.gz/ed2f030cff89d4b468e8efa838a0c460a685c784"
-
 eslint-module-utils@^2.12.0:
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz#fe4cfb948d61f49203d7b08871982b65b9af0b0b"


### PR DESCRIPTION
Removed the unnecessary package that was throwing false positive critical error on yarn. Should install through npm back if needed, not the github repo itself to avoid the false positive flag.

Added stricter yarn config to avoid unintended package upgrades to dependencies.