### PR TITLE
fix: root index should apply configured headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -172,8 +172,12 @@ module.exports = {
   async headers() {
     return [
       {
-        source: '/(.*)',
+        source: '/:path*',
         headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-XSS-Protection', value: '0' },
+          { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+          { key: 'Cross-Origin-Embedder-Policy', value: 'same-origin' },
           {
             key: 'Content-Security-Policy',
             value: cspHeader.replace(/\n/g, ''),


### PR DESCRIPTION
The headers were set in nextjs configuration in a way that they were not applied in the root index page at all. All the rest of the pages did have the configured headers, but the root index did not. Now when the source has a different matcher, also the root index gets the configured headers.

Reference: HH-432.

<img width="1970" height="1237" alt="image" src="https://github.com/user-attachments/assets/85fa7b61-726b-46c5-b9e3-48bde14f18ca" />
