### PR TITLE
PT-2007 | Reword "Show details" button so users know where to enrol

### DIFF
--- a/public/locales/en/occurrence.json
+++ b/public/locales/en/occurrence.json
@@ -9,7 +9,7 @@
   "showOccurrenceDetails": "Show occurrence details",
   "labelExternalEnrolmentLink": "Enrol",
   "labelNoEnrolment": "No enrolment",
-  "buttonShowDetails": "Show details",
+  "buttonShowDetails": "Show details and enrol",
   "buttonHideDetails": "Hide details",
   "ariaLabelShowDetails": "Show occurrence details",
   "occurrenceSelection": {

--- a/public/locales/fi/occurrence.json
+++ b/public/locales/fi/occurrence.json
@@ -9,7 +9,7 @@
   "showOccurrenceDetails": "Näytä tapahtuma-ajan lisätiedot",
   "labelExternalEnrolmentLink": "Ilmoittaudu",
   "labelNoEnrolment": "Ei ilmoittautumista",
-  "buttonShowDetails": "Näytä lisätiedot",
+  "buttonShowDetails": "Katso lisätiedot ja ilmoittaudu",
   "buttonHideDetails": "Piilota tiedot",
   "ariaLabelShowDetails": "Näytä tapahtuma-ajan lisätiedot",
   "occurrenceSelection": {

--- a/public/locales/sv/occurrence.json
+++ b/public/locales/sv/occurrence.json
@@ -9,7 +9,7 @@
   "showOccurrenceDetails": "Visa evenemangsedetaljer",
   "labelExternalEnrolmentLink": "Anmäl dig",
   "labelNoEnrolment": "Ingen registrering",
-  "buttonShowDetails": "Visa information",
+  "buttonShowDetails": "Visa information och anmäl dig",
   "buttonHideDetails": "Dölj information",
   "ariaLabelShowDetails": "Visa tidpunkten för evenemanget",
   "occurrenceSelection": {

--- a/src/domain/event/__tests__/EventPage.test.tsx
+++ b/src/domain/event/__tests__/EventPage.test.tsx
@@ -288,16 +288,16 @@ it('renders upcoming occurrencec correctly', async () => {
 
   const tableRows = screen.queryAllByRole('row');
   expect(tableRows[1].textContent).toMatchInlineSnapshot(
-    `"15.7.2020 – 17.7.2020suomi, ruotsi, englantifi, sv, enSoukan kirjasto30 / 30Näytä lisätiedot"`
+    `"15.7.2020 – 17.7.2020suomi, ruotsi, englantifi, sv, enSoukan kirjasto30 / 30Katso lisätiedot ja ilmoittaudu"`
   );
   expect(tableRows[2].textContent).toMatchInlineSnapshot(
-    `"16.7.2020 to12:00 – 13:00suomifiSoukan kirjasto30 / 30Näytä lisätiedot"`
+    `"16.7.2020 to12:00 – 13:00suomifiSoukan kirjasto30 / 30Katso lisätiedot ja ilmoittaudu"`
   );
   expect(tableRows[3].textContent).toMatchInlineSnapshot(
-    `"19.7.2020 su12:00 – 13:00suomi, englantifi, enSoukan kirjasto30 / 30Näytä lisätiedot"`
+    `"19.7.2020 su12:00 – 13:00suomi, englantifi, enSoukan kirjasto30 / 30Katso lisätiedot ja ilmoittaudu"`
   );
   expect(tableRows[5].textContent).toMatchInlineSnapshot(
-    `"21.7.2020 ti12:00 – 13:00suomi, englantifi, enSoukan kirjasto30 / 30Näytä lisätiedot"`
+    `"21.7.2020 ti12:00 – 13:00suomi, englantifi, enSoukan kirjasto30 / 30Katso lisätiedot ja ilmoittaudu"`
   );
 });
 
@@ -424,7 +424,7 @@ it('renders occurrences table and related stuff correctly', async () => {
 
   const tableRows = screen.getAllByRole('row');
   expect(tableRows[8].textContent).toMatchInlineSnapshot(
-    `"27.7.2020 ma12:00 – 13:00suomi, englantifi, enSoukan kirjasto30 / 30Näytä lisätiedot"`
+    `"27.7.2020 ma12:00 – 13:00suomi, englantifi, enSoukan kirjasto30 / 30Katso lisätiedot ja ilmoittaudu"`
   );
 });
 
@@ -462,7 +462,7 @@ it('hides seats left column header when event has external enrolment', async () 
 
   // shows multi day occurrence correctly
   expect(tableRows[1].textContent).toMatchInlineSnapshot(
-    `"15.7.2020 – 17.7.2020suomi, ruotsi, englantifi, sv, enSoukan kirjastoNäytä lisätiedot"`
+    `"15.7.2020 – 17.7.2020suomi, ruotsi, englantifi, sv, enSoukan kirjastoKatso lisätiedot ja ilmoittaudu"`
   );
 
   await userEvent.click(

--- a/src/domain/event/__tests__/enrolmentFormIntegration.test.tsx
+++ b/src/domain/event/__tests__/enrolmentFormIntegration.test.tsx
@@ -180,7 +180,7 @@ test('user can select single occurrences and enrol to it with enrolment form', a
   const rows = await screen.findAllByRole('row');
 
   expect(rows[1].textContent).toMatchInlineSnapshot(
-    `"25.9.2020 pe12:30 – 13:30suomi, englantifi, enKirjasto30 / 30Näytä lisätiedot"`
+    `"25.9.2020 pe12:30 – 13:30suomi, englantifi, enKirjasto30 / 30Katso lisätiedot ja ilmoittaudu"`
   );
 
   await userEvent.click(
@@ -264,13 +264,13 @@ test('user can select multiple occurrences and enrol to them with enrolment form
   const rows = await screen.findAllByRole('row');
 
   expect(rows[1].textContent).toMatchInlineSnapshot(
-    `"25.9.2020 pe12:30 – 13:30suomi, englantifi, enKirjasto30 / 30Näytä lisätiedot"`
+    `"25.9.2020 pe12:30 – 13:30suomi, englantifi, enKirjasto30 / 30Katso lisätiedot ja ilmoittaudu"`
   );
   expect(rows[2].textContent).toMatchInlineSnapshot(
-    `"26.9.2020 la13:20 – 14:20suomi, englantifi, enKirjasto30 / 30Näytä lisätiedot"`
+    `"26.9.2020 la13:20 – 14:20suomi, englantifi, enKirjasto30 / 30Katso lisätiedot ja ilmoittaudu"`
   );
   expect(rows[3].textContent).toMatchInlineSnapshot(
-    `"26.9.2020 la14:20 – 15:20suomi, englantifi, enKirjasto30 / 30Näytä lisätiedot"`
+    `"26.9.2020 la14:20 – 15:20suomi, englantifi, enKirjasto30 / 30Katso lisätiedot ja ilmoittaudu"`
   );
 
   await userEvent.click(

--- a/src/domain/event/occurrences/OccurrencesTable.tsx
+++ b/src/domain/event/occurrences/OccurrencesTable.tsx
@@ -55,7 +55,7 @@ interface Props {
   hideLoadMoreButton?: boolean;
 }
 
-export const enrolButtonColumnWidth = '250px';
+export const enrolButtonColumnWidth = '265px';
 
 const OccurrencesTable: React.FC<Props> = ({
   event,

--- a/src/domain/event/occurrences/occurrences.module.scss
+++ b/src/domain/event/occurrences/occurrences.module.scss
@@ -82,6 +82,8 @@
 
   .enrolmentExpandButton {
     font-size: 1rem;
+    min-width: 165px;
+    white-space: normal;
   }
 
   .expandEnrolButton {


### PR DESCRIPTION
## Description :sparkles:

### Reword "Show details" button so users know where to enrol

The translations were given by the product owner of Kultus.

Changed the layout a bit so the button fits in narrower view also.

### Related :handshake:

[PT-2007](https://helsinkisolutionoffice.atlassian.net/browse/PT-2007)

## Testing :alembic:

You can compare to the current view in production:
- https://kultus.hel.fi/fi/search → select some event for enrolling into, e.g. https://kultus.hel.fi/fi/event/kultus:agkuxtzgva



### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

From wide to narrow views

## Current production for comparison

### Maximum width

<img width="1397" height="344" alt="image" src="https://github.com/user-attachments/assets/dfbddd98-75b3-4a94-8acf-8fbc3f407d8a" />

### Minimum width without horizontal scrolling

<img width="823" height="415" alt="image" src="https://github.com/user-attachments/assets/aa3d9ba7-cad5-4912-966f-24d22a86df53" />

## PR in Finnish

### Maximum width

<img width="1241" height="271" alt="image" src="https://github.com/user-attachments/assets/7357e874-5e8f-497f-9afa-901997b5e037" />

### Minimum width without horizontal scrolling

<img width="853" height="283" alt="image" src="https://github.com/user-attachments/assets/1a6ee6a7-2a00-44e5-a176-00520a53b8fb" />

## PR in Swedish

### Maximum width

<img width="1233" height="263" alt="image" src="https://github.com/user-attachments/assets/45fa2c68-e615-4a61-8b8c-c393d07357b9" />

### Minimum width without horizontal scrolling

<img width="834" height="247" alt="image" src="https://github.com/user-attachments/assets/cf77109a-ad24-4302-ad3d-13954ed11b31" />

## PR in English

### Maximum width

<img width="1249" height="283" alt="image" src="https://github.com/user-attachments/assets/43af1686-630d-46d3-bd40-0eee8cd1bf16" />

### Minimum width without horizontal scrolling

<img width="827" height="251" alt="image" src="https://github.com/user-attachments/assets/deaf997c-ee11-4965-bc13-212721d83c6f" />

## Additional notes :spiral_notepad:


[PT-2007]: https://helsinkisolutionoffice.atlassian.net/browse/PT-2007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ